### PR TITLE
feat(provisioning): mint and allocate the tenant's platform subdomains

### DIFF
--- a/docs/DOMAIN_VERIFICATION.md
+++ b/docs/DOMAIN_VERIFICATION.md
@@ -74,23 +74,85 @@ all.
 
 Entitlement is therefore an **allocation recorded at write time**:
 
-- The platform grants one host to one conference, and only through
-  `provisionOrganization` — the platform-operator wizard and the
-  bearer-authenticated provisioning API. That is the sole caller that passes
-  `allocatePlatformHosts`.
+- The platform grants a host to one conference, and only through a
+  SERVER-DERIVED label: `provisionOrganization` (the platform-operator wizard and
+  the bearer-authenticated provisioning API) for a tenant's first edition, and
+  `createEdition` for later ones. Those are the only callers that pass
+  `allocatePlatformHosts`, and they pass ONLY hosts derived from the tenant's own
+  globally unique org slug — never a hostname anybody typed.
 - The `domainVerification` document records the grant (`method:
 "platform-owned"`, `conference` = the grantee).
 - Every read-time decision requires **both** the recorded allocation and a live
   suffix re-check (`isPlatformAllocated`). Neither half is sufficient: a
   mis-issued record for a host outside the zone grants nothing, and a host in the
   zone with no allocation grants nothing.
-- Tenant-facing writes never allocate. `updateDomains` and `createEdition`
-  **reject** an unallocated in-zone hostname (`findUnallocatedPlatformDomains`)
-  before any write, and `ensureDomainVerification` creates no document for one,
-  so even a bypass of the mutation guard fails closed.
+- TYPED hostnames never allocate. `updateDomains` and `createEdition` **reject**
+  an unallocated in-zone hostname in their payload
+  (`findUnallocatedPlatformDomains`) before any write, and
+  `ensureDomainVerification` creates no document for one, so even a bypass of the
+  mutation guard fails closed. An organizer can therefore never express a claim
+  outside their own org's namespace — which is exactly the hijack this prevents.
 - `revoked` is refused **before** the allocation check everywhere — routing, the
   allowlist and the admin view — so releasing the claim really does undo the
   grant.
+
+### Minting: what the platform actually hands out
+
+The same suffix that decides what is _in_ the zone decides what the platform
+**mints** (`derivePlatformHosts`). A tenant gets **two** hosts, both a **single
+label** — which is the whole reason this needs no per-tenant provider work:
+
+```
+acme-2026.konf.run    PERMANENT. This edition's own address, forever.
+acme.konf.run         The SHORT address of the org's LATEST edition. It MOVES.
+```
+
+`*.konf.run` and its alias already cover both. A nested form
+(`2026.acme.konf.run`) does **not** work: it needs a per-org wildcard registered
+_and_ a deployment aliased to it, and without that last step a visitor gets the
+CDN's own "deployment not found" page instead of ours.
+
+| Rule                                          | Why                                                                                                                                           |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Exactly **one label** above the suffix        | What a wildcard certificate covers. Enforced, not assumed: the label regex admits no dots and the host is re-counted against the suffix.      |
+| The dated host names the **edition**          | Editions are already addressed per year in the wild, and a retired edition keeps its URL permanently — archive links never break.             |
+| Year comes from the edition's `startDate`     | Deterministic; it cannot collide across an org's editions, and across orgs the globally unique org slug already guarantees uniqueness.        |
+| No dates yet → the two collapse into one host | A year is a factual claim and the host is permanent. Guessing the current year would strand a December signup on last year's address forever. |
+| Reserved labels refused (on the **org slug**) | `www`, `api`, `auth`, `admin`, … The claim is global and permanent, so the platform's own hostnames must never be handed out to a tenant.     |
+| Derived **once**, never re-derived            | Renaming the organization afterwards does not move, break or re-issue an address; claims and records are keyed by the hostname itself.        |
+
+There is deliberately **no fallback label** (`-2`, a random suffix) when a minted
+host is already claimed. Provisioning refuses instead, naming the host — an
+unpredictable address would be permanent too.
+
+**Both hosts are allocated**, each with its own `platform-owned` record naming
+the conference that holds it. Being in the zone still grants nothing on its own.
+
+### The short address moves — as a transfer, never as two writes
+
+`domains[]` is a globally unique routing claim, so the short address cannot sit
+on two editions at once and must never sit on none. Creating a newer edition
+therefore **transfers** it: released from the previous holder and claimed by the
+new one **inside the same Sanity transaction**, which is all-or-nothing. Two
+separate writes would have an interleaving that leaves the address duplicated (a
+routing collision) or lost (an address that resolves nowhere).
+
+`planEditionPlatformHosts` (`src/lib/conference/platformEditionHosts.ts`) decides
+it, and `createEdition` stages both halves:
+
+- **Later start date wins** (`shouldTakeLatestHost`). Back-filling a 2024 edition
+  after 2026 exists does **not** drag the short address backwards; it gets its own
+  dated host and nothing else. Two editions in one calendar year are ordered by
+  their actual start dates; an exact tie keeps the incumbent, because a live
+  address does not churn without evidence.
+- **The dated host never moves.** Only the bare host is ever released, which is
+  what makes retiring an old edition to a static archive safe.
+- **A foreign holder is a conflict, not a transfer.** The label derives from a
+  globally unique org slug, so a holder in another organization is an anomaly and
+  the edition is refused rather than the claim stolen.
+- **Provisioning never transfers.** It creates an organization's _first_ edition
+  and nothing else (a second provisioning under the same slug is refused by
+  `isOrgSlugTaken`), so the short address is always claimed fresh there.
 
 ### The suffix is configuration
 
@@ -218,18 +280,19 @@ existing consumers, so it fails closed from day one.
 
 ## Moving parts
 
-| Path                                              | Role                                                        |
-| ------------------------------------------------- | ----------------------------------------------------------- |
-| `src/lib/domain-verification/challenge.ts`        | record names, tokens, host classification                   |
-| `src/lib/domain-verification/platform.ts`         | the `PLATFORM_DOMAIN_SUFFIX` contract + label-wise matcher  |
-| `src/lib/domain-verification/dns.ts`              | bounded, uncached TXT resolution + hard/soft classification |
-| `src/lib/domain-verification/policy.ts`           | the delisting policy (pure)                                 |
-| `src/lib/domain-verification/allowlist.ts`        | exact-host OAuth redirect allowlist (#688 consumes this)    |
-| `src/lib/domain-verification/routing.ts`          | the flag-gated routing gate                                 |
-| `src/lib/domain-verification/sweep.ts`            | continuous re-verification + organizer alerts               |
-| `src/app/api/cron/domain-verification/route.ts`   | daily cron (05:00 UTC)                                      |
-| `src/server/routers/domainVerification.ts`        | admin list + re-check                                       |
-| `src/components/admin/DomainVerificationCard.tsx` | `/admin/settings#domain-verification`                       |
+| Path                                              | Role                                                                    |
+| ------------------------------------------------- | ----------------------------------------------------------------------- |
+| `src/lib/domain-verification/challenge.ts`        | record names, tokens, host classification                               |
+| `src/lib/domain-verification/platform.ts`         | the `PLATFORM_DOMAIN_SUFFIX` contract, label-wise matcher, host minting |
+| `src/lib/onboarding/provision.ts`                 | claims + allocates the minted host in the tenant transaction            |
+| `src/lib/domain-verification/dns.ts`              | bounded, uncached TXT resolution + hard/soft classification             |
+| `src/lib/domain-verification/policy.ts`           | the delisting policy (pure)                                             |
+| `src/lib/domain-verification/allowlist.ts`        | exact-host OAuth redirect allowlist (#688 consumes this)                |
+| `src/lib/domain-verification/routing.ts`          | the flag-gated routing gate                                             |
+| `src/lib/domain-verification/sweep.ts`            | continuous re-verification + organizer alerts                           |
+| `src/app/api/cron/domain-verification/route.ts`   | daily cron (05:00 UTC)                                                  |
+| `src/server/routers/domainVerification.ts`        | admin list + re-check                                                   |
+| `src/components/admin/DomainVerificationCard.tsx` | `/admin/settings#domain-verification`                                   |
 
 DNS resolution uses a dedicated `node:dns` `Resolver` with an explicit timeout
 and a fixed `tries`, plus an outer wall-clock race. Nothing about verification is

--- a/docs/PROVISIONING_API.md
+++ b/docs/PROVISIONING_API.md
@@ -51,7 +51,43 @@ Content-Type: application/json
 }
 ```
 
-The body is validated with `CreateOrganizationSchema` from `src/server/schemas/onboarding.ts` — **the same schema the operator wizard posts through**, not a looser copy. `billingEmail` is optional; `startDate`/`endDate` are optional but travel as a pair; `domains` may be empty (a tenant can start on no domain and attach one later).
+The body is validated with `CreateOrganizationSchema` from `src/server/schemas/onboarding.ts` — **the same schema the operator wizard posts through**, not a looser copy. `billingEmail` is optional; `startDate`/`endDate` are optional but travel as a pair; `domains` is normally **omitted** — see below.
+
+## The tenant's addresses
+
+Provisioning **mints the new edition's hostnames** and claims them in the same
+transaction. Without them a self-service tenant would exist at no address at
+all: tenant resolution is by request `Host` against `conference.domains[]`, so a
+conference that claims nothing is served by nothing and its organizer cannot
+reach `/admin`.
+
+```
+acme.konf.run         the SHORT address of the org's latest edition
+acme-2026.konf.run    this edition's PERMANENT address
+```
+
+- **Both are a single label** under `PLATFORM_DOMAIN_SUFFIX`, which is what the
+  live wildcard certificate covers — no per-tenant provider work, ever. A nested
+  form (`2026.acme.konf.run`) is deliberately not produced; it does not work
+  without a per-org wildcard and an aliased deployment.
+- **The year is the edition's `startDate`.** With no dates yet the two collapse
+  into the single bare host: a year is a factual claim about the event and the
+  address is permanent, so an unknown year is never guessed at.
+- **Reserved labels are refused** (`www`, `api`, `auth`, `admin`, …), checked on
+  the org slug.
+- **Renaming the org later does not move them.** The derivation runs once, at
+  provisioning; nothing re-derives it at read time.
+- The short address later **moves** to newer editions (see
+  `docs/DOMAIN_VERIFICATION.md`); the dated one never does, so archive links keep
+  resolving.
+- Any `domains` the caller _does_ send are claimed **in addition**, after the
+  minted hosts, and still have to prove themselves by DNS. The minted hosts route
+  immediately, so they are what the organizer signs in on while a custom domain
+  is still being verified.
+
+Both minted hosts are allocated to the new conference as
+`method: "platform-owned"` — see `docs/DOMAIN_VERIFICATION.md`. They are the
+entries in `challenges` with no TXT record to publish.
 
 ## Responses
 
@@ -61,9 +97,11 @@ The body is validated with `CreateOrganizationSchema` from `src/server/schemas/o
 | `200`  | same shape, `replayed: true`                                                                      | This key already provisioned; the **original** ids are returned and nothing was written.             |
 | `400`  | `{ error: "invalid_request", code, issues? }`                                                     | `idempotency_key_required`, `invalid_json`, or `schema_validation_failed` (with per-field `issues`). |
 | `401`  | `{ error: "unauthorized" }`                                                                       | Any authentication failure. Uniform and detail-free.                                                 |
-| `409`  | `{ error: "conflict", code, slug? \| domains? }`                                                  | `slug_taken`, `domain_claimed`, `ambiguous_organizer`.                                               |
+| `409`  | `{ error: "conflict", code, slug? \| domains? \| host? }`                                         | `slug_taken`, `domain_claimed`, `ambiguous_organizer`, `platform_host_taken`, `reserved_slug`.       |
 | `429`  | `{ error: "rate_limited" }` + `Retry-After`                                                       | Over a cap, or the limiter could not persist a hit.                                                  |
-| `500`  | `{ error: "internal_error" }`                                                                     | The transaction failed; nothing was written.                                                         |
+| `500`  | `{ error: "internal_error", code? }`                                                              | The transaction failed, or `platform_domain_unconfigured`; nothing was written.                      |
+
+`platform_host_taken` (with `host` and `slug`) means the slug is free but the address it mints is already claimed — the remedy is a different slug. `reserved_slug` means the slug would mint one of the platform's own hostnames. `platform_domain_unconfigured` is **not the caller's fault and not fixable by it**: no `PLATFORM_DOMAIN_SUFFIX` is set and no `domains` were sent, so the tenant would have no address; provisioning refuses rather than committing an unreachable one. Retrying will not help until the deployment is fixed.
 
 `challenges` is a `DomainVerificationView[]` — one per claimed domain, carrying the TXT record the caller must publish (#683). Domains are **claims, not proofs**: a new conference routes nothing until its records verify.
 

--- a/src/app/api/provisioning/organizations/route.test.ts
+++ b/src/app/api/provisioning/organizations/route.test.ts
@@ -203,19 +203,28 @@ vi.mock('@/lib/sanity/client', () => ({
 
 const syncDomainVerificationsMock = vi.fn(async () => {})
 const getDomainVerificationMock = vi.fn(async () => null)
-vi.mock('@/lib/domain-verification', () => ({
-  syncDomainVerifications: (...args: unknown[]) =>
-    syncDomainVerificationsMock(...(args as [])),
-  getDomainVerification: (...args: unknown[]) =>
-    getDomainVerificationMock(...(args as [])),
-  toDomainVerificationView: (hostname: string) => ({
-    hostname,
-    status: 'pending',
-  }),
-  findUnallocatedPlatformDomains: async (): Promise<string[]> => [],
-  PLATFORM_DOMAIN_NOT_ALLOCATED:
-    'That hostname belongs to the platform and has not been allocated to this conference',
-}))
+// The record-writing half is faked (its own suite owns it), but the ADDRESS
+// DERIVATION is the real thing: what host this endpoint mints for a slug is a
+// property of the endpoint, and a stubbed derivation would prove nothing.
+vi.mock('@/lib/domain-verification', async () => {
+  const platform = await vi.importActual<
+    typeof import('@/lib/domain-verification/platform')
+  >('@/lib/domain-verification/platform')
+  return {
+    syncDomainVerifications: (...args: unknown[]) =>
+      syncDomainVerificationsMock(...(args as [])),
+    getDomainVerification: (...args: unknown[]) =>
+      getDomainVerificationMock(...(args as [])),
+    toDomainVerificationView: (hostname: string) => ({
+      hostname,
+      status: 'pending',
+    }),
+    findUnallocatedPlatformDomains: async (): Promise<string[]> => [],
+    derivePlatformHosts: platform.derivePlatformHosts,
+    shouldTakeLatestHost: platform.shouldTakeLatestHost,
+    PLATFORM_DOMAIN_NOT_ALLOCATED: platform.PLATFORM_DOMAIN_NOT_ALLOCATED,
+  }
+})
 
 import { POST } from './route'
 
@@ -294,6 +303,7 @@ beforeEach(() => {
 
 afterEach(() => {
   delete process.env.PROVISIONING_API_TOKEN
+  vi.unstubAllEnvs()
   warnSpy.mockRestore()
   errorSpy.mockRestore()
 })
@@ -697,6 +707,89 @@ describe('provisioning API — malformed input is rejected before any write', ()
       request({ token: 'wrong-token-value-of-adequate-length!!', raw: '{' }),
     )
     expect(res.status).toBe(401)
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// 5b. THE TENANT'S ADDRESS
+//
+// This is the self-service caller: it sends no `domains`, so without a minted
+// host the tenant it creates is served by nothing and reachable by nobody.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('provisioning API — the tenant comes out reachable', () => {
+  const BARE = 'cloud-native-oslo.konf.run'
+  const DATED = 'cloud-native-oslo-2027.konf.run'
+  const MINTED = [BARE, DATED]
+
+  /** The self-service payload: no `domains` key at all. */
+  const selfService = () =>
+    body({
+      domains: [] as string[],
+    })
+
+  it('claims BOTH minted hosts for a caller that sends no domains', async () => {
+    vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
+    const res = await POST(request({ payload: selfService() }))
+
+    expect(res.status).toBe(201)
+    const conferences = ofType('conference')
+    expect(conferences).toHaveLength(1)
+    expect(conferences[0].domains).toEqual(MINTED)
+  })
+
+  it('hands both minted hosts to the platform ALLOCATION call for that conference', async () => {
+    vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
+    await POST(request({ payload: selfService() }))
+
+    const conferenceId = ofType('conference')[0]._id
+    expect(syncDomainVerificationsMock).toHaveBeenCalledWith(
+      conferenceId,
+      MINTED,
+      [],
+      { allocatePlatformHosts: true },
+    )
+  })
+
+  it('claims the minted hosts in ADDITION to a caller-supplied domain', async () => {
+    vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
+    await POST(request())
+    expect(ofType('conference')[0].domains).toEqual([
+      ...MINTED,
+      'oslo.cloudnativedays.no',
+    ])
+  })
+
+  it('refuses with a 409 when another conference already holds the minted host', async () => {
+    vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
+    docs.set('conference-incumbent', {
+      _id: 'conference-incumbent',
+      _type: 'conference',
+      domains: [BARE],
+    })
+    const res = await POST(request({ payload: selfService() }))
+
+    expect(ofType('organization')).toHaveLength(0)
+    expect(ofType('conference')).toHaveLength(1) // only the incumbent
+    expect(res.status).toBe(409)
+    await expect(res.json()).resolves.toMatchObject({
+      code: 'platform_host_taken',
+      host: BARE,
+    })
+  })
+
+  it('writes NOTHING when no suffix is configured and the caller named no domain', async () => {
+    vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', '')
+    const res = await POST(request({ payload: selfService() }))
+
+    // The ghost tenant: an org + conference at no address, reported as success.
+    expect(ofType('organization')).toHaveLength(0)
+    expect(ofType('conference')).toHaveLength(0)
+    expect(ofType('speaker')).toHaveLength(0)
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toMatchObject({
+      code: 'platform_domain_unconfigured',
+    })
   })
 })
 

--- a/src/app/api/provisioning/organizations/route.ts
+++ b/src/app/api/provisioning/organizations/route.ts
@@ -49,8 +49,17 @@ import { CreateOrganizationSchema } from '@/server/schemas/onboarding'
  *     "organization": { "name", "slug", "contactEmail", "billingEmail"? },
  *     "conference":   { "title", "city", "country", "startDate"?, "endDate"? },
  *     "organizer":    { "name", "email" },
- *     "domains":      ["oslo.example.com"]
+ *     "domains":      ["oslo.example.com"]      (OPTIONAL, usually omitted)
  *   }
+ *
+ * ── THE TENANT'S ADDRESS ───────────────────────────────────────────────────
+ * `domains` is normally omitted by this caller: provisioning MINTS the
+ * edition's host — `<org-slug>-<year>.<PLATFORM_DOMAIN_SUFFIX>`, one label, or
+ * the bare slug when no `startDate` was given — and claims it in the
+ * transaction, so the response's first challenge is a live, `platform-owned`
+ * host the organizer can sign in on immediately. Any `domains` sent are claimed
+ * IN ADDITION and still have to prove themselves by DNS. See
+ * `@/lib/onboarding/provision`.
  *
  * ── RESPONSES ──────────────────────────────────────────────────────────────
  *   201 { organizationId, conferenceId, speakerId, speakerCreated,
@@ -59,9 +68,9 @@ import { CreateOrganizationSchema } from '@/server/schemas/onboarding'
  *       ORIGINAL ids are returned and nothing was written.
  *   400 { error: "invalid_request", code, issues? }
  *   401 { error: "unauthorized" }                       (uniform, always)
- *   409 { error: "conflict", code, slug? | domains? }
+ *   409 { error: "conflict", code, slug? | domains? | host? }
  *   429 { error: "rate_limited" }                       (+ Retry-After)
- *   500 { error: "internal_error" }
+ *   500 { error: "internal_error", code? }
  */
 
 const RETRY_AFTER_SECONDS = 60
@@ -172,6 +181,44 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
               domains: rejection.domains,
             },
             { status: 409 },
+          )
+        case 'platform_host_taken':
+          // A CONFLICT, not a bad request: the payload is fine and the slug is
+          // free, but the address it mints is taken. The control panel's remedy
+          // is the same as for `slug_taken` — ask for a different slug — so it
+          // is reported the same way, with the offending host named.
+          return NextResponse.json(
+            {
+              error: 'conflict',
+              code: 'platform_host_taken',
+              slug: rejection.slug,
+              host: rejection.host,
+            },
+            { status: 409 },
+          )
+        case 'reserved_slug':
+          // Same shape and remedy as `slug_taken` — the slug is unusable and
+          // the control panel has to ask for another one.
+          return NextResponse.json(
+            {
+              error: 'conflict',
+              code: 'reserved_slug',
+              slug: rejection.slug,
+            },
+            { status: 409 },
+          )
+        case 'no_host_available':
+          // NOT the caller's fault and NOT fixable by it: this caller does not
+          // name domains, so the missing `PLATFORM_DOMAIN_SUFFIX` is a platform
+          // misconfiguration. A named 500 tells the operator where to look and
+          // keeps the control panel from retrying a request that cannot succeed
+          // until the deployment changes.
+          console.error(
+            '[provisioning] refused: no host could be minted for the tenant — is PLATFORM_DOMAIN_SUFFIX set?',
+          )
+          return NextResponse.json(
+            { error: 'internal_error', code: 'platform_domain_unconfigured' },
+            { status: 500 },
           )
         case 'ambiguous_organizer':
           return NextResponse.json(

--- a/src/components/admin/onboarding/OnboardingWizard.stories.tsx
+++ b/src/components/admin/onboarding/OnboardingWizard.stories.tsx
@@ -48,12 +48,48 @@ const handlers = [
           speakerId: 'speaker-xyz',
           speakerCreated: false,
           organizerMatchedName: 'Kari Nordmann',
-          // Domain ownership is CLAIMED, not proven, at hand-off (#683).
+          // Provisioning MINTS the tenant's two platform hosts (the short
+          // address first) and claims them alongside the operator's own
+          // domain. The minted pair is allocated — verified, nothing to
+          // publish — while the custom domain is claimed, not proven (#683).
           challenges: [
+            {
+              hostname: 'cloud-native-oslo.konf.run',
+              status: 'verified',
+              grandfathered: false,
+              platformOwned: true,
+              graceUntil: null,
+              recordName: null,
+              recordValue: null,
+              wildcard: false,
+              devOnly: false,
+              redirectAllowlisted: true,
+              routable: true,
+              lastCheckedAt: null,
+              lastSuccessAt: null,
+              lastError: null,
+            },
+            {
+              hostname: 'cloud-native-oslo-2027.konf.run',
+              status: 'verified',
+              grandfathered: false,
+              platformOwned: true,
+              graceUntil: null,
+              recordName: null,
+              recordValue: null,
+              wildcard: false,
+              devOnly: false,
+              redirectAllowlisted: true,
+              routable: true,
+              lastCheckedAt: null,
+              lastSuccessAt: null,
+              lastError: null,
+            },
             {
               hostname: 'oslo.cloudnativedays.no',
               status: 'pending',
               grandfathered: false,
+              platformOwned: false,
               graceUntil: null,
               recordName: '_konf-challenge.oslo.cloudnativedays.no',
               recordValue:

--- a/src/components/admin/onboarding/OnboardingWizard.tsx
+++ b/src/components/admin/onboarding/OnboardingWizard.tsx
@@ -667,7 +667,12 @@ function SuccessPanel({
   organizerEmail: string
   domains: string[]
 }) {
-  const firstDomain = domains[0]
+  // The hosts the SERVER actually claimed, not the ones typed into the form:
+  // provisioning mints `<org-slug>.<platform suffix>` and puts it first, so the
+  // typed list alone would announce "no domain attached yet" for a tenant that
+  // has a live address.
+  const primary = result.challenges[0] ?? null
+  const firstDomain = primary?.hostname ?? domains[0]
   return (
     <div className="space-y-6">
       <div className="rounded-lg border border-green-300 bg-green-50 p-6 dark:border-green-700/60 dark:bg-green-900/20">
@@ -764,11 +769,25 @@ function SuccessPanel({
             Next: the activation checklist
           </h4>
           <p className="text-sm text-gray-600 dark:text-gray-300">
-            Once DNS and Vercel domain setup for{' '}
-            <code className="rounded bg-gray-100 px-1 dark:bg-gray-800">
-              {firstDomain}
-            </code>{' '}
-            point at this platform, the tenant&apos;s admin lives at{' '}
+            {primary?.platformOwned ? (
+              <>
+                The tenant is reachable now — we issued{' '}
+                <code className="rounded bg-gray-100 px-1 dark:bg-gray-800">
+                  {firstDomain}
+                </code>{' '}
+                and it serves this conference immediately, with no DNS to set
+                up.{' '}
+              </>
+            ) : (
+              <>
+                Point DNS and Vercel domain setup for{' '}
+                <code className="rounded bg-gray-100 px-1 dark:bg-gray-800">
+                  {firstDomain}
+                </code>{' '}
+                at this platform first.{' '}
+              </>
+            )}
+            The tenant&apos;s admin lives at{' '}
             <a
               href={`https://${firstDomain}/admin/settings`}
               className="font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400"

--- a/src/lib/conference/platformEditionHosts.test.ts
+++ b/src/lib/conference/platformEditionHosts.test.ts
@@ -1,0 +1,200 @@
+/**
+ * @vitest-environment node
+ *
+ * The transfer PLAN for the short `<org-slug>` address. The plan is what the
+ * caller stages in one transaction, so its two halves — what the new edition
+ * claims and what the previous holder releases — are asserted together: a plan
+ * that claims without releasing duplicates a globally unique routing claim, and
+ * one that releases without claiming loses the address entirely.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+interface Holder {
+  _id: string
+  organizationId: string | null
+  startDate: string | null
+  domains: string[]
+}
+
+let holders: Holder[] = []
+
+const fetchMock = vi.fn(async () => holders)
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: () => fetchMock() },
+}))
+
+import { planEditionPlatformHosts } from './platformEditionHosts'
+
+const ORG = 'org-cnb'
+
+function plan(
+  overrides: Partial<Parameters<typeof planEditionPlatformHosts>[0]> = {},
+) {
+  return planEditionPlatformHosts({
+    orgSlug: 'cnb',
+    organizationId: ORG,
+    startDate: '2026-06-01',
+    claimedDomains: holders.flatMap((h) => h.domains),
+    ...overrides,
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  holders = []
+  vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('a first claim (nobody holds the short address)', () => {
+  it('claims both hosts and releases nothing', async () => {
+    expect(await plan()).toEqual({
+      claim: ['cnb.konf.run', 'cnb-2026.konf.run'],
+      releaseFrom: null,
+      transferring: null,
+      conflict: null,
+    })
+  })
+
+  it('collapses to one host for an undated edition', async () => {
+    expect(await plan({ startDate: null })).toEqual({
+      claim: ['cnb.konf.run'],
+      releaseFrom: null,
+      transferring: null,
+      conflict: null,
+    })
+  })
+})
+
+describe('a transfer (a previous edition holds the short address)', () => {
+  beforeEach(() => {
+    holders = [
+      {
+        _id: 'conference-2025',
+        organizationId: ORG,
+        startDate: '2025-06-01',
+        domains: ['cnb.konf.run', 'cnb-2025.konf.run'],
+      },
+    ]
+  })
+
+  it('claims AND releases — never one without the other', async () => {
+    const result = await plan()
+    expect(result.claim).toContain('cnb.konf.run')
+    expect(result.releaseFrom).toBe('conference-2025')
+    expect(result.transferring).toBe('cnb.konf.run')
+    expect(result.conflict).toBeNull()
+  })
+
+  it('moves ONLY the short address, never the permanent one', async () => {
+    const result = await plan()
+    // The previous edition keeps `cnb-2025.konf.run` forever — that is what
+    // makes retiring it to a static archive safe.
+    expect(result.transferring).not.toBe('cnb-2025.konf.run')
+    expect(result.claim).not.toContain('cnb-2025.konf.run')
+  })
+
+  it('refuses to move it BACKWARDS to an earlier edition', async () => {
+    const result = await plan({ startDate: '2024-06-01' })
+    expect(result.claim).toEqual(['cnb-2024.konf.run'])
+    expect(result.releaseFrom).toBeNull()
+    expect(result.transferring).toBeNull()
+  })
+
+  it('orders two editions in one calendar year by their start dates', async () => {
+    holders = [
+      {
+        _id: 'conference-spring',
+        organizationId: ORG,
+        startDate: '2026-03-01',
+        domains: ['cnb.konf.run', 'cnb-2026.konf.run'],
+      },
+    ]
+    // The autumn edition is later, so it takes the short address — but the
+    // dated host is already held, so the whole thing is a conflict rather than
+    // a silent double-claim of `cnb-2026.konf.run`.
+    expect((await plan({ startDate: '2026-09-01' })).conflict).toBe(
+      'cnb-2026.konf.run',
+    )
+  })
+
+  it('refuses when the edition’s own permanent host is already held', async () => {
+    holders = [
+      {
+        _id: 'conference-other',
+        organizationId: ORG,
+        startDate: '2026-06-01',
+        domains: ['cnb-2026.konf.run'],
+      },
+    ]
+    const result = await plan()
+    expect(result.conflict).toBe('cnb-2026.konf.run')
+    expect(result.claim).toEqual([])
+    expect(result.releaseFrom).toBeNull()
+  })
+})
+
+describe('a foreign holder', () => {
+  it('is a CONFLICT, never a transfer', async () => {
+    holders = [
+      {
+        _id: 'conference-foreign',
+        organizationId: 'org-someone-else',
+        startDate: '2020-01-01',
+        domains: ['cnb.konf.run'],
+      },
+    ]
+    const result = await plan()
+    expect(result.conflict).toBe('cnb.konf.run')
+    // Nothing is claimed and nothing is released: stealing a claim from another
+    // tenant is worse than the new edition having no short address.
+    expect(result.claim).toEqual([])
+    expect(result.releaseFrom).toBeNull()
+  })
+
+  it('is a conflict even when the new edition is newer', async () => {
+    holders = [
+      {
+        _id: 'conference-foreign',
+        organizationId: 'org-someone-else',
+        startDate: '2030-01-01',
+        domains: ['cnb.konf.run'],
+      },
+    ]
+    expect((await plan({ startDate: '2031-01-01' })).conflict).toBe(
+      'cnb.konf.run',
+    )
+  })
+
+  it('refuses a WILDCARD that would serve the minted host', async () => {
+    const result = await plan({ claimedDomains: ['*.konf.run'] })
+    expect(result.conflict).not.toBeNull()
+    expect(result.claim).toEqual([])
+  })
+})
+
+describe('nothing to mint', () => {
+  it('mints nothing when the platform operates no zone', async () => {
+    vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', '')
+    expect(await plan()).toEqual({
+      claim: [],
+      releaseFrom: null,
+      transferring: null,
+      conflict: null,
+    })
+    // …and does not even look for a holder.
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('mints nothing for a conference with no organization', async () => {
+    expect((await plan({ organizationId: null })).claim).toEqual([])
+    expect((await plan({ orgSlug: null })).claim).toEqual([])
+  })
+
+  it('mints nothing for a reserved org slug', async () => {
+    expect((await plan({ orgSlug: 'admin' })).claim).toEqual([])
+  })
+})

--- a/src/lib/conference/platformEditionHosts.ts
+++ b/src/lib/conference/platformEditionHosts.ts
@@ -1,0 +1,166 @@
+/**
+ * THE SHORT ADDRESS THAT MOVES.
+ *
+ * A tenant is addressed by two platform hosts, both a single label under
+ * `PLATFORM_DOMAIN_SUFFIX` (see `@/lib/domain-verification/platform`):
+ *
+ *   `acme-2026.konf.run`  PERMANENT — this edition's own address, so archive
+ *                         links keep resolving long after it is retired;
+ *   `acme.konf.run`       the SHORT address of the org's LATEST edition, which
+ *                         therefore has to MOVE when a newer edition appears.
+ *
+ * `conference.domains[]` entries are a GLOBALLY UNIQUE routing claim, so the
+ * bare host cannot sit on two editions at once — and it must never sit on
+ * none. Moving it is a TRANSFER: released from the previous holder and claimed
+ * by the new one, or neither. This module decides the transfer; the caller
+ * stages both halves in ONE Sanity transaction, which is all-or-nothing, so
+ * there is no interleaving in which the address is duplicated or lost.
+ *
+ * ## Why the planning is a read, not an inference
+ *
+ * Which edition currently holds the short address is a fact in the content
+ * lake, not something derivable from a slug. It is read here, by hostname, and
+ * the two rules applied to it are:
+ *
+ *  - {@link shouldTakeLatestHost} — the new edition takes the address only if
+ *    it starts LATER. Back-filling a 2024 edition after 2026 exists must not
+ *    drag the org's short address backwards.
+ *  - SAME ORG ONLY. A minted label belongs to one organization by construction
+ *    (the org slug is globally unique), so a holder from another org is an
+ *    anomaly, reported as a CONFLICT and never transferred. Stealing a claim is
+ *    the one outcome worse than not having one.
+ *
+ * The dated host is never transferred: it is permanent, so any holder at all
+ * is a conflict.
+ */
+
+import {
+  derivePlatformHosts,
+  shouldTakeLatestHost,
+} from '@/lib/domain-verification'
+import { clientReadUncached } from '@/lib/sanity/client'
+import { domainEntriesOverlap, normalizeDomain } from './domains'
+
+/** One conference's hold on a platform host. */
+interface HostHolder {
+  _id: string
+  organizationId: string | null
+  startDate: string | null
+  domains: string[]
+}
+
+export interface EditionHostPlan {
+  /** Platform hosts the NEW edition claims, in `domains[]` order. */
+  claim: string[]
+  /**
+   * The conference the bare host must be RELEASED from, in the same
+   * transaction that claims it. `null` when nothing is being transferred.
+   */
+  releaseFrom: string | null
+  /** The bare host when it is moving — what the release selector targets. */
+  transferring: string | null
+  /** A minted host some other tenant holds. Refuse; never transfer. */
+  conflict: string | null
+}
+
+const EMPTY_PLAN: EditionHostPlan = {
+  claim: [],
+  releaseFrom: null,
+  transferring: null,
+  conflict: null,
+}
+
+/**
+ * Which conferences currently hold either minted host. Keyed by hostname — a
+ * global namespace — so this is deliberately not tenant-scoped.
+ */
+async function findHostHolders(hosts: string[]): Promise<HostHolder[]> {
+  const rows = await clientReadUncached.fetch<HostHolder[] | null>(
+    // groq-global: `domains[]` is a GLOBAL routing claim; the holder of a
+    // hostname may be any tenant's conference, which is exactly what makes a
+    // foreign holder worth detecting.
+    `*[_type == "conference" && count(domains[@ in $hosts]) > 0]{
+      _id,
+      "organizationId": organization._ref,
+      "startDate": startDate,
+      domains
+    }`,
+    { hosts },
+  )
+  return rows ?? []
+}
+
+/**
+ * Decide the new edition's platform hosts and any transfer they imply.
+ *
+ * Returns {@link EMPTY_PLAN} — mint nothing — whenever no host can be derived
+ * (no platform zone, a reserved or unusable slug) or the source edition has no
+ * organization. That is deliberately NOT fatal here, unlike in provisioning: a
+ * new edition always carries at least one domain of its own (its schema
+ * requires it), so it is reachable regardless, and a platform-side
+ * misconfiguration must not block an organizer from creating next year's
+ * conference.
+ */
+export async function planEditionPlatformHosts(input: {
+  orgSlug: string | null | undefined
+  organizationId: string | null | undefined
+  startDate: string | null | undefined
+  /** Every `domains[]` entry claimed anywhere, for the overlap check. */
+  claimedDomains: readonly string[]
+}): Promise<EditionHostPlan> {
+  const { orgSlug, organizationId, startDate } = input
+  if (!orgSlug || !organizationId) return EMPTY_PLAN
+
+  const derived = derivePlatformHosts(orgSlug, startDate)
+  if (!derived.ok) return EMPTY_PLAN
+  const { bare, dated } = derived.hosts
+
+  const holders = await findHostHolders([...new Set([bare, dated])])
+  const holderOf = (host: string) =>
+    holders.find((h) => h.domains.some((d) => normalizeDomain(d) === host)) ??
+    null
+
+  // The DATED host is permanent and belongs to this edition alone. Any holder
+  // — even a sibling edition — means it is not ours to take.
+  const datedHolder = dated === bare ? null : holderOf(dated)
+  if (datedHolder !== null) return { ...EMPTY_PLAN, conflict: dated }
+
+  const bareHolder = holderOf(bare)
+  // A holder from another organization is an anomaly (the label is derived
+  // from a globally unique org slug), and transferring across tenants would be
+  // a hijack. Refuse instead.
+  if (bareHolder !== null && bareHolder.organizationId !== organizationId) {
+    return { ...EMPTY_PLAN, conflict: bare }
+  }
+
+  // A wildcard claim could serve either host without holding it exactly; the
+  // routing matcher is the authority on that, so it is consulted too.
+  const overlapping = [bare, dated].find((host) =>
+    input.claimedDomains.some(
+      (entry) =>
+        domainEntriesOverlap(normalizeDomain(entry), host) &&
+        // The sibling's exact hold on the bare host is the transfer case, not
+        // a conflict.
+        !(
+          host === bare &&
+          bareHolder !== null &&
+          normalizeDomain(entry) === bare
+        ),
+    ),
+  )
+  if (overlapping !== undefined) return { ...EMPTY_PLAN, conflict: overlapping }
+
+  // The dated host is always claimed; the bare one only when this edition is
+  // genuinely the latest.
+  const takesBare =
+    bareHolder === null ||
+    shouldTakeLatestHost(bareHolder.startDate, startDate ?? null)
+  const claim = takesBare ? [...new Set([bare, dated])] : [dated]
+
+  return {
+    claim,
+    releaseFrom: takesBare && bareHolder !== null ? bareHolder._id : null,
+    transferring: takesBare && bareHolder !== null ? bare : null,
+    conflict: null,
+  }
+}

--- a/src/lib/domain-verification/index.ts
+++ b/src/lib/domain-verification/index.ts
@@ -25,7 +25,12 @@ export {
   getDomainVerification,
   listDomainVerificationsForConference,
 } from './sanity'
-export { PLATFORM_DOMAIN_NOT_ALLOCATED } from './platform'
+export {
+  derivePlatformHosts,
+  PLATFORM_DOMAIN_NOT_ALLOCATED,
+  shouldTakeLatestHost,
+} from './platform'
+export type { PlatformHostRefusal, PlatformHostSet } from './platform'
 export {
   findUnallocatedPlatformDomains,
   listDomainVerificationViews,

--- a/src/lib/domain-verification/platform.test.ts
+++ b/src/lib/domain-verification/platform.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
-import { isPlatformZoneHost, platformDomainSuffix } from './platform'
+import {
+  derivePlatformHosts,
+  isPlatformZoneHost,
+  platformDomainSuffix,
+  shouldTakeLatestHost,
+} from './platform'
 
 /**
  * The suffix matcher is the whole security surface of platform-owned
@@ -121,5 +126,183 @@ describe('isPlatformZoneHost', () => {
     withSuffix('events.example.org')
     expect(isPlatformZoneHost('kubeday.events.example.org')).toBe(true)
     expect(isPlatformZoneHost('kubeday.konf.run')).toBe(false)
+  })
+})
+
+/**
+ * MINTING. The derivation is what turns a new tenant into a REACHABLE one, so
+ * its shape is a contract, not a detail: two SINGLE labels (a wildcard
+ * certificate covers no more), a permanent dated host per edition, a short
+ * host for the latest one, and no invented year when none is known.
+ */
+describe('derivePlatformHosts', () => {
+  it('mints the permanent dated host and the short bare host', () => {
+    withSuffix('konf.run')
+    expect(derivePlatformHosts('acme', '2026-05-04')).toEqual({
+      ok: true,
+      hosts: { bare: 'acme.konf.run', dated: 'acme-2026.konf.run' },
+    })
+  })
+
+  it('produces SINGLE labels only — never a nested form', () => {
+    withSuffix('konf.run')
+    const derived = derivePlatformHosts('acme', '2026-05-04')
+    expect(derived.ok).toBe(true)
+    if (!derived.ok) return
+    // `*.konf.run` secures `acme-2026.konf.run` and NOT `2026.acme.konf.run`:
+    // the nested form additionally needs a per-org wildcard AND a deployment
+    // aliased to it, or a visitor gets the CDN's own error page.
+    for (const host of [derived.hosts.bare, derived.hosts.dated]) {
+      expect(host.split('.')).toHaveLength(3)
+      expect(host.slice(0, -'.konf.run'.length)).not.toContain('.')
+    }
+  })
+
+  it('collapses onto ONE host, asserting no year, when there are no dates yet', () => {
+    withSuffix('konf.run')
+    for (const missing of [null, undefined, '', 'not-a-date']) {
+      expect(derivePlatformHosts('acme', missing)).toEqual({
+        ok: true,
+        hosts: { bare: 'acme.konf.run', dated: 'acme.konf.run' },
+      })
+    }
+  })
+
+  it('keeps every dated host distinct from the bare one and from each other', () => {
+    withSuffix('konf.run')
+    const y2026 = derivePlatformHosts('acme', '2026-05-04')
+    const y2027 = derivePlatformHosts('acme', '2027-05-04')
+    expect(y2026.ok && y2027.ok).toBe(true)
+    if (!y2026.ok || !y2027.ok) return
+    const hosts = [y2026.hosts.bare, y2026.hosts.dated, y2027.hosts.dated]
+    expect(new Set(hosts).size).toBe(3)
+  })
+
+  it('is stable — the same inputs always mint the same hosts', () => {
+    withSuffix('konf.run')
+    expect(derivePlatformHosts('acme', '2026-05-04')).toEqual(
+      derivePlatformHosts('acme', '2026-05-04'),
+    )
+  })
+
+  it('REFUSES when the platform operates no zone', () => {
+    withSuffix(undefined)
+    expect(derivePlatformHosts('acme', '2026-05-04')).toEqual({
+      ok: false,
+      reason: 'no-zone',
+    })
+  })
+
+  it('REFUSES a label DNS cannot carry (over 63 octets)', () => {
+    withSuffix('konf.run')
+    expect(derivePlatformHosts('a'.repeat(63), null).ok).toBe(true)
+    expect(derivePlatformHosts('a'.repeat(64), null)).toEqual({
+      ok: false,
+      reason: 'unusable-label',
+    })
+    // The DATED label is the longer of the pair, and it refuses the whole set:
+    // half a pair would leave an edition without its permanent address.
+    expect(derivePlatformHosts('a'.repeat(60), '2026-05-04')).toEqual({
+      ok: false,
+      reason: 'unusable-label',
+    })
+  })
+
+  it('REFUSES anything that would smuggle extra labels into the host', () => {
+    withSuffix('konf.run')
+    for (const slug of ['acme.evil', 'a.b', '*', 'acme:3000', '', '-acme']) {
+      expect(derivePlatformHosts(slug, null)).toEqual({
+        ok: false,
+        reason: 'unusable-label',
+      })
+    }
+  })
+
+  it('REFUSES slugs whose bare host the platform keeps for itself', () => {
+    withSuffix('konf.run')
+    for (const slug of [
+      'www',
+      'api',
+      'admin',
+      'auth',
+      'my',
+      'status',
+      'konf',
+    ]) {
+      // Checked on the ORG SLUG: `admin-2026` would be harmless, but the pair
+      // is all-or-nothing and `admin.konf.run` is not the tenant's to take.
+      expect(derivePlatformHosts(slug, '2026-05-04')).toEqual({
+        ok: false,
+        reason: 'reserved',
+      })
+    }
+  })
+
+  it('mints inside the WHITE-LABELLED zone, and only there', () => {
+    withSuffix('events.example.org')
+    expect(derivePlatformHosts('acme', '2026-05-04')).toEqual({
+      ok: true,
+      hosts: {
+        bare: 'acme.events.example.org',
+        dated: 'acme-2026.events.example.org',
+      },
+    })
+  })
+
+  it('mints only hosts its own allocation gate would accept', () => {
+    // Self-consistency: everything returned must be in the zone, or a caller
+    // would claim a host that can never be allocated to it.
+    withSuffix('konf.run')
+    for (const [slug, date] of [
+      ['acme', '2026-05-04'],
+      ['acme', null],
+      ['x', '2099-12-31'],
+    ] as const) {
+      const derived = derivePlatformHosts(slug, date)
+      expect(derived.ok).toBe(true)
+      if (!derived.ok) continue
+      expect(isPlatformZoneHost(derived.hosts.bare)).toBe(true)
+      expect(isPlatformZoneHost(derived.hosts.dated)).toBe(true)
+    }
+  })
+})
+
+/**
+ * WHERE THE SHORT ADDRESS POINTS. The bare host moves between editions, so the
+ * rule that decides when has to be a function, not an inline comparison.
+ */
+describe('shouldTakeLatestHost', () => {
+  it('moves to an edition that starts LATER', () => {
+    expect(shouldTakeLatestHost('2026-05-04', '2027-05-04')).toBe(true)
+  })
+
+  it('does NOT move to an edition that starts EARLIER', () => {
+    // Back-filling a 2024 edition after 2026 exists must not drag the org's
+    // short address backwards in time.
+    expect(shouldTakeLatestHost('2026-05-04', '2024-05-04')).toBe(false)
+  })
+
+  it('orders two editions in the SAME calendar year by their actual dates', () => {
+    // Spring loses to autumn; autumn does not lose to spring.
+    expect(shouldTakeLatestHost('2026-03-01', '2026-09-01')).toBe(true)
+    expect(shouldTakeLatestHost('2026-09-01', '2026-03-01')).toBe(false)
+  })
+
+  it('keeps the incumbent on an exact tie — a live address does not churn', () => {
+    expect(shouldTakeLatestHost('2026-05-04', '2026-05-04')).toBe(false)
+  })
+
+  it('never lets an UNDATED edition take it from a dated one', () => {
+    expect(shouldTakeLatestHost('2026-05-04', null)).toBe(false)
+    expect(shouldTakeLatestHost('2026-05-04', undefined)).toBe(false)
+    expect(shouldTakeLatestHost('2026-05-04', '  ')).toBe(false)
+  })
+
+  it('lets a DATED edition take it from an undated incumbent', () => {
+    expect(shouldTakeLatestHost(null, '2026-05-04')).toBe(true)
+  })
+
+  it('keeps the incumbent when NEITHER has dates', () => {
+    expect(shouldTakeLatestHost(null, null)).toBe(false)
   })
 })

--- a/src/lib/domain-verification/platform.ts
+++ b/src/lib/domain-verification/platform.ts
@@ -63,6 +63,19 @@
  * a *prefix* of someone else's). The comparison therefore splits both sides into
  * DNS labels and requires the suffix to be the exact trailing labels of the
  * host, with at least one label to spare.
+ *
+ * ## Minting: {@link derivePlatformHosts}
+ *
+ * The same suffix that decides what is IN the zone also decides what the
+ * platform MINTS for an edition — the pair `<org-slug>.<suffix>` and
+ * `<org-slug>-<year>.<suffix>`, derived in one place so the two can never
+ * disagree. Provisioning claims and allocates them; see
+ * `src/lib/onboarding/provision.ts` and
+ * `src/lib/conference/platformEditionHosts.ts`.
+ *
+ * The derivation runs ONCE per edition, at creation. Nothing re-derives it at
+ * read time, so renaming an organization later cannot move, break or silently
+ * re-issue an address that is already in the wild.
  */
 
 import { isValidDomainEntry, normalizeDomain } from '@/lib/conference/domains'
@@ -147,6 +160,259 @@ export function isPlatformZoneHost(
   const host = normalizeDomain(entry)
   if (!host || host.startsWith('*.')) return false
   return isSubdomainOfSuffix(host, suffix)
+}
+
+/**
+ * A single legal DNS label: 1-63 characters, alphanumeric with interior
+ * hyphens. Deliberately NOT `ORG_SLUG_RE` — this is a DNS constraint, not a
+ * slug-style one, and the 63-octet label ceiling (RFC 1035 §2.3.4) is the half
+ * that actually matters here: org slugs are allowed up to 96 characters, so a
+ * long one would otherwise mint a hostname that resolves nowhere.
+ */
+const DNS_LABEL_RE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/
+
+/**
+ * Labels the platform keeps for ITSELF, refused as a minted tenant address.
+ *
+ * Cheap to add now and impossible to add later: the claim is globally unique
+ * and permanent, so the first tenant slugged `api` or `auth` would take
+ * `api.<suffix>` off the platform for good — including the one host the central
+ * auth origin (#688) is going to want. The list covers the conventional
+ * infrastructure names (RFC 2142 mailbox names, the usual www/api/cdn shape),
+ * the platform's own product surfaces and the environment names a deploy would
+ * plausibly use.
+ */
+const RESERVED_PLATFORM_LABELS = new Set([
+  // infrastructure / conventional hostnames
+  'www',
+  'api',
+  'cdn',
+  'static',
+  'assets',
+  'media',
+  'img',
+  'images',
+  'files',
+  'mail',
+  'email',
+  'smtp',
+  'imap',
+  'mx',
+  'ns',
+  'ns1',
+  'ns2',
+  'dns',
+  'ftp',
+  'vpn',
+  'proxy',
+  'edge',
+  'origin',
+  // platform surfaces
+  'admin',
+  'auth',
+  'login',
+  'signin',
+  'signup',
+  'account',
+  'accounts',
+  'app',
+  'apps',
+  'my',
+  'dashboard',
+  'console',
+  'status',
+  'health',
+  'billing',
+  'pay',
+  'payments',
+  'checkout',
+  'docs',
+  'doc',
+  'blog',
+  'help',
+  'support',
+  'kb',
+  'go',
+  'link',
+  // brand / operations
+  'konf',
+  'runkonf',
+  'platform',
+  'internal',
+  'security',
+  'abuse',
+  'postmaster',
+  'webmaster',
+  'hostmaster',
+  'noreply',
+  'no-reply',
+  'root',
+  // environments
+  'dev',
+  'test',
+  'stage',
+  'staging',
+  'preview',
+  'demo',
+  'sandbox',
+  'beta',
+  'alpha',
+  'local',
+  'localhost',
+])
+
+/**
+ * Why hosts could NOT be minted. The callers report these differently — a
+ * missing zone is a deployment problem, a reserved label is the operator's
+ * choice of slug — so they are distinguished at the source rather than
+ * flattened into `null`.
+ */
+export type PlatformHostRefusal = 'no-zone' | 'unusable-label' | 'reserved'
+
+/**
+ * The pair of hosts an edition is addressed by. `bare === dated` when the
+ * edition has no start date, in which case the tenant simply has one host.
+ */
+export interface PlatformHostSet {
+  /** `acme.konf.run` — the SHORT address of the org's LATEST edition. Moves. */
+  bare: string
+  /** `acme-2026.konf.run` — this edition's PERMANENT address. Never moves. */
+  dated: string
+}
+
+export type PlatformHostsDerivation =
+  | { ok: true; hosts: PlatformHostSet }
+  | { ok: false; reason: PlatformHostRefusal }
+
+/** The 4-digit edition year of a `YYYY-MM-DD` start date, or `null`. */
+function editionYear(startDate: string | null | undefined): string | null {
+  if (typeof startDate !== 'string') return null
+  const match = /^(\d{4})-\d{2}-\d{2}$/.exec(startDate.trim())
+  return match ? match[1] : null
+}
+
+/** `<label>.<suffix>`, or `null` when it is not a host we could allocate. */
+function mintHost(
+  label: string,
+  suffix: string,
+  env: NodeJS.ProcessEnv,
+): string | null {
+  if (!DNS_LABEL_RE.test(label)) return null
+  const host = `${label}.${suffix}`
+  if (!isValidDomainEntry(host) || !isPlatformZoneHost(host, env)) return null
+  // ONE label below the suffix, asserted rather than assumed: this is exactly
+  // the property a wildcard certificate can cover.
+  if (host.split('.').length !== suffix.split('.').length + 1) return null
+  return host
+}
+
+/**
+ * THE HOSTNAMES THE PLATFORM MINTS FOR AN EDITION — two of them, both a SINGLE
+ * label under the platform suffix:
+ *
+ *   `acme-2026.konf.run`  the edition's PERMANENT address. Belongs to that
+ *                         edition forever and never moves, so an archived
+ *                         edition's links keep resolving after it is retired.
+ *   `acme.konf.run`       the SHORT address of the org's LATEST edition. This
+ *                         one MOVES: creating a newer edition transfers it.
+ *
+ * ## Why the edition, not the organization
+ *
+ * Conferences are already addressed per edition in the wild
+ * (`2024.cloudnativebergen.dev`, `2026.cloudnativedays.no`), and an edition's
+ * URL has to outlive the edition. A dated host cannot collide across an org's
+ * own editions, and cannot collide across orgs at all — the org slug is
+ * globally unique and both labels inherit that uniqueness.
+ *
+ * ## ONE LABEL, never nested
+ *
+ * `acme-2026.konf.run`, NOT `2026.acme.konf.run`. A wildcard certificate covers
+ * exactly one label; the nested form additionally needs a per-org wildcard
+ * registered AND a deployment aliased to it, and without that last step a
+ * visitor gets the CDN's own "deployment not found" page instead of ours. Both
+ * labels here are single, which is why this needs no per-tenant provider work
+ * at all. Enforced in {@link mintHost} rather than trusted: the label regex
+ * admits no dots and the final host is re-counted against the suffix.
+ *
+ * ## When the year is unknown
+ *
+ * `startDate` is optional at provisioning (the activation checklist collects
+ * dates later), and the answer is that `dated` collapses onto `bare` — NOT a
+ * guess at the current year. A year in a hostname is a factual claim about the
+ * event, the host is permanent and unmigratable, and a customer signing up in
+ * December for next year's conference would be stuck with last year's address
+ * forever. The tenant is still reachable, which is the whole point.
+ *
+ * ## Refusals
+ *
+ * `ok: false` — never a guess, never a fallback label:
+ *
+ *  - `no-zone` — the suffix is unset or unusable ({@link platformDomainSuffix}):
+ *    this deployment operates no zone of its own;
+ *  - `unusable-label` — a label DNS cannot carry (a slug over 63 characters, or
+ *    one the year pushes over), so the host would resolve nowhere; also the
+ *    self-consistency backstop, since a host our own {@link isPlatformZoneHost}
+ *    would refuse to allocate must never reach a caller;
+ *  - `reserved` — the ORG SLUG is in {@link RESERVED_PLATFORM_LABELS}. Checked
+ *    on the bare label because that is the one the org would actually take:
+ *    `www-2026` is harmless, `www` is not, and the pair is all-or-nothing.
+ *
+ * A refusal means "the platform cannot give this edition an address", and the
+ * caller has to act on it loudly. It must NEVER be read as "no address needed"
+ * — that is precisely the unreachable-tenant bug.
+ */
+export function derivePlatformHosts(
+  orgSlug: string,
+  startDate: string | null | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): PlatformHostsDerivation {
+  const suffix = platformDomainSuffix(env)
+  if (suffix === null) return { ok: false, reason: 'no-zone' }
+
+  const slug = normalizeDomain(orgSlug)
+  if (RESERVED_PLATFORM_LABELS.has(slug)) {
+    return { ok: false, reason: 'reserved' }
+  }
+
+  const year = editionYear(startDate)
+  const bare = mintHost(slug, suffix, env)
+  const dated = year === null ? bare : mintHost(`${slug}-${year}`, suffix, env)
+  if (bare === null || dated === null) {
+    return { ok: false, reason: 'unusable-label' }
+  }
+  return { ok: true, hosts: { bare, dated } }
+}
+
+/**
+ * Should a NEW edition take the bare `<org-slug>` host away from the edition
+ * that currently holds it? PURE, so the one rule that decides where a moving
+ * address points is a testable function rather than an inline comparison.
+ *
+ * "Latest" is by START DATE, not by creation order and not by year alone:
+ *
+ *  - A candidate starting LATER than the incumbent takes it. That is the whole
+ *    purpose of the short address.
+ *  - A candidate starting EARLIER does NOT. Back-filling a 2024 edition after
+ *    2026 exists must not drag the org's short address backwards in time, and
+ *    this is the case that would silently do it.
+ *  - Ties keep the incumbent. Two editions in the same calendar year are
+ *    ordered by their actual start dates, so the spring event still loses to
+ *    the autumn one; only an exact same-day tie holds, and then the sitting
+ *    edition wins because there is no evidence to move a live address.
+ *  - A candidate with NO dates never takes it from a dated incumbent — we
+ *    cannot show it is newer.
+ *
+ * Dates are ISO `YYYY-MM-DD`, where lexicographic order IS chronological order.
+ */
+export function shouldTakeLatestHost(
+  incumbentStartDate: string | null | undefined,
+  candidateStartDate: string | null | undefined,
+): boolean {
+  const incumbent = incumbentStartDate?.trim() || null
+  const candidate = candidateStartDate?.trim() || null
+  if (candidate === null) return false
+  if (incumbent === null) return true
+  return candidate > incumbent
 }
 
 /**

--- a/src/lib/onboarding/provision.test.ts
+++ b/src/lib/onboarding/provision.test.ts
@@ -1,0 +1,704 @@
+/**
+ * @vitest-environment node
+ *
+ * THE TENANT'S ADDRESSES — provisioning mints the pair
+ * `<org-slug>.<suffix>` + `<org-slug>-<year>.<suffix>`, claims both in the
+ * atomic transaction, and ALLOCATES both to the new conference.
+ *
+ * Every assertion here is on OBSERVABLE STATE in an in-memory content lake:
+ * which documents exist, what `conference.domains[]` contains, and what the
+ * `domainVerification` document says (`method`, `status`, and WHICH conference
+ * it references). Deliberately NOT on error messages — a message assertion
+ * passes happily against code that wrote a broken tenant anyway, which is the
+ * exact failure mode this file exists to catch.
+ *
+ * The domain-verification stack is REAL here (only the Sanity client is faked),
+ * so the allocation is exercised end to end rather than through a spy: a stub
+ * would let "we called sync with a flag" stand in for "a platform-owned record
+ * exists naming this conference", and those are not the same claim.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }))
+
+interface Doc extends Record<string, unknown> {
+  _id: string
+  _type: string
+}
+
+const docs = new Map<string, Doc>()
+
+function conflict(message: string): Error & { statusCode: number } {
+  return Object.assign(new Error(message), { statusCode: 409 })
+}
+
+function insertDoc(doc: Doc): void {
+  if (docs.has(doc._id)) throw conflict(`Document ${doc._id} already exists`)
+  docs.set(doc._id, { ...doc })
+}
+
+/** The `domainVerification` PROJECTION, mirrored (see `domain-verification/sanity.ts`). */
+function projectVerification(doc: Doc) {
+  return {
+    _id: doc._id,
+    hostname: doc.hostname,
+    conferenceId: (doc.conference as { _ref?: string } | undefined)?._ref,
+    token: doc.token,
+    status: doc.status ?? 'pending',
+    method: doc.method ?? 'dns-txt',
+    graceUntil: doc.graceUntil ?? null,
+    verifiedAt: doc.verifiedAt ?? null,
+    lastSuccessAt: doc.lastSuccessAt ?? null,
+    lastCheckedAt: doc.lastCheckedAt ?? null,
+    firstFailureAt: doc.firstFailureAt ?? null,
+    consecutiveFailures: doc.consecutiveFailures ?? 0,
+    consecutiveSoftFailures: doc.consecutiveSoftFailures ?? 0,
+    lastError: doc.lastError ?? null,
+  }
+}
+
+const fetchMock = vi.fn(
+  async (query: string, params: Record<string, unknown> = {}) => {
+    if (query.includes('_type == "domainVerification"')) {
+      const doc = docs.get(params.id as string)
+      return doc ? projectVerification(doc) : null
+    }
+    // Provisioning receipt, addressed by deterministic id.
+    if (query.includes('_type == $type && _id == $id')) {
+      const doc = docs.get(params.id as string)
+      return doc && doc._type === params.type ? { ...doc } : null
+    }
+    if (query.includes('count(*[_type == "organization"')) {
+      return [...docs.values()].filter(
+        (d) =>
+          d._type === 'organization' &&
+          (d.slug as { current?: string } | undefined)?.current === params.slug,
+      ).length
+    }
+    // The real GROQ only pre-narrows; the JS overlap predicate is the
+    // authority, so returning every claimed entry is faithful.
+    if (query.includes('.domains[]')) {
+      return [...docs.values()]
+        .filter((d) => d._type === 'conference')
+        .flatMap((d) => (d.domains as string[] | undefined) ?? [])
+    }
+    if (query.includes('_type == "speaker"')) {
+      return [...docs.values()]
+        .filter(
+          (d) =>
+            d._type === 'speaker' &&
+            String(d.email ?? '').toLowerCase() === params.email,
+        )
+        .map((d) => ({ _id: d._id, name: d.name }))
+    }
+    throw new Error(`Unexpected query: ${query}`)
+  },
+)
+
+/** Standalone patch builder — `ensureDomainVerification`'s upgrade/reset path. */
+function standalonePatch(id: string) {
+  let updates: Record<string, unknown> = {}
+  let removals: string[] = []
+  const chain = {
+    set(values: Record<string, unknown>) {
+      updates = { ...updates, ...values }
+      return chain
+    },
+    unset(fields: string[]) {
+      removals = [...removals, ...fields]
+      return chain
+    },
+    async commit() {
+      const doc = docs.get(id)
+      if (!doc) throw conflict(`Document ${id} is gone`)
+      const next = { ...doc, ...updates }
+      for (const field of removals) delete next[field]
+      docs.set(id, next as Doc)
+    },
+  }
+  return chain
+}
+
+function transactionPatch(id: string) {
+  const ops: Array<(doc: Doc) => Doc> = []
+  const builder = {
+    setIfMissing(values: Record<string, unknown>) {
+      ops.push((doc) => ({ ...values, ...doc }))
+      return builder
+    },
+    insert(_pos: string, _selector: string, items: unknown[]) {
+      ops.push((doc) => ({
+        ...doc,
+        organizations: [
+          ...((doc.organizations as unknown[] | undefined) ?? []),
+          ...items,
+        ],
+      }))
+      return builder
+    },
+  }
+  return {
+    builder,
+    apply() {
+      const doc = docs.get(id)
+      if (!doc) throw conflict(`Document ${id} is gone`)
+      docs.set(
+        id,
+        ops.reduce((acc, op) => op(acc), doc as Doc),
+      )
+    },
+  }
+}
+
+/** Every document handed to `tx.create` — i.e. what rode the transaction. */
+let createdInTransaction: Doc[] = []
+/** Fault injection for the all-or-nothing rollback. */
+let failCommit = false
+
+function makeTransaction() {
+  const staged: Array<() => void> = []
+  const tx = {
+    create(doc: Doc) {
+      createdInTransaction.push(doc)
+      staged.push(() => insertDoc(doc))
+      return tx
+    },
+    patch(id: string, fn: (p: unknown) => unknown) {
+      const rec = transactionPatch(id)
+      fn(rec.builder)
+      staged.push(() => rec.apply())
+      return tx
+    },
+    async commit() {
+      if (failCommit) throw new Error('sanity unavailable')
+      // ALL-OR-NOTHING: snapshot, apply, restore on any failure.
+      const snapshot = new Map(docs)
+      try {
+        for (const op of staged) op()
+      } catch (error) {
+        docs.clear()
+        for (const [id, doc] of snapshot) docs.set(id, doc)
+        throw error
+      }
+      return {}
+    },
+  }
+  return tx
+}
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: {
+    fetch: (query: string, params?: Record<string, unknown>) =>
+      fetchMock(query, params ?? {}),
+  },
+  clientReadCached: { fetch: vi.fn() },
+  clientWrite: {
+    transaction: () => makeTransaction(),
+    create: async (doc: Doc) => {
+      insertDoc(doc)
+      return doc
+    },
+    createIfNotExists: async (doc: Doc) => {
+      if (!docs.has(doc._id)) docs.set(doc._id, { ...doc })
+      return doc
+    },
+    patch: (id: string) => standalonePatch(id),
+    delete: async () => ({ results: [] }),
+  },
+}))
+
+import { provisionOrganization } from './provision'
+import type { OnboardingInput } from './create'
+
+const SUFFIX = 'konf.run'
+const SLUG = 'cloud-native-oslo'
+/** The SHORT address of the org's latest edition. */
+const BARE = `${SLUG}.${SUFFIX}`
+/** This edition's PERMANENT address. */
+const DATED = `${SLUG}-2027.${SUFFIX}`
+/** Both, in `domains[]` order. */
+const MINTED = [BARE, DATED]
+
+function input(overrides: Partial<OnboardingInput> = {}): OnboardingInput {
+  return {
+    organization: {
+      name: 'Cloud Native Oslo',
+      slug: SLUG,
+      contactEmail: 'hello@cno.no',
+    },
+    conference: {
+      title: 'Cloud Native Days Oslo 2027',
+      city: 'Oslo',
+      country: 'Norway',
+      startDate: '2027-06-01',
+      endDate: '2027-06-02',
+    },
+    organizer: { name: 'Kari Nordmann', email: 'kari@cno.no' },
+    domains: [],
+    ...overrides,
+  }
+}
+
+/** The same tenant with no dates yet — `startDate` is optional at provisioning. */
+function undated(overrides: Partial<OnboardingInput> = {}): OnboardingInput {
+  const base = input(overrides)
+  return {
+    ...base,
+    conference: {
+      title: base.conference.title,
+      city: base.conference.city,
+      country: base.conference.country,
+    },
+  }
+}
+
+const ofType = (type: string) =>
+  [...docs.values()].filter((d) => d._type === type)
+
+/** The verification document for a hostname, straight out of the fake lake. */
+function verificationFor(hostname: string): Doc | undefined {
+  return ofType('domainVerification').find((d) => d.hostname === hostname)
+}
+
+/** The one conference document — the thing a tenant is reachable through. */
+function theConference(): Doc {
+  const conferences = ofType('conference')
+  expect(conferences).toHaveLength(1)
+  return conferences[0]
+}
+
+let errorSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  docs.clear()
+  createdInTransaction = []
+  failCommit = false
+  process.env.AUTH_SECRET = 'test-auth-secret'
+  vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', SUFFIX)
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  errorSpy.mockRestore()
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// 1. THE TENANT COMES OUT REACHABLE
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('provisioning mints the tenant an address', () => {
+  it('claims BOTH minted hosts for a tenant that asked for no domain', async () => {
+    const outcome = await provisionOrganization(input())
+
+    expect(outcome.ok).toBe(true)
+    // THE assertion the bug is about: resolution is by request Host against
+    // `domains[]`, so an empty list is a tenant nothing serves.
+    expect(theConference().domains).toEqual(MINTED)
+  })
+
+  it('ALLOCATES EACH minted host to THAT conference (platform-owned, verified)', async () => {
+    const outcome = await provisionOrganization(input())
+    expect(outcome.ok).toBe(true)
+    if (!outcome.ok) return
+
+    for (const host of MINTED) {
+      const record = verificationFor(host)
+      // Without a record the host fails closed everywhere — unrouted under
+      // enforcement, never on the redirect allowlist. Claiming is not enough.
+      expect(record).toBeDefined()
+      expect(record).toMatchObject({
+        hostname: host,
+        method: 'platform-owned',
+        status: 'verified',
+        // …and allocated to THIS conference. A record naming any other
+        // document is the #778 cross-tenant hijack, not a grant to this tenant.
+        conference: { _ref: outcome.conferenceId },
+      })
+      expect(record).not.toHaveProperty('graceUntil')
+    }
+  })
+
+  it('stages the claim INSIDE the transaction, not as a follow-up write', async () => {
+    await provisionOrganization(input())
+
+    // The conference document as it was HANDED TO THE TRANSACTION already
+    // carries the host. A post-commit patch would produce the same final state
+    // but leave a window in which the tenant exists at no address — exactly the
+    // half-built state the all-or-nothing transaction exists to prevent.
+    const staged = createdInTransaction.find((d) => d._type === 'conference')
+    expect(staged?.domains).toEqual(MINTED)
+  })
+
+  it('leaves NO claim and NO allocation behind when the transaction fails', async () => {
+    failCommit = true
+    const outcome = await provisionOrganization(input())
+
+    expect(outcome.ok).toBe(false)
+    expect(ofType('organization')).toHaveLength(0)
+    expect(ofType('conference')).toHaveLength(0)
+    // The allocation is a GLOBAL, permanent grant — minting one for a tenant
+    // that was never created would burn the hostname for good.
+    expect(ofType('domainVerification')).toHaveLength(0)
+  })
+
+  it('is reachable and allocated on the SECOND front door too (same transaction, replayed)', async () => {
+    const first = await provisionOrganization(input(), {
+      idempotencyKey: 'idem-0123456789abcdef',
+    })
+    const second = await provisionOrganization(input(), {
+      idempotencyKey: 'idem-0123456789abcdef',
+    })
+
+    expect(first.ok && second.ok).toBe(true)
+    if (!first.ok || !second.ok) return
+    // ONE tenant, and the replay names it.
+    expect(ofType('organization')).toHaveLength(1)
+    expect(second.conferenceId).toBe(first.conferenceId)
+    expect(second.replayed).toBe(true)
+    // The receipt carried the MINTED host, so the replay re-mints the same
+    // allocation rather than an empty list.
+    expect(theConference().domains).toEqual(MINTED)
+    expect(verificationFor(BARE)).toMatchObject({
+      method: 'platform-owned',
+      conference: { _ref: first.conferenceId },
+    })
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// 1b. THE DERIVATION RULE
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('the minted host names the EDITION', () => {
+  it('carries the edition year taken from the start date', async () => {
+    await provisionOrganization(
+      input({
+        conference: {
+          title: 'Cloud Native Days Oslo 2031',
+          city: 'Oslo',
+          country: 'Norway',
+          startDate: '2031-09-14',
+          endDate: '2031-09-15',
+        },
+      }),
+    )
+    expect(theConference().domains).toEqual([BARE, `${SLUG}-2031.${SUFFIX}`])
+  })
+
+  it('is ONE label above the platform suffix — a wildcard certificate covers no more', async () => {
+    await provisionOrganization(input())
+
+    // `acme-2027.konf.run`, never `2027.acme.konf.run`: `*.konf.run` secures
+    // the first and NOT the second, and per-tenant certificates are the exact
+    // work the wildcard exists to avoid.
+    for (const host of theConference().domains as string[]) {
+      expect(host.split('.')).toHaveLength(SUFFIX.split('.').length + 1)
+      expect(host.slice(0, -(SUFFIX.length + 1))).not.toContain('.')
+    }
+  })
+
+  it('asserts NO year when the tenant has no dates yet', async () => {
+    const outcome = await provisionOrganization(undated())
+    expect(outcome.ok).toBe(true)
+
+    // The bare slug ALONE, NOT a guess at the current year: the host is
+    // permanent and unmigratable, so a customer signing up in December for next
+    // year's conference must not be stuck with last year's address forever.
+    expect(theConference().domains).toEqual([BARE])
+    expect(BARE).not.toMatch(/\d{4}/)
+  })
+
+  it('gives an undated tenant a REACHABLE host all the same', async () => {
+    const outcome = await provisionOrganization(undated())
+    expect(outcome.ok).toBe(true)
+    if (!outcome.ok) return
+
+    // Deferring the claim until dates exist would recreate the very bug this
+    // change fixes, so the undated tenant is allocated exactly like a dated one.
+    expect(verificationFor(BARE)).toMatchObject({
+      method: 'platform-owned',
+      status: 'verified',
+      conference: { _ref: outcome.conferenceId },
+    })
+  })
+
+  it('keeps the bare label distinct from every dated one', async () => {
+    await provisionOrganization(undated())
+    // The bare label and every `<slug>-<year>` label are distinct by
+    // construction, so the dated rule stays intact for later editions.
+    expect(theConference().domains).not.toContain(DATED)
+  })
+})
+
+describe('the minted host is issued ONCE, never re-derived', () => {
+  it('survives a later org-slug rename untouched', async () => {
+    const outcome = await provisionOrganization(input())
+    expect(outcome.ok).toBe(true)
+    if (!outcome.ok) return
+
+    // kontroll can rename the organization afterwards.
+    const org = docs.get(outcome.organizationId)!
+    docs.set(outcome.organizationId, {
+      ...org,
+      slug: { _type: 'slug', current: 'renamed-entirely' },
+    })
+
+    // The address is in the wild, so it must not move, break or re-issue: both
+    // the claim and the allocation are keyed by the hostname itself and nothing
+    // re-derives them at read time.
+    expect(theConference().domains).toEqual(MINTED)
+    expect(verificationFor(DATED)).toMatchObject({
+      method: 'platform-owned',
+      conference: { _ref: outcome.conferenceId },
+    })
+    expect(verificationFor(`renamed-entirely.${SUFFIX}`)).toBeUndefined()
+  })
+})
+
+describe('labels the platform keeps for itself', () => {
+  it.each(['www', 'api', 'admin', 'auth', 'my', 'status'])(
+    'refuses the slug %s outright and writes nothing',
+    async (slug) => {
+      const outcome = await provisionOrganization(
+        undated({
+          organization: { name: 'X', slug, contactEmail: 'hello@cno.no' },
+        }),
+      )
+
+      expect(outcome.ok).toBe(false)
+      expect(ofType('organization')).toHaveLength(0)
+      expect(ofType('conference')).toHaveLength(0)
+      expect(ofType('domainVerification')).toHaveLength(0)
+    },
+  )
+
+  it('refuses even when the caller supplied its own domain', async () => {
+    // Not a reachability problem — this tenant HAS an address. The point is
+    // that a permanent, globally unique claim on the platform's own `auth`
+    // hostname must never be handed out by accident.
+    const outcome = await provisionOrganization(
+      undated({
+        organization: { name: 'X', slug: 'auth', contactEmail: 'hello@cno.no' },
+        domains: ['oslo.cloudnativedays.no'],
+      }),
+    )
+    expect(outcome.ok).toBe(false)
+    if (outcome.ok) return
+    expect(outcome.rejection).toEqual({ code: 'reserved_slug', slug: 'auth' })
+    expect(ofType('conference')).toHaveLength(0)
+  })
+
+  it('refuses a reserved slug even though the DATED label would be harmless', async () => {
+    // `admin-2027` is fine on its own, but the pair is all-or-nothing and
+    // `admin.konf.run` is not a tenant's to take.
+    const outcome = await provisionOrganization(
+      input({
+        organization: {
+          name: 'X',
+          slug: 'admin',
+          contactEmail: 'hello@cno.no',
+        },
+      }),
+    )
+    expect(outcome.ok).toBe(false)
+    expect(ofType('conference')).toHaveLength(0)
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// 2. THE MINTED HOST AND CALLER-SUPPLIED DOMAINS COEXIST
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('caller-supplied domains', () => {
+  it('keeps a custom domain AND mints both platform hosts, minted first', async () => {
+    const outcome = await provisionOrganization(
+      input({ domains: ['oslo.cloudnativedays.no'] }),
+    )
+    expect(outcome.ok).toBe(true)
+
+    expect(theConference().domains).toEqual([
+      ...MINTED,
+      'oslo.cloudnativedays.no',
+    ])
+  })
+
+  it('proves a custom domain by DNS while the minted host is allocated outright', async () => {
+    const outcome = await provisionOrganization(
+      input({ domains: ['oslo.cloudnativedays.no'] }),
+    )
+    expect(outcome.ok).toBe(true)
+
+    expect(verificationFor(BARE)).toMatchObject({
+      method: 'platform-owned',
+      status: 'verified',
+    })
+    // The custom domain gets NO free pass: pending, with a token to publish.
+    const custom = verificationFor('oslo.cloudnativedays.no')
+    expect(custom).toMatchObject({ method: 'dns-txt', status: 'pending' })
+    expect(typeof custom?.token).toBe('string')
+  })
+
+  it('deduplicates a caller that names a minted host itself', async () => {
+    const outcome = await provisionOrganization(input({ domains: [DATED] }))
+    expect(outcome.ok).toBe(true)
+
+    expect(theConference().domains).toEqual(MINTED)
+    expect(ofType('domainVerification')).toHaveLength(2)
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// 3. COLLISION — PERMANENT, SO REFUSED RATHER THAN WORKED AROUND
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('the minted host is already claimed', () => {
+  function claimedBySomeoneElse(entry: string) {
+    docs.set('conference-incumbent', {
+      _id: 'conference-incumbent',
+      _type: 'conference',
+      title: 'Incumbent',
+      domains: [entry],
+    })
+  }
+
+  it('writes NOTHING when another conference holds the exact host', async () => {
+    claimedBySomeoneElse(BARE)
+    const outcome = await provisionOrganization(input())
+
+    expect(outcome.ok).toBe(false)
+    // The guard that a permissive implementation cannot survive: no tenant.
+    expect(ofType('organization')).toHaveLength(0)
+    expect(ofType('conference')).toEqual([
+      expect.objectContaining({ _id: 'conference-incumbent' }),
+    ])
+    expect(ofType('speaker')).toHaveLength(0)
+    // …and the incumbent's claim is untouched.
+    expect(docs.get('conference-incumbent')?.domains).toEqual([BARE])
+  })
+
+  it('writes NOTHING when a WILDCARD over the zone would capture it', async () => {
+    claimedBySomeoneElse(`*.${SUFFIX}`)
+    const outcome = await provisionOrganization(input())
+
+    expect(outcome.ok).toBe(false)
+    expect(ofType('organization')).toHaveLength(0)
+    expect(ofType('conference')).toHaveLength(1)
+  })
+
+  it('names the collision distinctly from a domain the caller actually asked for', async () => {
+    claimedBySomeoneElse(BARE)
+    const outcome = await provisionOrganization(input())
+    expect(outcome.ok).toBe(false)
+    if (outcome.ok) return
+    // A caller that never mentioned this host must be able to tell "your slug's
+    // address is taken" from "a domain you sent is taken" — the remedies differ.
+    expect(outcome.rejection).toEqual({
+      code: 'platform_host_taken',
+      host: BARE,
+      slug: SLUG,
+    })
+  })
+
+  it('never mints a fallback label — the address always matches the slug', async () => {
+    claimedBySomeoneElse(BARE)
+    await provisionOrganization(input())
+    // No `-2`, no random suffix: NOTHING was claimed at all.
+    const claims = ofType('conference').flatMap(
+      (d) => (d.domains as string[] | undefined) ?? [],
+    )
+    expect(claims).toEqual([BARE])
+  })
+
+  it('REFUSES rather than transferring — a first edition never steals', async () => {
+    // The short address is transferable BETWEEN an org's own editions, but
+    // provisioning only ever creates an org's first, so any holder here is a
+    // foreign one and taking it would be a cross-tenant hijack.
+    claimedBySomeoneElse(BARE)
+    await provisionOrganization(input())
+    expect(docs.get('conference-incumbent')?.domains).toEqual([BARE])
+    expect(ofType('conference')).toHaveLength(1)
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// 4. NO ADDRESS DERIVABLE — REFUSE, NEVER COMMIT A GHOST TENANT
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('no address can be minted', () => {
+  it('refuses outright when the suffix is unset and no domain was supplied', async () => {
+    vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', '')
+    const outcome = await provisionOrganization(input())
+
+    expect(outcome.ok).toBe(false)
+    // The ghost tenant this whole change exists to prevent: an organization and
+    // a conference no host serves and no organizer can reach.
+    expect(ofType('organization')).toHaveLength(0)
+    expect(ofType('conference')).toHaveLength(0)
+    expect(ofType('speaker')).toHaveLength(0)
+    expect(ofType('domainVerification')).toHaveLength(0)
+  })
+
+  it('refuses without reading the content lake at all', async () => {
+    vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', '')
+    await provisionOrganization(input())
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses a slug DNS cannot carry (>63-character label) rather than minting a dead host', async () => {
+    vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', SUFFIX)
+    const slug = 'a'.repeat(64)
+    const outcome = await provisionOrganization(
+      input({
+        organization: {
+          name: 'Long',
+          slug,
+          contactEmail: 'hello@cno.no',
+        },
+      }),
+    )
+
+    expect(outcome.ok).toBe(false)
+    expect(ofType('conference')).toHaveLength(0)
+  })
+
+  it('still provisions with an UNSET suffix when the caller supplies a domain', async () => {
+    vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', '')
+    const outcome = await provisionOrganization(
+      input({ domains: ['oslo.cloudnativedays.no'] }),
+    )
+
+    expect(outcome.ok).toBe(true)
+    // A deployment that operates no zone of its own is unaffected: the tenant
+    // has an address, so there is nothing to refuse.
+    expect(theConference().domains).toEqual(['oslo.cloudnativedays.no'])
+    expect(verificationFor('oslo.cloudnativedays.no')).toMatchObject({
+      method: 'dns-txt',
+    })
+  })
+
+  it('mints nothing for a host outside the configured zone even under allocation', async () => {
+    // Re-pointing the suffix must not retro-grant a host we no longer own.
+    vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'elsewhere.example')
+    const outcome = await provisionOrganization(
+      input({ domains: ['oslo.cloudnativedays.no'] }),
+    )
+    expect(outcome.ok).toBe(true)
+
+    expect(theConference().domains).toEqual([
+      `${SLUG}.elsewhere.example`,
+      `${SLUG}-2027.elsewhere.example`,
+      'oslo.cloudnativedays.no',
+    ])
+    expect(verificationFor('oslo.cloudnativedays.no')).toMatchObject({
+      method: 'dns-txt',
+    })
+    expect(verificationFor(`${SLUG}-2027.elsewhere.example`)).toMatchObject({
+      method: 'platform-owned',
+    })
+    // The hosts under the OLD zone were never claimed, so nothing grants them.
+    expect(verificationFor(BARE)).toBeUndefined()
+    expect(verificationFor(DATED)).toBeUndefined()
+  })
+})

--- a/src/lib/onboarding/provision.ts
+++ b/src/lib/onboarding/provision.ts
@@ -8,10 +8,12 @@ import {
   domainEntriesOverlap,
 } from '@/lib/conference/domains'
 import {
+  derivePlatformHosts,
   getDomainVerification,
   syncDomainVerifications,
   toDomainVerificationView,
   type DomainVerificationView,
+  type PlatformHostRefusal,
 } from '@/lib/domain-verification'
 import {
   PROVISIONING_RECEIPT_RETENTION_DAYS,
@@ -33,6 +35,12 @@ import { buildOnboardingDocuments, type OnboardingInput } from './create'
  * That single-implementation rule is load-bearing: a second copy would fork the
  * per-field document enumeration in `buildOnboardingDocuments` (#752) and start
  * silently dropping new conference fields on whichever path was forgotten.
+ *
+ * ADDRESSING: the platform MINTS the new tenant's host — `<org-slug>.<suffix>`
+ * — and claims it in the same transaction ({@link planTenantDomains}). Without
+ * it a self-service tenant would exist at no address at all: resolution is by
+ * request `Host` against `conference.domains[]`, so a conference claiming
+ * nothing is served by nothing and its organizer cannot even reach /admin.
  *
  * SERVER-SIDE AUTHORITY (the wizard and the control panel only mirror these):
  *   - org slug must be globally unique among organizations;
@@ -106,6 +114,105 @@ export async function findConflictingDomains(
   )
 }
 
+/**
+ * The domains the new conference will actually CLAIM, and the platform hosts
+ * among them (empty, with a reason, when none could be minted).
+ *
+ * ## The derivation
+ *
+ * Both hosts from {@link derivePlatformHosts} — one rule, one implementation,
+ * shared with the matcher that decides what is inside the platform zone:
+ *
+ *   `acme.konf.run`       the SHORT address of the org's latest edition;
+ *   `acme-2026.konf.run`  this edition's permanent address.
+ *
+ * With no dates yet the two collapse into one host (that function explains why
+ * a guessed year is worse than none).
+ *
+ * ## The bare host is NOT transferred here — it cannot be
+ *
+ * The short address MOVES as newer editions appear, and a transfer has to
+ * release it from the previous holder in the same breath as claiming it. That
+ * case is unreachable on this path: provisioning creates an organization's
+ * FIRST edition and nothing else, because `isOrgSlugTaken` refuses a second
+ * provisioning under the same slug outright. So there is never an incumbent
+ * edition of this org, and the bare host is always claimed fresh. If some
+ * OTHER tenant somehow holds it, that is a collision and is refused below —
+ * never stolen. The transfer belongs to the edition-creation path;
+ * {@link shouldTakeLatestHost} is the shared rule for it.
+ *
+ * ## Coexisting with caller-supplied domains
+ *
+ * The minted hosts are PREPENDED to whatever the caller asked for rather than
+ * replacing it, and the two coexist deliberately:
+ *
+ *  - The operator wizard may pass a custom domain. That domain is CLAIMED but
+ *    unproven at creation (`pending`, no TXT published yet), so under
+ *    `DOMAIN_VERIFICATION_ENFORCE_ROUTING` it does not route and the tenant
+ *    would be unreachable for as long as DNS takes. The minted hosts work
+ *    immediately — they are inside a zone we already serve under a wildcard
+ *    certificate — so they are the addresses the organizer signs in on while
+ *    their own domain is still being proven. Nothing is dropped, and the bare
+ *    host goes FIRST so the short address is the primary one every surface
+ *    reads off `domains[0]`.
+ *  - The self-service API passes none, and gets exactly the minted pair.
+ *
+ * A caller that names a minted host explicitly is deduplicated, not
+ * double-claimed.
+ *
+ * ## Nothing derivable
+ *
+ * An empty result is the ONE state the caller must refuse: no suffix
+ * configured (or a slug DNS cannot carry) AND no caller-supplied domain means a
+ * tenant at no address whatsoever. Deployments that operate no platform zone
+ * keep working exactly as before as long as they pass a domain — the refusal is
+ * scoped to the case where there would be no host at all, not to an unset
+ * suffix per se.
+ *
+ * ## No fallback label, ever
+ *
+ * There is deliberately no `-2` suffixing when a minted host is already
+ * claimed. The claim is globally unique and PERMANENT, so an auto-suffixed
+ * address would (a) silently stop matching the slug and year every other
+ * surface derives it from, and (b) hand out an address nobody can predict. A
+ * collision is surfaced as a rejection naming the host; the remedy is a
+ * different org slug, chosen by whoever is provisioning.
+ *
+ * ## Minted once, never re-derived
+ *
+ * The org slug is editable from the control panel afterwards. That does NOT
+ * move these hosts: they are stored in `conference.domains[]` and in the
+ * `domainVerification` records, all keyed by the hostname itself, and nothing
+ * re-derives them at read time. A renamed org keeps the addresses it was issued
+ * — which is the point, since they are already in the wild.
+ */
+export function planTenantDomains(
+  orgSlug: string,
+  startDate: string | null | undefined,
+  requested: readonly string[],
+): {
+  domains: string[]
+  platformHosts: string[]
+  refusal: PlatformHostRefusal | null
+} {
+  const normalized = requested.map(normalizeDomain).filter((d) => d !== '')
+  const derived = derivePlatformHosts(orgSlug, startDate)
+  if (!derived.ok) {
+    return { domains: normalized, platformHosts: [], refusal: derived.reason }
+  }
+  // Bare first (the short, primary address), then the dated one — deduplicated,
+  // since an undated edition mints the same host twice.
+  const platformHosts = [...new Set([derived.hosts.bare, derived.hosts.dated])]
+  return {
+    domains: [
+      ...platformHosts,
+      ...normalized.filter((entry) => !platformHosts.includes(entry)),
+    ],
+    platformHosts,
+    refusal: null,
+  }
+}
+
 /** Whether an organization already claims this slug. */
 export async function isOrgSlugTaken(slug: string): Promise<boolean> {
   const count = await clientReadUncached.fetch<number>(
@@ -177,6 +284,16 @@ async function readReceipt(id: string): Promise<Receipt | null> {
 export type ProvisionRejection =
   | { code: 'slug_taken'; slug: string }
   | { code: 'domain_claimed'; domains: string[] }
+  /** The minted `<slug>-<year>.<suffix>` host is already claimed — the org slug
+   * is free but its address is not, so provisioning would strand the tenant. */
+  | { code: 'platform_host_taken'; host: string; slug: string }
+  /** The minted label is one the platform keeps for itself (`www`, `auth`, …).
+   * Refused whether or not the caller supplied other domains: the claim is
+   * permanent, so it must never be handed out by accident. */
+  | { code: 'reserved_slug'; slug: string }
+  /** No host could be minted AND the caller named none: the tenant would exist
+   * at no address. A deployment misconfiguration, refused rather than written. */
+  | { code: 'no_host_available'; slug: string }
   | { code: 'ambiguous_organizer' }
   | { code: 'commit_failed'; cause: unknown }
 
@@ -288,12 +405,39 @@ export async function provisionOrganization(
     }
   }
 
+  // The tenant's ADDRESSES, decided before anything is read or written: the
+  // minted `<slug>.<suffix>` + `<slug>-<year>.<suffix>` pair, plus whatever the
+  // caller asked for.
+  const { domains, platformHosts, refusal } = planTenantDomains(
+    input.organization.slug,
+    input.conference.startDate,
+    input.domains,
+  )
+  // A reserved label is refused even when the caller supplied its own domain:
+  // the point is not that this tenant lacks an address, it is that this slug
+  // must never be allowed to take one of the platform's own hostnames.
+  if (refusal === 'reserved') {
+    return {
+      ok: false,
+      rejection: { code: 'reserved_slug', slug: input.organization.slug },
+    }
+  }
+  if (domains.length === 0) {
+    // Refuse LOUDLY. Committing here is what produced the ghost tenants: an
+    // organization and a conference that no host serves and no organizer can
+    // reach, indistinguishable from a successful provision to the caller.
+    return {
+      ok: false,
+      rejection: { code: 'no_host_available', slug: input.organization.slug },
+    }
+  }
+
   const [slugTaken, taken, speakerMatches] = await Promise.all([
     isOrgSlugTaken(input.organization.slug),
-    // Overlap-aware (exact OR wildcard, both directions) and SKIPPED outright
-    // for a domainless tenant — that path must not depend on a global read it
-    // doesn't need.
-    findConflictingDomains(input.domains),
+    // Overlap-aware (exact OR wildcard, both directions), over the EFFECTIVE
+    // list — the minted host is a globally unique claim like any other and is
+    // checked as one.
+    findConflictingDomains(domains),
     findSpeakersByEmail(input.organizer.email),
   ])
 
@@ -301,6 +445,22 @@ export async function provisionOrganization(
     return {
       ok: false,
       rejection: { code: 'slug_taken', slug: input.organization.slug },
+    }
+  }
+  // Reported ahead of an ordinary domain conflict, and separately: the caller
+  // never asked for these hosts, so "already claimed" would be baffling. The
+  // actionable remedy is a different org slug. Note this is NOT a transfer
+  // opportunity — a claim on the org's own labels held by anyone else is a
+  // collision, and stealing it is exactly what must not happen.
+  const takenPlatformHost = platformHosts.find((host) => taken.includes(host))
+  if (takenPlatformHost !== undefined) {
+    return {
+      ok: false,
+      rejection: {
+        code: 'platform_host_taken',
+        host: takenPlatformHost,
+        slug: input.organization.slug,
+      },
     }
   }
   if (taken.length > 0) {
@@ -312,7 +472,7 @@ export async function provisionOrganization(
   const existingSpeaker = speakerMatches[0] ?? null
 
   const { organization, conference, speaker } = buildOnboardingDocuments(
-    input,
+    { ...input, domains },
     {
       organizationId: generateKey('organization'),
       conferenceId: generateKey('conference'),
@@ -351,7 +511,9 @@ export async function provisionOrganization(
         conferenceId: conference._id,
         speakerId,
         speakerCreated: speaker !== null,
-        domains: input.domains,
+        // The EFFECTIVE list, so a replay re-mints (and re-allocates) exactly
+        // the hosts this tenant was actually given.
+        domains,
         createdAt: new Date(now).toISOString(),
         expiresAt: new Date(
           now + PROVISIONING_RECEIPT_RETENTION_DAYS * 24 * 60 * 60 * 1000,
@@ -382,7 +544,7 @@ export async function provisionOrganization(
     return { ok: false, rejection: { code: 'commit_failed', cause: error } }
   }
 
-  const challenges = await mintChallenges(conference._id, input.domains)
+  const challenges = await mintChallenges(conference._id, domains)
 
   // A new conference document exists; bust the shared conferences tag so domain
   // resolution can see it once its domain actually routes here.

--- a/src/server/routers/conference.createEdition.test.ts
+++ b/src/server/routers/conference.createEdition.test.ts
@@ -20,6 +20,8 @@ const ORG_ID = 'org-test'
 const SOURCE_DOC = {
   _id: SOURCE_ID,
   title: 'Cloud Native Days Bergen 2025',
+  // The tenant the edition belongs to — platform hosts are minted from its slug.
+  organization: { _type: 'reference', _ref: ORG_ID },
   organizer: 'Cloud Native Bergen',
   city: 'Bergen',
   topics: [{ _type: 'reference', _ref: 'topic-a', _key: 'k1' }],
@@ -41,6 +43,8 @@ let claimedDomains: string[] = ['cloudnativebergen.no', '2025.cnb.no']
 const createSpy = vi.fn()
 const commitMock = vi.fn().mockResolvedValue({})
 const patchSpy = vi.fn()
+/** Patches STAGED IN THE TRANSACTION: `[conferenceId, unset-selectors]`. */
+const txPatchSpy = vi.fn()
 
 function makeTransaction() {
   const tx = {
@@ -48,14 +52,38 @@ function makeTransaction() {
       createSpy(doc)
       return tx
     },
+    patch: (id: string, fn: (p: unknown) => unknown) => {
+      const unsets: string[] = []
+      const builder = {
+        unset: (fields: string[]) => {
+          unsets.push(...fields)
+          return builder
+        },
+      }
+      fn(builder)
+      txPatchSpy(id, unsets)
+      return tx
+    },
     commit: () => commitMock(),
   }
   return tx
 }
 
+/** Conferences holding a platform host, for the transfer planner's read. */
+let platformHostHolders: Array<{
+  _id: string
+  organizationId: string | null
+  startDate: string | null
+  domains: string[]
+}> = []
+/** The source conference's organization slug, minted hosts derive from it. */
+let sourceOrgSlug: string | null = null
+
 const fetchMock = vi.fn(async (query: string) => {
   if (query.includes('_type == "sponsorTier"')) return SOURCE_TIERS
   if (query.includes('_type == "contractTemplate"')) return SOURCE_TEMPLATES
+  if (query.includes('organization->slug.current')) return sourceOrgSlug
+  if (query.includes('count(domains[@ in $hosts])')) return platformHostHolders
   if (query.includes('.domains[]')) return claimedDomains
   if (query.includes('_id == $id')) return SOURCE_DOC
   return null
@@ -85,13 +113,21 @@ const syncDomainVerificationsMock = vi.fn(async () => {})
 const findUnallocatedPlatformDomainsMock = vi.fn(
   async (): Promise<string[]> => [],
 )
-vi.mock('@/lib/domain-verification', () => ({
-  syncDomainVerifications: (...args: unknown[]) =>
-    syncDomainVerificationsMock(...(args as [])),
-  findUnallocatedPlatformDomains: () => findUnallocatedPlatformDomainsMock(),
-  PLATFORM_DOMAIN_NOT_ALLOCATED:
-    'That hostname belongs to the platform and has not been allocated to this conference',
-}))
+// The MINTING rules are the real thing — what host an edition gets and where
+// the short address points are properties under test, not stubs.
+vi.mock('@/lib/domain-verification', async () => {
+  const platform = await vi.importActual<
+    typeof import('@/lib/domain-verification/platform')
+  >('@/lib/domain-verification/platform')
+  return {
+    syncDomainVerifications: (...args: unknown[]) =>
+      syncDomainVerificationsMock(...(args as [])),
+    findUnallocatedPlatformDomains: () => findUnallocatedPlatformDomainsMock(),
+    derivePlatformHosts: platform.derivePlatformHosts,
+    shouldTakeLatestHost: platform.shouldTakeLatestHost,
+    PLATFORM_DOMAIN_NOT_ALLOCATED: platform.PLATFORM_DOMAIN_NOT_ALLOCATED,
+  }
+})
 
 import { conferenceRouter } from './conference'
 import { DOMAIN_ALREADY_CLAIMED } from '@/lib/conference/domains'
@@ -131,6 +167,8 @@ function input(overrides: Record<string, unknown> = {}) {
 beforeEach(() => {
   vi.clearAllMocks()
   claimedDomains = ['cloudnativebergen.no', '2025.cnb.no']
+  platformHostHolders = []
+  sourceOrgSlug = null
   commitMock.mockResolvedValue({})
   // The domain conference carries the org the authz waist gates on, so
   // `resolveOrganizationId()` yields ORG_ID for every request in this file.
@@ -275,5 +313,174 @@ describe('validateNewDomains', () => {
       domains: ['2026.cnb.no', '*.cndn.no', 'fresh.example.com'],
     })
     expect(res.taken).toEqual(['2026.cnb.no', '*.cndn.no'])
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// PLATFORM HOSTS: the permanent dated address, and the SHORT address that MOVES
+//
+// `domains[]` is a globally unique routing claim, so the short address cannot
+// sit on two editions and must not sit on none. Every assertion below is on the
+// documents that came out of the ONE transaction.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** The conference document the transaction was asked to create. */
+function createdConference() {
+  return createSpy.mock.calls
+    .map((c) => c[0])
+    .find((d: { _type?: string }) => d._type === 'conference') as {
+    domains?: string[]
+  }
+}
+
+describe('createEdition — platform hosts', () => {
+  beforeEach(() => {
+    vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
+    sourceOrgSlug = 'cnb'
+  })
+
+  it('claims the edition’s own permanent host and the short one', async () => {
+    await makeCaller({ isOrganizer: true }).createEdition(input())
+    expect(createdConference().domains).toEqual([
+      'cnb.konf.run',
+      'cnb-2026.konf.run',
+      '2026.cnb.no',
+    ])
+  })
+
+  it('TRANSFERS the short address off the previous edition, in the same transaction', async () => {
+    platformHostHolders = [
+      {
+        _id: 'conference-2025',
+        organizationId: ORG_ID,
+        startDate: '2025-06-01',
+        domains: ['cnb.konf.run', 'cnb-2025.konf.run'],
+      },
+    ]
+    claimedDomains = ['cnb.konf.run', 'cnb-2025.konf.run']
+
+    await makeCaller({ isOrganizer: true }).createEdition(input())
+
+    // Exactly one of the two halves is not enough: the new edition claims it…
+    expect(createdConference().domains).toContain('cnb.konf.run')
+    // …and the previous holder is released, in the SAME all-or-nothing
+    // transaction. Two separate writes could leave it on both (a routing
+    // collision) or on neither (an address that resolves nowhere).
+    expect(txPatchSpy).toHaveBeenCalledWith('conference-2025', [
+      'domains[@ == "cnb.konf.run"]',
+    ])
+    expect(commitMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves the previous edition’s PERMANENT host alone', async () => {
+    platformHostHolders = [
+      {
+        _id: 'conference-2025',
+        organizationId: ORG_ID,
+        startDate: '2025-06-01',
+        domains: ['cnb.konf.run', 'cnb-2025.konf.run'],
+      },
+    ]
+    claimedDomains = ['cnb.konf.run', 'cnb-2025.konf.run']
+
+    await makeCaller({ isOrganizer: true }).createEdition(input())
+
+    // Retirement depends on this: the dated host is what archive links use, and
+    // only the bare host is ever unset.
+    const unsets = txPatchSpy.mock.calls.flatMap(([, fields]) => fields)
+    expect(unsets).toEqual(['domains[@ == "cnb.konf.run"]'])
+    expect(createdConference().domains).not.toContain('cnb-2025.konf.run')
+  })
+
+  it('does NOT let a PAST-year edition steal the short address', async () => {
+    platformHostHolders = [
+      {
+        _id: 'conference-2026',
+        organizationId: ORG_ID,
+        startDate: '2026-06-01',
+        domains: ['cnb.konf.run', 'cnb-2026.konf.run'],
+      },
+    ]
+    claimedDomains = ['cnb.konf.run', 'cnb-2026.konf.run']
+
+    // Back-filling 2024 after 2026 exists.
+    await makeCaller({ isOrganizer: true }).createEdition(
+      input({
+        title: 'CNB 2024',
+        startDate: '2024-06-01',
+        endDate: '2024-06-02',
+        domains: ['2024.cnb.no'],
+      }),
+    )
+
+    // It gets its own permanent host and nothing else…
+    expect(createdConference().domains).toEqual([
+      'cnb-2024.konf.run',
+      '2024.cnb.no',
+    ])
+    // …and the 2026 edition is never patched, so the short address stays put.
+    expect(txPatchSpy).not.toHaveBeenCalled()
+  })
+
+  it('allocates every minted host to the NEW edition (#778 write-time grant)', async () => {
+    await makeCaller({ isOrganizer: true }).createEdition(input())
+    expect(syncDomainVerificationsMock).toHaveBeenCalledWith(
+      expect.any(String),
+      ['cnb.konf.run', 'cnb-2026.konf.run'],
+      [],
+      { allocatePlatformHosts: true },
+    )
+    // The organizer's OWN domains never ride the allocating call — a tenant
+    // must not be able to self-serve a grant on a typed hostname.
+    expect(syncDomainVerificationsMock).toHaveBeenCalledWith(
+      expect.any(String),
+      ['2026.cnb.no'],
+    )
+  })
+
+  it('REFUSES rather than stealing a host another organization holds', async () => {
+    platformHostHolders = [
+      {
+        _id: 'conference-foreign',
+        organizationId: 'org-someone-else',
+        startDate: '2020-01-01',
+        domains: ['cnb.konf.run'],
+      },
+    ]
+    claimedDomains = ['cnb.konf.run']
+
+    await expect(
+      makeCaller({ isOrganizer: true }).createEdition(input()),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    expect(createSpy).not.toHaveBeenCalled()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('REFUSES when the edition’s permanent host is already held', async () => {
+    // The dated host is permanent; a holder means it is not ours to take, and
+    // there is no transfer that could make it so.
+    platformHostHolders = [
+      {
+        _id: 'conference-other',
+        organizationId: ORG_ID,
+        startDate: '2026-06-01',
+        domains: ['cnb-2026.konf.run'],
+      },
+    ]
+    claimedDomains = ['cnb-2026.konf.run']
+
+    await expect(
+      makeCaller({ isOrganizer: true }).createEdition(input()),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('mints nothing, and still creates the edition, with no platform zone', async () => {
+    vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', '')
+    await makeCaller({ isOrganizer: true }).createEdition(input())
+    // A platform misconfiguration must not block an organizer from creating
+    // next year's conference — the edition always carries a domain of its own.
+    expect(createdConference().domains).toEqual(['2026.cnb.no'])
+    expect(commitMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/server/routers/conference.ts
+++ b/src/server/routers/conference.ts
@@ -35,6 +35,7 @@ import {
   PLATFORM_DOMAIN_NOT_ALLOCATED,
   syncDomainVerifications,
 } from '@/lib/domain-verification'
+import { planEditionPlatformHosts } from '@/lib/conference/platformEditionHosts'
 import {
   buildEditionDocuments,
   type SourceConference,
@@ -985,7 +986,7 @@ export const conferenceRouter = router({
     .mutation(async ({ input }) => {
       const sourceId = await resolveConferenceId()
 
-      const [source, sourceTiers, sourceTemplates, claimedDomains] =
+      const [source, sourceTiers, sourceTemplates, claimedDomains, orgSlug] =
         await Promise.all([
           clientReadUncached.fetch<SourceConference | null>(
             `*[_type == "conference" && _id == $id][0]`,
@@ -1000,6 +1001,13 @@ export const conferenceRouter = router({
             { id: sourceId },
           ),
           fetchClaimedDomains(),
+          // The org slug is what the platform hosts are minted FROM. Read from
+          // the source conference's organization ref — never from client input.
+          clientReadUncached.fetch<string | null>(
+            // groq-global-scoped: keyed by the SERVER-resolved source conference id (`resolveConferenceId`, from the request Host), exactly like the reads above it.
+            `*[_type == "conference" && _id == $id][0].organization->slug.current`,
+            { id: sourceId },
+          ),
         ])
 
       if (!source?._id) {
@@ -1038,6 +1046,23 @@ export const conferenceRouter = router({
         })
       }
 
+      // PLATFORM HOSTS FOR THE NEW EDITION: its own permanent
+      // `<org-slug>-<year>` address, plus the short `<org-slug>` address when
+      // this edition is genuinely the org's latest — which means TRANSFERRING
+      // that one off the edition currently holding it.
+      const hostPlan = await planEditionPlatformHosts({
+        orgSlug,
+        organizationId: source.organization?._ref ?? null,
+        startDate: input.startDate,
+        claimedDomains,
+      })
+      if (hostPlan.conflict !== null) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `${DOMAIN_ALREADY_CLAIMED}: ${hostPlan.conflict}`,
+        })
+      }
+
       const { conference, sponsorTiers, contractTemplates, summary } =
         buildEditionDocuments(
           {
@@ -1045,7 +1070,17 @@ export const conferenceRouter = router({
             sponsorTiers: sourceTiers ?? [],
             contractTemplates: sourceTemplates ?? [],
           },
-          input,
+          // The minted hosts lead, so the short address is the edition's
+          // primary one; the organizer's own domains follow, deduplicated.
+          {
+            ...input,
+            domains: [
+              ...hostPlan.claim,
+              ...input.domains.filter(
+                (entry) => !hostPlan.claim.includes(normalizeDomain(entry)),
+              ),
+            ],
+          },
           {
             newConferenceId,
             mintId: () => generateKey('doc'),
@@ -1057,6 +1092,17 @@ export const conferenceRouter = router({
         let tx = clientWrite.transaction().create(conference)
         for (const tier of sponsorTiers) tx = tx.create(tier)
         for (const tpl of contractTemplates) tx = tx.create(tpl)
+        // THE TRANSFER, in the SAME all-or-nothing transaction that claims it.
+        // `domains[]` is globally unique, so releasing and claiming cannot be
+        // two writes: one of them failing would leave the short address on
+        // both editions (a routing collision) or on neither (an address that
+        // resolves nowhere). Atomicity is what rules both out.
+        if (hostPlan.releaseFrom !== null && hostPlan.transferring !== null) {
+          const releasing = hostPlan.transferring
+          tx = tx.patch(hostPlan.releaseFrom, (p) =>
+            p.unset([`domains[@ == "${releasing}"]`]),
+          )
+        }
         await tx.commit()
       } catch (error) {
         throw new TRPCError({
@@ -1070,6 +1116,17 @@ export const conferenceRouter = router({
       // pending, never inherited from the source edition. Best-effort (#683):
       // the edition is already committed and a missing record fails closed.
       await syncDomainVerifications(newConferenceId, input.domains)
+      // The minted hosts are ALLOCATED (#778) — and only these, because they
+      // were derived server-side from the tenant's OWN org slug rather than
+      // typed. Anything the organizer types is still refused above by
+      // `findUnallocatedPlatformDomains`, so a tenant can never self-serve a
+      // grant on a label outside its own namespace. A transferred host is
+      // re-pointed to the new holder by the same call.
+      if (hostPlan.claim.length > 0) {
+        await syncDomainVerifications(newConferenceId, hostPlan.claim, [], {
+          allocatePlatformHosts: true,
+        })
+      }
 
       // New edition adds a conference document; bust the shared conferences tag
       // so domain resolution can see it once its domain actually resolves.

--- a/src/server/routers/onboarding.test.ts
+++ b/src/server/routers/onboarding.test.ts
@@ -83,15 +83,23 @@ vi.mock('@/lib/sanity/client', () => ({
 // Tenant creation claims domains, so it mints their ownership-verification
 // records and hands the operator the challenge to publish (#683).
 const syncDomainVerificationsMock = vi.fn(async () => {})
-vi.mock('@/lib/domain-verification', () => ({
-  syncDomainVerifications: (...args: unknown[]) =>
-    syncDomainVerificationsMock(...(args as [])),
-  getDomainVerification: async () => null,
-  toDomainVerificationView: (hostname: string) => ({ hostname }),
-  findUnallocatedPlatformDomains: async (): Promise<string[]> => [],
-  PLATFORM_DOMAIN_NOT_ALLOCATED:
-    'That hostname belongs to the platform and has not been allocated to this conference',
-}))
+// Record writing is faked; the ADDRESS DERIVATION is real, so what host the
+// wizard mints for a slug is actually exercised rather than stubbed.
+vi.mock('@/lib/domain-verification', async () => {
+  const platform = await vi.importActual<
+    typeof import('@/lib/domain-verification/platform')
+  >('@/lib/domain-verification/platform')
+  return {
+    syncDomainVerifications: (...args: unknown[]) =>
+      syncDomainVerificationsMock(...(args as [])),
+    getDomainVerification: async () => null,
+    toDomainVerificationView: (hostname: string) => ({ hostname }),
+    findUnallocatedPlatformDomains: async (): Promise<string[]> => [],
+    derivePlatformHosts: platform.derivePlatformHosts,
+    shouldTakeLatestHost: platform.shouldTakeLatestHost,
+    PLATFORM_DOMAIN_NOT_ALLOCATED: platform.PLATFORM_DOMAIN_NOT_ALLOCATED,
+  }
+})
 
 import {
   onboardingRouter,
@@ -151,6 +159,7 @@ beforeEach(() => {
 
 afterEach(() => {
   delete process.env.PLATFORM_ORG_SLUG
+  vi.unstubAllEnvs()
 })
 
 describe('createOrganization — authorization (platform waist)', () => {
@@ -250,13 +259,24 @@ describe('createOrganization — server-side uniqueness authority', () => {
     expect(commitMock).not.toHaveBeenCalled()
   })
 
-  it('skips the claimed-domains read entirely for a domainless tenant', async () => {
-    await makeCaller(operator).createOrganization(input({ domains: [] }))
-    expect(commitMock).toHaveBeenCalledTimes(1)
-    const domainQueries = fetchMock.mock.calls.filter(([q]) =>
-      (q as string).includes('.domains[]'),
-    )
-    expect(domainQueries).toEqual([])
+  it('refuses a tenant that would have NO address, before any read', async () => {
+    // No platform suffix configured and no domain typed: committing would
+    // create an organization and a conference that no host serves.
+    await expect(
+      makeCaller(operator).createOrganization(input({ domains: [] })),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    expect(createSpy).not.toHaveBeenCalled()
+    expect(commitMock).not.toHaveBeenCalled()
+    // Refused before the uniqueness reads — only the authz read happened.
+    const provisioningReads = fetchMock.mock.calls.filter(([q]) => {
+      const query = q as string
+      return (
+        query.includes('.domains[]') ||
+        query.includes('_type == "speaker"') ||
+        query.includes('count(')
+      )
+    })
+    expect(provisioningReads).toEqual([])
   })
 
   it('refuses an organizer email matching SEVERAL accounts (duplicates first)', async () => {
@@ -372,12 +392,51 @@ describe('createOrganization — atomic transaction', () => {
     expect(commitMock).toHaveBeenCalledTimes(1)
   })
 
-  it('accepts a tenant with NO domains and omits the field', async () => {
-    await makeCaller(operator).createOrganization(input({ domains: [] }))
+  it('mints both platform subdomains for a tenant the operator gave no domain', async () => {
+    // The SAME front-door contract as the machine API: an operator who types no
+    // domain still gets a reachable tenant, not a ghost one.
+    vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
+    const result = await makeCaller(operator).createOrganization(
+      input({ domains: [] }),
+    )
     const conf = createSpy.mock.calls
       .map((c) => c[0])
       .find((d) => d._type === 'conference')
-    expect(conf).not.toHaveProperty('domains')
+    expect(conf.domains).toEqual([
+      'cloud-native-oslo.konf.run',
+      'cloud-native-oslo-2027.konf.run',
+    ])
+    // …and it rides the platform's allocation call, so it comes out granted.
+    expect(syncDomainVerificationsMock).toHaveBeenCalledWith(
+      result.conferenceId,
+      ['cloud-native-oslo.konf.run', 'cloud-native-oslo-2027.konf.run'],
+      [],
+      { allocatePlatformHosts: true },
+    )
+  })
+
+  it('claims the minted hosts ALONGSIDE the domain the operator typed, minted first', async () => {
+    vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
+    await makeCaller(operator).createOrganization(input())
+    const conf = createSpy.mock.calls
+      .map((c) => c[0])
+      .find((d) => d._type === 'conference')
+    // The typed domain is CLAIMED but unproven, so it may not route yet; the
+    // minted host works immediately and is therefore the primary address.
+    expect(conf.domains).toEqual([
+      'cloud-native-oslo.konf.run',
+      'cloud-native-oslo-2027.konf.run',
+      'oslo.cloudnativedays.no',
+    ])
+  })
+
+  it('refuses when another conference already holds the minted address', async () => {
+    vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
+    claimedDomains = ['cloud-native-oslo.konf.run']
+    await expect(
+      makeCaller(operator).createOrganization(input({ domains: [] })),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    expect(commitMock).not.toHaveBeenCalled()
   })
 
   it('rejects a lone start date (dates travel as a pair) before any read', async () => {

--- a/src/server/routers/onboarding.ts
+++ b/src/server/routers/onboarding.ts
@@ -24,6 +24,19 @@ export const ORG_SLUG_ALREADY_TAKEN = 'Already used by another organization'
 export const AMBIGUOUS_ORGANIZER_EMAIL =
   'That email matches multiple speaker accounts — resolve the duplicates before onboarding this organizer'
 
+/** Prefix when the address minted from the org slug is already claimed. The
+ * slug itself is free, so the wizard must point at the ADDRESS, not the slug. */
+export const PLATFORM_HOST_ALREADY_CLAIMED =
+  'Another conference already claims the address this slug would get — choose a different slug'
+
+/** Message when no address at all could be given to the new tenant. */
+export const NO_TENANT_HOST_AVAILABLE =
+  'This deployment mints no tenant subdomains (PLATFORM_DOMAIN_SUFFIX is unset), so the tenant would have no address — add a domain below'
+
+/** Prefix when the slug would mint a hostname the platform keeps for itself. */
+export const RESERVED_ORG_SLUG =
+  'That slug is reserved by the platform — choose another'
+
 /**
  * PLATFORM-OPERATOR gate (onboarding S1). Layered on `protectedProcedure`
  * (authentication) exactly like `requireAdmin` layers the tenant waist — but
@@ -61,6 +74,24 @@ function toTRPCError(rejection: ProvisionRejection): TRPCError {
       return new TRPCError({
         code: 'BAD_REQUEST',
         message: `${DOMAIN_ALREADY_CLAIMED}: ${rejection.domains.join(', ')}`,
+      })
+    case 'platform_host_taken':
+      return new TRPCError({
+        code: 'BAD_REQUEST',
+        message: `${PLATFORM_HOST_ALREADY_CLAIMED}: ${rejection.host}`,
+      })
+    case 'reserved_slug':
+      return new TRPCError({
+        code: 'BAD_REQUEST',
+        message: `${RESERVED_ORG_SLUG}: ${rejection.slug}`,
+      })
+    case 'no_host_available':
+      // BAD_REQUEST rather than a 500: the operator can fix it from the form
+      // they are looking at by attaching a domain, which is not true of the
+      // machine caller (see the provisioning API's mapping).
+      return new TRPCError({
+        code: 'BAD_REQUEST',
+        message: NO_TENANT_HOST_AVAILABLE,
       })
     case 'ambiguous_organizer':
       return new TRPCError({


### PR DESCRIPTION
## The bug

`konf.run` is delegated to Vercel with a live `*.konf.run` wildcard, so any `<label>.konf.run` already resolves, routes and is covered by the certificate. But **nothing wrote that hostname.** kontroll sends `domains: []`, and tenant resolution is by request `Host` against `conference.domains[]` — so the self-service path produced an organization and a conference **that no host served and no admin could reach.** The operator wizard could pass domains by hand; the customer path could not.

## The derivation rule

Provisioning now mints the **edition's** addresses — two of them, both a **single label** under `PLATFORM_DOMAIN_SUFFIX`:

```
acme.konf.run         the SHORT address of the org's LATEST edition. It MOVES.
acme-2026.konf.run    this edition's PERMANENT address. It never moves.
```

Single-label is a hard constraint, not a style choice: `*.konf.run` and its alias already cover both, so this needs **no Vercel API calls and no per-tenant setup**. A nested form (`2026.acme.konf.run`) needs a per-org wildcard *and* an aliased deployment, and without that last step a visitor gets the CDN's own error page. `derivePlatformHosts` enforces it rather than assuming it — the label regex admits no dots and the final host is re-counted against the suffix — and a test asserts exactly one label above the suffix.

The year is the edition's `startDate`. The label names an edition because that is how conferences are already addressed in the wild (`2024.cloudnativebergen.dev`), and because a retired edition has to keep its URL when it is archived to a static site.

## Edge cases

**Unknown year.** `startDate` is optional, and the answer is the bare `<org-slug>` alone — *not* the current year. A year in a hostname is a factual claim, the host is permanent and unmigratable, and a customer signing up in December for next year's conference would be stuck with last year's address forever. Deferring the claim was rejected outright: that recreates the bug. The tenant is reachable either way.

**Two editions in one calendar year.** Ordered by actual `startDate`, so spring loses the short address to autumn. An exact same-day tie keeps the incumbent — a live address does not churn without evidence. Their *dated* hosts would collide, and that is reported as a conflict rather than silently double-claimed.

**Slug changes after provisioning.** Nothing happens, deliberately. The derivation runs **once**, at creation; the hosts live in `domains[]` and in the `domainVerification` records, both keyed by the hostname itself, and nothing re-derives them at read time. A renamed org keeps the addresses it was issued — they are already in the wild. Covered by a test that renames the org and asserts the claim and allocation are untouched.

**Reserved labels.** Added a denylist (`www`, `api`, `admin`, `auth`, `my`, `status`, `konf`, the RFC 2142 mailbox names, environment names). Checked on the **org slug**, i.e. the bare label, because that is the one the tenant would actually take; the pair is all-or-nothing, so a reserved slug is refused outright.

## Collision, and an unset suffix

**Collision → refuse, never work around.** No `-2` suffixing: the claim is globally unique and permanent, so an auto-suffixed address would stop matching the slug every other surface derives it from and would be unpredictable forever. A taken minted host is reported as `platform_host_taken` (naming the host) — distinct from `domain_claimed`, because the caller never asked for that host and the remedy is a different slug.

**Suffix unset.** Scoped refusal, not a blanket one. If the caller supplied a domain the tenant has an address and provisioning proceeds exactly as before — deployments operating no zone of their own are unaffected. If the caller supplied none (the self-service shape), it is refused: `no_host_available` → 500 `platform_domain_unconfigured` on the API (a platform misconfiguration the machine caller cannot fix, and retrying will not help), BAD_REQUEST on the wizard (the operator *can* fix it from the form by typing a domain). Committing here is exactly the ghost tenant this PR exists to prevent.

## The moving claim

The short address is a globally unique routing claim, so it cannot sit on two editions and must never sit on none. `createEdition` **transfers** it: released from the previous holder and claimed by the new one **in the same Sanity transaction**, which is all-or-nothing. Two separate writes have an interleaving that duplicates or loses the address; one transaction has none. A revision-guard was considered unnecessary because the transaction itself is the compare-and-swap.

`planEditionPlatformHosts` decides it: later start date wins, the dated host never moves (this is what makes retirement safe), and a holder in **another organization** is a conflict rather than a transfer — stealing a claim is worse than not having one.

**Provisioning never transfers**, and cannot: it creates an organization's *first* edition and nothing else, because `isOrgSlugTaken` refuses a second provisioning under the same slug. Any holder it encounters is therefore foreign, and it refuses.

## Allocation

Both hosts get their own `platform-owned` record naming the conference that holds it, on the same path that claims them — #778's write-time allocation model, unchanged. `createEdition` allocates only **server-derived** hosts (from the tenant's own globally unique org slug); anything an organizer *types* is still refused by `findUnallocatedPlatformDomains`, so a tenant can never express a claim outside its own namespace.

## Both front doors

The tRPC operator wizard and the bearer-authenticated API both call the one `provisionOrganization` transaction; only authentication differs, and that is left untouched. Both are asserted separately, and where the wizard passes explicit domains the minted hosts are **prepended**, not substituted: a typed domain is claimed but unproven at creation, so it may not route yet, while the minted hosts work immediately — they are the addresses the organizer signs in on while their own domain is being verified. `domains[0]` is the short minted host, which the hand-off screen now shows.

## Sabotage evidence

Every assertion is on observable state — which documents exist, what `domains[]` contains, what the verification record says and **which conference it names**. No test asserts on an error message. Baseline: **178 passed** across the seven affected suites.

| # | Sabotage | Result |
|---|---|---|
| a | Drop the minted hosts from the transaction (`{ ...input, domains: input.domains }`) | **15 failed** / 96 passed |
| b | Claim the hosts but skip the allocation (`allocatePlatformHosts: false`) | **11 failed** / 100 passed |
| c | Allocate the host to a different conference (`createReference('conference-somebody-else')`) | **3 failed** / 29 passed |
| d | Transfer claims but never releases → short address on **both** | **2 failed** / 20 passed |
| e | Transfer releases but never claims → short address on **neither** | **5 failed** / 30 passed |
| f | A past-year edition steals the short address (`shouldTakeLatestHost` → always true) | **5 failed** / 62 passed |

## Gates

`pnpm test` 6772 passed / 471 files · `pnpm typecheck` clean · `npx eslint .` **0 errors, 216 warnings (unchanged from `origin/main`)** · `npx prettier --check .` clean · `pnpm knip` clean.

`pnpm build` **fails on `origin/main` too** — `Failed to collect page data for /api/cron/contract-reminders`, from a dynamic `path.join` Turbopack rejects in `src/lib/system-status/checks.ts`. Verified identical on a clean `origin/main` worktree, so it is pre-existing and unrelated to this change.

## Visual check

`pnpm shoot systems-admin-platform-onboarding-wizard--done` — the hand-off screen now shows the minted short address as the tenant's address ("reachable now … with no DNS to set up"), and the minted hosts correctly carry no TXT challenge while the operator's custom domain still does. The story's mock was updated to the shape the server actually returns now.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Provisioning now derives and allocates short and edition-specific platform subdomains, while edition creation can transfer the short hostname to a newer edition.
- Adds platform-host derivation, reserved-label handling, collision reporting, and provisioning refusal when no address is available.
- Extends both provisioning front doors and the onboarding hand-off UI to expose immediately routable platform addresses.
- Adds edition-transfer planning and associated domain-verification allocation.
- Adds extensive integration and unit coverage plus updated provisioning/domain documentation.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until short-host transfer concurrency and post-commit allocation failure are handled so a successful edition creation cannot duplicate or orphan the tenant address.

The new transfer path makes a globally unique routing decision from an unguarded snapshot and commits the claim separately from a best-effort allocation update, allowing either multiple winners or an unroutable transferred hostname.

**Files Needing Attention:** src/server/routers/conference.ts, src/lib/conference/platformEditionHosts.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/domain-verification/platform.ts | Adds deterministic single-label platform-host derivation, reserved-label refusal, and latest-edition date comparison. |
| src/lib/onboarding/provision.ts | Prepends derived platform hosts during provisioning, checks collisions, and allocates them with the tenant transaction flow. |
| src/lib/conference/platformEditionHosts.ts | Plans short-host transfers and permanent dated claims, but its decision is based on a pre-transaction holder snapshot. |
| src/server/routers/conference.ts | Implements edition host transfer and allocation, but concurrent transfers can produce duplicate claims and post-commit allocation failure can orphan the short address. |
| src/app/api/provisioning/organizations/route.ts | Maps new platform-host conflicts and missing-platform-domain configuration to explicit API responses. |
| src/server/routers/onboarding.ts | Maps provisioning host refusals into actionable operator-facing tRPC errors. |
| src/components/admin/onboarding/OnboardingWizard.tsx | Uses the server-returned primary challenge to show the tenant's immediately available admin address. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Admin
  participant Router as createEdition
  participant Sanity
  participant Verify as Domain verification
  Admin->>Router: Create newer edition
  Router->>Sanity: Read current short-host holder
  Sanity-->>Router: Incumbent edition
  Router->>Sanity: Transaction: create edition + release incumbent
  Sanity-->>Router: Commit succeeds
  Router->>Verify: Allocate minted hosts to new edition
  Verify-->>Router: Best-effort completion
  Router-->>Admin: New edition result
```

<sub>Reviews (1): Last reviewed commit: ["feat(provisioning): mint and allocate th..."](https://github.com/cloudnativebergen/website/commit/0ab8f3cd23dfbde797102a33bc532a9e5c2ab18e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50231080)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Conference Core: Editions, Settings & AI Agent Config](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/conference-core.md)

<!-- /greptile_comment -->