### PR TITLE
feat(cache): external invalidation endpoint for kontroll, and one slug resolver

### DIFF
--- a/__tests__/api/trpc/workshop.test.ts
+++ b/__tests__/api/trpc/workshop.test.ts
@@ -56,6 +56,22 @@ vi.mock('@/lib/organization/sanity', () => ({
   getOrganizationRefForCurrentConference: vi.fn(async () => 'org-test'),
 }))
 
+/**
+ * The UNCACHED slug→id read behind `PLATFORM_ORG_SLUG` (RunKonf/platform#36).
+ * The platform-org grant is an ID comparison against this LIVE read, never the
+ * cached org document's `slug` — mocked at the Sanity boundary so the real
+ * `isPlatformOrganization` runs, and set per test so a case has to OPT IN to
+ * being the platform org.
+ */
+const live = vi.hoisted(() => ({ platformOrgId: null as string | null }))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: {
+    fetch: async (_query: string, params?: Record<string, unknown>) =>
+      typeof params?.slug === 'string' ? live.platformOrgId : null,
+  },
+}))
+
 vi.mock('@/lib/email/workshop', () => ({
   sendBasicWorkshopConfirmation: vi.fn(async () => {}),
 }))
@@ -125,8 +141,10 @@ const baseSignupInput = {
 
 beforeEach(() => {
   vi.clearAllMocks()
-  // Names the org above as the platform org, which is what grants `workshops`.
+  // Names the org above as the platform org, which is what grants `workshops`:
+  // the env contract, AND the live slug→id resolution it is compared through.
   vi.stubEnv('PLATFORM_ORG_SLUG', 'platform-org')
+  live.platformOrgId = 'org-test'
 })
 
 afterEach(() => {

--- a/__tests__/api/webhooks/checkin-ticket-sold.test.ts
+++ b/__tests__/api/webhooks/checkin-ticket-sold.test.ts
@@ -34,6 +34,22 @@ vi.mock('@/lib/organization/sanity', () => ({
   getOrganizationRefForCurrentConference: () => null,
 }))
 
+/**
+ * The UNCACHED slug→id read behind `PLATFORM_ORG_SLUG` (RunKonf/platform#36).
+ * The platform-org grant is an ID comparison against this LIVE read, never the
+ * cached org document's `slug` — mocked at the Sanity boundary so the real
+ * `isPlatformOrganization` runs, and set per test so a case has to OPT IN to
+ * being the platform org.
+ */
+const live = vi.hoisted(() => ({ platformOrgId: null as string | null }))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: {
+    fetch: async (_query: string, params?: Record<string, unknown>) =>
+      typeof params?.slug === 'string' ? live.platformOrgId : null,
+  },
+}))
+
 const SECRET = 'checkin-webhook-test-secret'
 const PLATFORM_SLUG = 'platform-org'
 
@@ -122,6 +138,7 @@ describe('api/webhooks/checkin/ticket-sold — HMAC signature', () => {
     // Default: the conference belongs to the platform org, which keeps the
     // workshop feature (the behaviour these signature tests predate).
     vi.stubEnv('PLATFORM_ORG_SLUG', PLATFORM_SLUG)
+    live.platformOrgId = 'org-platform'
     mockGetOrganizationById.mockResolvedValue({
       _id: 'org-platform',
       name: 'Platform',
@@ -269,6 +286,7 @@ describe('api/webhooks/checkin/ticket-sold — workshop feature gate', () => {
     vi.clearAllMocks()
     process.env.CHECKIN_WEBHOOK_SECRET = SECRET
     vi.stubEnv('PLATFORM_ORG_SLUG', PLATFORM_SLUG)
+    live.platformOrgId = null
     mockSendWorkshop.mockResolvedValue({
       data: { emailId: 'em-1' },
       error: null,
@@ -338,6 +356,7 @@ describe('api/webhooks/checkin/ticket-sold — workshop feature gate', () => {
   })
 
   it('DOES email for the platform org — today’s behaviour is unchanged', async () => {
+    live.platformOrgId = 'org-platform'
     mockGetConference.mockResolvedValue({
       conference: conferenceOwnedBy('org-platform'),
       error: null,

--- a/__tests__/app/admin/workshops-gate.test.tsx
+++ b/__tests__/app/admin/workshops-gate.test.tsx
@@ -38,12 +38,29 @@ vi.mock('@/lib/workshop/sanity', () => ({
   getWorkshopsByConference: (...args: unknown[]) => mockGetWorkshops(...args),
 }))
 
+/**
+ * The UNCACHED slug→id read behind `PLATFORM_ORG_SLUG` (RunKonf/platform#36).
+ * The platform-org grant is an ID comparison against this LIVE read, never the
+ * cached org document's `slug` — mocked at the Sanity boundary so the real
+ * `isPlatformOrganization` runs, and set per test so a case has to OPT IN to
+ * being the platform org.
+ */
+const live = vi.hoisted(() => ({ platformOrgId: null as string | null }))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: {
+    fetch: async (_query: string, params?: Record<string, unknown>) =>
+      typeof params?.slug === 'string' ? live.platformOrgId : null,
+  },
+}))
+
 import WorkshopAdminPage from '@/app/(admin)/admin/workshops/page'
 
 const PLATFORM_SLUG = 'platform-org'
 
 beforeEach(() => {
   vi.clearAllMocks()
+  live.platformOrgId = null
   vi.stubEnv('PLATFORM_ORG_SLUG', PLATFORM_SLUG)
   mockGetWorkshops.mockResolvedValue([])
   mockGetConference.mockResolvedValue({
@@ -83,6 +100,7 @@ describe('/admin/workshops — feature gate', () => {
   })
 
   it('renders for the platform org — today’s behaviour is unchanged', async () => {
+    live.platformOrgId = 'org-A'
     mockGetOrganizationById.mockResolvedValue({
       _id: 'org-A',
       name: 'Platform',

--- a/__tests__/app/workshop/portal-gate.test.tsx
+++ b/__tests__/app/workshop/portal-gate.test.tsx
@@ -37,6 +37,22 @@ vi.mock('@/lib/organization/sanity', () => ({
   getOrganizationRefForCurrentConference: () => null,
 }))
 
+/**
+ * The UNCACHED slug→id read behind `PLATFORM_ORG_SLUG` (RunKonf/platform#36).
+ * The platform-org grant is an ID comparison against this LIVE read, never the
+ * cached org document's `slug` — mocked at the Sanity boundary so the real
+ * `isPlatformOrganization` runs, and set per test so a case has to OPT IN to
+ * being the platform org.
+ */
+const live = vi.hoisted(() => ({ platformOrgId: null as string | null }))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: {
+    fetch: async (_query: string, params?: Record<string, unknown>) =>
+      typeof params?.slug === 'string' ? live.platformOrgId : null,
+  },
+}))
+
 vi.mock('@workos-inc/authkit-nextjs', () => ({
   withAuth: (...args: unknown[]) => mockWithAuth(...args),
 }))
@@ -75,6 +91,7 @@ async function is404(render: () => Promise<unknown>): Promise<boolean> {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  live.platformOrgId = null
   vi.stubEnv('PLATFORM_ORG_SLUG', PLATFORM_SLUG)
   mockWithAuth.mockResolvedValue({ user: null })
 })
@@ -132,6 +149,7 @@ describe('workshop portal — unresolvable org fails CLOSED', () => {
 
 describe('workshop portal — feature ON (platform org)', () => {
   beforeEach(() => {
+    live.platformOrgId = 'org-platform'
     mockGetConference.mockResolvedValue({
       conference: conference('org-platform'),
       error: null,

--- a/docs/PROVISIONING_API.md
+++ b/docs/PROVISIONING_API.md
@@ -2,6 +2,8 @@
 
 `POST /api/provisioning/organizations` creates a tenant — one `organization`, its first `conference`, and the first organizer's membership — for a caller that is **not a signed-in platform operator**. It exists for `RunKonf/kontroll` (the control panel at my.konf.app), which is a separate application with no Konf session.
 
+The same caller also **writes** `organization` documents directly, with its own Sanity token, and must be able to bust this app's caches afterwards. That is `POST /api/provisioning/cache/invalidate` — same bearer secret, documented at the end of this file.
+
 ## One transaction, two front doors
 
 There is exactly **one** tenant-creation implementation: `provisionOrganization()` in `src/lib/onboarding/provision.ts`.
@@ -141,3 +143,75 @@ Nothing about the caller's key is stored — only its salted hash, which is alre
 ## Residual risk
 
 Global slug and domain uniqueness are still enforced by a read-then-write check inside the transaction's preamble, not by a database constraint (Sanity has none). Two requests with **different** idempotency keys racing on the **same** slug can therefore both pass the check. The idempotency receipt does not close this — it is keyed on the request, not the slug. In practice the wizard and the control panel both preflight, and the window is milliseconds; closing it properly means deriving the organization's `_id` from its slug so Sanity's create-CAS enforces uniqueness, which is a follow-up.
+
+---
+
+# Cache Invalidation API
+
+`POST /api/provisioning/cache/invalidate` lets kontroll bust this app's caches after it has written a document. Tracked as RunKonf/platform#36.
+
+## Why it exists
+
+Two applications write the same Sanity dataset, and only one of them could invalidate the other's cache. `getOrganizationById` (`src/lib/organization/sanity.ts`) is `'use cache'` with `cacheLife('hours')` — revalidate 1h, **expire 24h** — over `name`, `slug` and `contactEmail`: exactly the fields kontroll writes when an organizer edits organization settings. The only `revalidateTag(organizationTag(...))` in this repo was a platform-operator tRPC mutation kontroll cannot reach.
+
+So an organizer edited their organization in kontroll, saw a success message, and their conference site kept serving the old values for up to a day. Both applications behaved exactly as written, which is what made it miserable to diagnose.
+
+## Request
+
+```http
+POST /api/provisioning/cache/invalidate
+Authorization: Bearer <PROVISIONING_API_TOKEN>
+Content-Type: application/json
+```
+
+```json
+{
+  "targets": [
+    { "type": "organization", "id": "<organization _id>" },
+    { "type": "conference", "id": "<conference _id>" },
+    { "type": "domain", "domain": "oslo.example.com" }
+  ]
+}
+```
+
+- **1 to 20 targets** per call (`MAX_INVALIDATION_TARGETS`).
+- The caller names a **document**, never a tag. Which cache tag that implies is this app's decision, so the tag structure stays ours to change — and the broad `content:*` tags (which bust every tenant at once) are not in the vocabulary and cannot be reached.
+- Ids are validated by **shape only** (`[A-Za-z0-9._-]{1,200}`); hostnames are lowercased and validated with the same helper the `domains[]` editor uses, so the computed tag is byte-identical to the one the cached read registered.
+- **No `Idempotency-Key`.** Invalidation is naturally idempotent — revalidating a tag twice is indistinguishable from once — so a key would add a required header and a stored receipt to protect nothing.
+
+## Responses
+
+| Status | Body                                          | Meaning                                                                   |
+| ------ | --------------------------------------------- | ------------------------------------------------------------------------- |
+| `200`  | `{ invalidated: number, tags: string[] }`     | Every named target was revalidated. `tags` echoes the caller's own input. |
+| `400`  | `{ error: "invalid_request", code, issues? }` | `invalid_json` or `schema_validation_failed` (with per-field `issues`).   |
+| `401`  | `{ error: "unauthorized" }`                   | Any authentication failure. Uniform and detail-free.                      |
+| `429`  | `{ error: "rate_limited" }` + `Retry-After`   | Over a cap, or the limiter could not persist a hit.                       |
+| `500`  | `{ error: "internal_error" }`                 | Nothing was revalidated.                                                  |
+
+**Invalidating something that does not exist is a no-op, not an error.** Nothing in this path reads Sanity: a tag is a pure function of the caller's input, so an unknown id revalidates a tag nothing is stored under and gets the same `200` as a real hit. There is no lookup, and therefore no existence oracle.
+
+## Why it shares `PROVISIONING_API_TOKEN`
+
+Same caller, same trust boundary, same rotation — and this endpoint is **strictly less powerful** than what that secret already grants. A holder can mint organizations, claim domains (which is also an OAuth redirect grant) and attach organizers; busting a cache entry is a subset of that blast radius. A second secret would protect nothing an attacker with the first one could not already do, while adding a rotation surface and one more environment variable to forget in a new environment — and a forgotten one fails closed, which for this endpoint means silent staleness.
+
+If a caller ever legitimately needs invalidation **without** provisioning, split it then: `authenticateProvisioningRequest` is a pure function of the request headers and takes a different env name in one edit.
+
+## Bounds — it must not become a stampede primitive
+
+Two limits, both on the same durable, Sanity-backed limiter as provisioning but on **their own buckets**, so frequent invalidation traffic can never crowd out the rare, far more dangerous tenant-creation call:
+
+- `invalidate-attempt`, bucketed by client IP, charged **before** the token is compared — 60/min, 600/hour, 3000/day. The bound on brute-forcing the secret.
+- `invalidate`, a **single global** bucket, charged after authentication and after validation — 60/min, 600/hour, 5000/day. Not keyed on anything the caller can rotate, because `x-forwarded-for` is caller-controlled.
+
+Together with the 20-target cap that is at most **1200 tag revalidations a minute, platform-wide**, no matter what is sent. Without both halves, a holder of the secret could drop every tenant's cached reads in a loop and turn the site into an uncached passthrough to Sanity.
+
+Both fail **closed** on a limiter outage. When the limit does trip the cost is bounded and self-healing: the caller gets a `429`, and the entry it wanted to bust still revalidates on its own within the hour.
+
+## What it is NOT for: authorization
+
+`org.slug` is an authorization input — `PLATFORM_ORG_SLUG` names the organization whose organizers are platform operators — and it used to be derived two ways with different staleness: uncached in `getPlatformOrgId()`, and off the **cached** org document in the workshops gate and the platform router's gate. Production has one organization that is both the platform org and a tenant, so an admin editing its slug in kontroll lost operator standing instantly on one path while the workshop portal — which emails attendees — stayed live on the revoked grant for up to 24 hours.
+
+That is now **one resolver**: `getPlatformOrgId()` (`src/lib/authz/platform.ts`), uncached, and every caller compares ids against it. Deliberately **not** solved by having kontroll invalidate a tag: a revocation that waits on a caller remembering to call an endpoint is not a revocation. This endpoint exists for content, not for grants.
+
+The cost is one extra `_id`-only Sanity lookup per gate evaluation, not deduplicated within a request. If that ever shows up in latency the fix is request-scoped memoization (React `cache()`), which removes the duplicate fetch without reintroducing cross-request staleness — never a `'use cache'` entry.

--- a/docs/PROVISIONING_API.md
+++ b/docs/PROVISIONING_API.md
@@ -187,7 +187,9 @@ Content-Type: application/json
 | `400`  | `{ error: "invalid_request", code, issues? }` | `invalid_json` or `schema_validation_failed` (with per-field `issues`).   |
 | `401`  | `{ error: "unauthorized" }`                   | Any authentication failure. Uniform and detail-free.                      |
 | `429`  | `{ error: "rate_limited" }` + `Retry-After`   | Over a cap, or the limiter could not persist a hit.                       |
-| `500`  | `{ error: "internal_error" }`                 | Nothing was revalidated.                                                  |
+| `500`  | `{ error: "internal_error" }`                 | Unexpected failure. Some targets may already have been revalidated.       |
+
+**A `500` is not "nothing happened" — it is "retry the whole batch".** Tags are revalidated one at a time, so a failure part-way through leaves the earlier targets already busted. That is safe to ignore and safe to repeat: revalidating a tag twice is indistinguishable from once, which is the same property that makes this endpoint idempotent and keyless. There is no partial-success body to inspect, and none is needed — resend the identical `targets` array.
 
 **Invalidating something that does not exist is a no-op, not an error.** Nothing in this path reads Sanity: a tag is a pure function of the caller's input, so an unknown id revalidates a tag nothing is stored under and gets the same `200` as a real hit. There is no lookup, and therefore no existence oracle.
 

--- a/sanity/schemaTypes/provisioningRateLimit.ts
+++ b/sanity/schemaTypes/provisioningRateLimit.ts
@@ -1,7 +1,8 @@
 import { defineType, defineField } from 'sanity'
 
 /**
- * RATE-LIMIT COUNTER for the machine provisioning API (#753).
+ * RATE-LIMIT COUNTER for the machine API RunKonf/kontroll calls (#753,
+ * RunKonf/platform#36).
  *
  * Same shape and same mechanics as `emailSignInRateLimit` — both ride the one
  * bucket primitive in `src/lib/rate-limit/bucket.ts` — kept as a separate type
@@ -9,12 +10,19 @@ import { defineType, defineField } from 'sanity'
  * interfere: a sign-in burst must not consume the budget that bounds tenant
  * creation.
  *
- * Two scopes:
- *  - `attempt` — one bucket per client IP, charged BEFORE the bearer token is
- *    checked. This is the bound on brute-forcing the shared secret.
+ * Four scopes, one pre-auth/post-auth pair per endpoint. They share this
+ * document TYPE (and therefore its cleanup cron) but never a bucket: the scope
+ * is part of the id digest, so invalidation traffic cannot crowd out
+ * provisioning.
+ *  - `attempt` / `invalidate-attempt` — one bucket per client IP, charged
+ *    BEFORE the bearer token is checked. This is the bound on brute-forcing the
+ *    shared secret.
  *  - `create` — a SINGLE global bucket, charged after authentication. This is
  *    the bound on bulk tenant minting if the secret ever leaks, and it is
  *    deliberately not keyed on anything a caller can rotate.
+ *  - `invalidate` — likewise global and post-authentication: with the per-call
+ *    target cap it is what stops a leaked secret from being used to drop every
+ *    tenant's cached reads in a loop.
  *
  * NO PII AT REST: the subject is never stored — only its salted hash, which is
  * already the document id.
@@ -32,7 +40,9 @@ export default defineType({
       type: 'string',
       title: 'Scope',
       description: 'Which counter family this bucket belongs to.',
-      options: { list: ['attempt', 'create'] },
+      options: {
+        list: ['attempt', 'create', 'invalidate-attempt', 'invalidate'],
+      },
       readOnly: true,
     }),
     defineField({

--- a/src/app/api/provisioning/cache/invalidate/coherence.test.ts
+++ b/src/app/api/provisioning/cache/invalidate/coherence.test.ts
@@ -1,0 +1,324 @@
+/**
+ * @vitest-environment node
+ *
+ * CACHE COHERENCE (RunKonf/platform#36) — the end-to-end property, proved as
+ * far as it can honestly be proved in a unit test:
+ *
+ *   read (cached) → external write → invalidate → read returns the NEW value.
+ *
+ * ── WHAT IS REAL AND WHAT IS NOT ───────────────────────────────────────────
+ *
+ * `'use cache'` is a COMPILER DIRECTIVE. Under vitest nothing transforms it, so
+ * `getOrganizationById` does not memoize here and Next's cache handler does not
+ * exist: a test that merely called it twice would prove nothing at all, and one
+ * that claimed to be exercising Next's cache would be a lie.
+ *
+ * So the memoization is EMULATED — `readThroughEmulatedCache` below is a tag-keyed
+ * entry map that stands in for Next's — and everything the emulator is a stand
+ * in FOR is stated plainly:
+ *
+ *   REAL   the `getOrganizationById` body, including the exact `cacheTag(...)`
+ *          calls it registers (captured through the mocked `next/cache`);
+ *   REAL   the route handler, its authentication, its target vocabulary, and
+ *          the exact tag strings it hands to `revalidateTag`;
+ *   FAKE   the storage and eviction between them.
+ *
+ * The property that can actually break — and the one that broke in production —
+ * is whether those two tag strings are THE SAME STRING. A read that tags
+ * `sanity:organization-X` and an invalidation that revalidates anything else
+ * is a silent no-op, and no amount of correct plumbing on either side detects
+ * it. That is what this file pins: the eviction below keys on nothing but tag
+ * equality, so a mismatch anywhere in the chain leaves the stale value in place
+ * and every assertion here fails.
+ *
+ * What it does NOT prove: that Next's own cache handler honours a tag it has
+ * been given. That is Next's contract, not ours, and it is not testable from
+ * here.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+/** The emulated cache, reachable from the mocked `next/cache` (hoisted). */
+const cache = vi.hoisted(() => {
+  const entries = new Map<string, { value: unknown; tags: string[] }>()
+  /** Tags registered by the read currently executing, if any. */
+  let collecting: string[] | null = null
+  return {
+    entries,
+    collect(tag: string) {
+      collecting?.push(tag)
+    },
+    /** Drop every entry carrying `tag` — what `revalidateTag` means to us. */
+    evict(tag: string) {
+      for (const [key, entry] of entries) {
+        if (entry.tags.includes(tag)) entries.delete(key)
+      }
+    },
+    begin(tags: string[]) {
+      collecting = tags
+    },
+    end() {
+      collecting = null
+    },
+    reset() {
+      entries.clear()
+      collecting = null
+    },
+  }
+})
+
+const revalidateTagSpy = vi.hoisted(() => vi.fn())
+
+vi.mock('next/cache', () => ({
+  unstable_noStore: () => {},
+  cacheLife: () => {},
+  cacheTag: (tag: string) => cache.collect(tag),
+  revalidateTag: (tag: string, profile?: string) => {
+    revalidateTagSpy(tag, profile)
+    cache.evict(tag)
+  },
+}))
+
+/** The content lake, as kontroll leaves it. */
+const orgDocs = new Map<string, Record<string, unknown>>()
+/** How many times the org projection actually hit Sanity. */
+let orgFetches = 0
+
+interface Doc extends Record<string, unknown> {
+  _id: string
+  _type: string
+  _rev?: string
+}
+
+/** Rate-limit buckets — the route charges two on every call. */
+const buckets = new Map<string, Doc>()
+let revCounter = 0
+
+function standalonePatch(id: string) {
+  let updates: Record<string, unknown> = {}
+  const chain = {
+    ifRevisionId() {
+      return chain
+    },
+    set(values: Record<string, unknown>) {
+      updates = { ...updates, ...values }
+      return chain
+    },
+    async commit() {
+      const doc = buckets.get(id)
+      if (doc)
+        buckets.set(id, { ...doc, ...updates, _rev: `rev-${++revCounter}` })
+    },
+  }
+  return chain
+}
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: {
+    fetch: async (query: string, params: Record<string, unknown> = {}) => {
+      if (query.includes('_type == $type && _id == $id')) {
+        return buckets.get(params.id as string) ?? null
+      }
+      if (query.includes('_type == "organization"')) {
+        orgFetches++
+        return orgDocs.get(params.orgId as string) ?? null
+      }
+      throw new Error(`Unexpected query: ${query}`)
+    },
+  },
+  clientReadCached: { fetch: vi.fn() },
+  clientWrite: {
+    create: async (doc: Doc) => {
+      buckets.set(doc._id, { ...doc, _rev: `rev-${++revCounter}` })
+      return doc
+    },
+    patch: (id: string) => standalonePatch(id),
+    delete: async () => ({ results: [] }),
+  },
+}))
+
+import { getOrganizationById } from '@/lib/organization/sanity'
+import { POST } from './route'
+
+/**
+ * Stand-in for Next's `'use cache'`: memoize on the argument, remember whatever
+ * tags the body registered, and serve from the entry until one of those tags is
+ * revalidated. Deliberately dumb — the only thing it knows how to do is compare
+ * tag strings.
+ */
+async function readThroughEmulatedCache<T>(
+  key: string,
+  body: () => Promise<T>,
+): Promise<T> {
+  const hit = cache.entries.get(key)
+  if (hit) return hit.value as T
+
+  const tags: string[] = []
+  cache.begin(tags)
+  let value: T
+  try {
+    value = await body()
+  } finally {
+    cache.end()
+  }
+  cache.entries.set(key, { value, tags })
+  return value
+}
+
+/** One cached read of the organization, exactly as a page would do it. */
+function readOrganization(orgId: string) {
+  return readThroughEmulatedCache(`org:${orgId}`, () =>
+    getOrganizationById(orgId),
+  )
+}
+
+const ENDPOINT = 'https://konf.app/api/provisioning/cache/invalidate'
+const TOKEN = 'prov_live_5f3c1a9e77b4d206c8ae13f0b95d7e42'
+
+function invalidate(targets: Array<Record<string, unknown>>) {
+  return POST(
+    new Request(ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${TOKEN}`,
+        'x-forwarded-for': '203.0.113.7',
+      },
+      body: JSON.stringify({ targets }),
+    }) as unknown as Parameters<typeof POST>[0],
+  )
+}
+
+/** What kontroll does with its own token, entirely outside this app. */
+function kontrollWrites(orgId: string, patch: Record<string, unknown>): void {
+  orgDocs.set(orgId, { ...(orgDocs.get(orgId) ?? {}), ...patch })
+}
+
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  cache.reset()
+  orgDocs.clear()
+  buckets.clear()
+  orgFetches = 0
+  revCounter = 0
+  process.env.AUTH_SECRET = 'test-auth-secret'
+  process.env.PROVISIONING_API_TOKEN = TOKEN
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+  orgDocs.set('org-A', {
+    _id: 'org-A',
+    name: 'Old Name',
+    slug: 'acme',
+    contactEmail: 'old@acme.test',
+  })
+  orgDocs.set('org-B', { _id: 'org-B', name: 'Other Org', slug: 'other' })
+})
+
+afterEach(() => {
+  delete process.env.PROVISIONING_API_TOKEN
+  delete process.env.AUTH_SECRET
+  warnSpy.mockRestore()
+})
+
+describe('kontroll writes, then invalidates', () => {
+  it('serves the NEW value after invalidation, and the stale one before it', async () => {
+    // 1. First read populates the entry.
+    await expect(readOrganization('org-A')).resolves.toMatchObject({
+      name: 'Old Name',
+      contactEmail: 'old@acme.test',
+    })
+    expect(orgFetches).toBe(1)
+
+    // 2. The other application edits the organization with its own token. It
+    //    never runs a line of this app's code.
+    kontrollWrites('org-A', {
+      name: 'New Name',
+      contactEmail: 'new@acme.test',
+    })
+
+    // 3. Without invalidation this app keeps serving the old values — the bug.
+    await expect(readOrganization('org-A')).resolves.toMatchObject({
+      name: 'Old Name',
+      contactEmail: 'old@acme.test',
+    })
+    expect(orgFetches).toBe(1)
+
+    // 4. kontroll calls the endpoint it now has.
+    const response = await invalidate([{ type: 'organization', id: 'org-A' }])
+    expect(response.status).toBe(200)
+
+    // 5. The next read sees the write.
+    await expect(readOrganization('org-A')).resolves.toMatchObject({
+      name: 'New Name',
+      contactEmail: 'new@acme.test',
+    })
+    expect(orgFetches).toBe(2)
+  })
+
+  it('busts ONLY the named organization — a neighbour keeps its entry', async () => {
+    await readOrganization('org-A')
+    await readOrganization('org-B')
+    expect(orgFetches).toBe(2)
+
+    kontrollWrites('org-A', { name: 'New Name' })
+    kontrollWrites('org-B', { name: 'Other Org, Renamed' })
+
+    await invalidate([{ type: 'organization', id: 'org-A' }])
+
+    await expect(readOrganization('org-A')).resolves.toMatchObject({
+      name: 'New Name',
+    })
+    // org-B was not named, so it is still served from its entry — invalidation
+    // is targeted, not a flush.
+    await expect(readOrganization('org-B')).resolves.toMatchObject({
+      name: 'Other Org',
+    })
+    expect(orgFetches).toBe(3)
+  })
+
+  it('does NOT bust the entry when a DIFFERENT org is invalidated', async () => {
+    await readOrganization('org-A')
+    kontrollWrites('org-A', { name: 'New Name' })
+
+    await invalidate([{ type: 'organization', id: 'org-B' }])
+
+    await expect(readOrganization('org-A')).resolves.toMatchObject({
+      name: 'Old Name',
+    })
+    expect(orgFetches).toBe(1)
+  })
+
+  it('leaves the entry alone when the call is REFUSED', async () => {
+    delete process.env.PROVISIONING_API_TOKEN
+
+    await readOrganization('org-A')
+    kontrollWrites('org-A', { name: 'New Name' })
+
+    const response = await invalidate([{ type: 'organization', id: 'org-A' }])
+    expect(response.status).toBe(401)
+
+    // A refused call must not have the side effect of a successful one.
+    await expect(readOrganization('org-A')).resolves.toMatchObject({
+      name: 'Old Name',
+    })
+    expect(orgFetches).toBe(1)
+  })
+
+  it('revalidates the SAME tag the read registered — no second spelling', async () => {
+    await readOrganization('org-A')
+    const registered = cache.entries.get('org:org-A')?.tags ?? []
+
+    await invalidate([{ type: 'organization', id: 'org-A' }])
+    const revalidated = revalidateTagSpy.mock.calls.map(
+      (call) => call[0] as string,
+    )
+
+    // The read registers the broad content tag AND the per-tenant one; the
+    // endpoint may only ever reach the per-tenant one, and it must be a tag the
+    // read actually registered.
+    expect(registered).toContain('sanity:organization-org-A')
+    expect(revalidated).toEqual(['sanity:organization-org-A'])
+    expect(registered).toEqual(expect.arrayContaining(revalidated))
+  })
+})

--- a/src/app/api/provisioning/cache/invalidate/route.test.ts
+++ b/src/app/api/provisioning/cache/invalidate/route.test.ts
@@ -1,0 +1,434 @@
+/**
+ * @vitest-environment node
+ *
+ * EXTERNAL CACHE INVALIDATION (RunKonf/platform#36) — the guard tests.
+ *
+ * Every assertion is on an OBSERVABLE EFFECT: the status code, and above all
+ * WHICH TAGS `revalidateTag` was handed. Error strings are never asserted on —
+ * a broken guard that revalidated anyway would pass such a test happily — and
+ * the uniform-401 property is checked by comparing whole response bodies to
+ * each other rather than to an expected message.
+ *
+ * The Sanity fake models the one behaviour the rate limiter leans on:
+ * `patch(...).ifRevisionId(rev)` fails unless the revision is current, and
+ * `create` on an explicit id fails if the document exists. Without that the
+ * limiter's compare-and-swap would not actually be exercised.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('next/cache', () => ({
+  unstable_noStore: () => {},
+  revalidateTag: vi.fn(),
+}))
+
+interface Doc extends Record<string, unknown> {
+  _id: string
+  _type: string
+  _rev?: string
+}
+
+const docs = new Map<string, Doc>()
+let revCounter = 0
+const nextRev = () => `rev-${++revCounter}`
+
+function conflict(message: string): Error & { statusCode: number } {
+  return Object.assign(new Error(message), { statusCode: 409 })
+}
+
+/**
+ * Every content read this route could possibly make. It must stay EMPTY-handed:
+ * the endpoint is specified never to look anything up (that is what keeps it
+ * from being an existence oracle), so any call here that is not a rate-limit
+ * bucket read is a regression.
+ */
+const contentFetches: string[] = []
+
+const fetchMock = vi.fn(
+  async (query: string, params: Record<string, unknown> = {}) => {
+    if (query.includes('_type == $type && _id == $id')) {
+      const doc = docs.get(params.id as string)
+      return doc && doc._type === params.type ? { ...doc } : null
+    }
+    contentFetches.push(query)
+    return null
+  },
+)
+
+function standalonePatch(id: string) {
+  let expectedRev: string | undefined
+  let updates: Record<string, unknown> = {}
+  const chain = {
+    ifRevisionId(rev: string) {
+      expectedRev = rev
+      return chain
+    },
+    set(values: Record<string, unknown>) {
+      updates = { ...updates, ...values }
+      return chain
+    },
+    async commit() {
+      const doc = docs.get(id)
+      if (!doc) throw conflict(`Document ${id} is gone`)
+      if (expectedRev !== undefined && doc._rev !== expectedRev) {
+        throw conflict(`Revision moved on ${id}`)
+      }
+      docs.set(id, { ...doc, ...updates, _rev: nextRev() })
+    },
+  }
+  return chain
+}
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: {
+    fetch: (query: string, params?: Record<string, unknown>) =>
+      fetchMock(query, params ?? {}),
+  },
+  clientReadCached: { fetch: vi.fn() },
+  clientWrite: {
+    create: async (doc: Doc) => {
+      if (docs.has(doc._id)) throw conflict(`${doc._id} already exists`)
+      docs.set(doc._id, { ...doc, _rev: nextRev() })
+      return doc
+    },
+    patch: (id: string) => standalonePatch(id),
+    delete: async () => ({ results: [] }),
+  },
+}))
+
+import { revalidateTag } from 'next/cache'
+import { POST } from './route'
+import { MAX_INVALIDATION_TARGETS } from '@/lib/cache/invalidation'
+
+const revalidateTagMock = revalidateTag as unknown as ReturnType<typeof vi.fn>
+
+const ENDPOINT = 'https://konf.app/api/provisioning/cache/invalidate'
+
+/** 40 chars — comfortably over the 32-char floor. */
+const TOKEN = 'prov_live_5f3c1a9e77b4d206c8ae13f0b95d7e42'
+
+type Target = Record<string, unknown>
+
+function request({
+  token = TOKEN as string | null,
+  targets = [{ type: 'organization', id: 'org-A' }] as Target[],
+  payload,
+  raw,
+  ip = '203.0.113.7' as string | null,
+}: {
+  token?: string | null
+  targets?: Target[]
+  payload?: unknown
+  raw?: string
+  ip?: string | null
+} = {}) {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+  }
+  if (ip !== null) headers['x-forwarded-for'] = ip
+  if (token !== null) headers.authorization = `Bearer ${token}`
+  return new Request(ENDPOINT, {
+    method: 'POST',
+    headers,
+    body: raw ?? JSON.stringify(payload ?? { targets }),
+  }) as unknown as Parameters<typeof POST>[0]
+}
+
+/** Every tag handed to `revalidateTag` so far, in call order. */
+function revalidatedTags(): string[] {
+  return revalidateTagMock.mock.calls.map((call) => call[0] as string)
+}
+
+let warnSpy: ReturnType<typeof vi.spyOn>
+let errorSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  docs.clear()
+  contentFetches.length = 0
+  revCounter = 0
+  process.env.AUTH_SECRET = 'test-auth-secret'
+  process.env.PROVISIONING_API_TOKEN = TOKEN
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  delete process.env.PROVISIONING_API_TOKEN
+  delete process.env.AUTH_SECRET
+  warnSpy.mockRestore()
+  errorSpy.mockRestore()
+})
+
+describe('authentication — fail closed, and nothing is invalidated', () => {
+  it('refuses when PROVISIONING_API_TOKEN is UNSET, revalidating nothing', async () => {
+    delete process.env.PROVISIONING_API_TOKEN
+
+    const response = await POST(request())
+
+    expect(response.status).toBe(401)
+    expect(revalidateTagMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses when the configured secret is EMPTY or WHITESPACE', async () => {
+    for (const secret of ['', '   ']) {
+      revalidateTagMock.mockClear()
+      process.env.PROVISIONING_API_TOKEN = secret
+
+      const response = await POST(request({ token: secret }))
+
+      expect(response.status).toBe(401)
+      expect(revalidateTagMock).not.toHaveBeenCalled()
+    }
+  })
+
+  it('refuses when the configured secret is TOO SHORT, even if presented exactly', async () => {
+    const weak = 'short-secret'
+    process.env.PROVISIONING_API_TOKEN = weak
+
+    const response = await POST(request({ token: weak }))
+
+    expect(response.status).toBe(401)
+    expect(revalidateTagMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses a missing header, a non-bearer scheme and a wrong token', async () => {
+    for (const token of [null, 'Basic abc', `${TOKEN}x`]) {
+      revalidateTagMock.mockClear()
+
+      const response = await POST(request({ token }))
+
+      expect(response.status).toBe(401)
+      expect(revalidateTagMock).not.toHaveBeenCalled()
+    }
+  })
+
+  it('answers every failure mode with the IDENTICAL body — no oracle', async () => {
+    const bodies: string[] = []
+
+    delete process.env.PROVISIONING_API_TOKEN
+    bodies.push(await (await POST(request())).text())
+
+    process.env.PROVISIONING_API_TOKEN = 'short-secret'
+    bodies.push(await (await POST(request({ token: 'short-secret' }))).text())
+
+    process.env.PROVISIONING_API_TOKEN = TOKEN
+    bodies.push(await (await POST(request({ token: null }))).text())
+    bodies.push(await (await POST(request({ token: `${TOKEN}x` }))).text())
+
+    expect(new Set(bodies).size).toBe(1)
+  })
+
+  it('METERS unauthenticated attempts — a brute-force run is cut off', async () => {
+    delete process.env.PROVISIONING_API_TOKEN
+
+    const statuses: number[] = []
+    for (let i = 0; i < 70; i++) {
+      statuses.push((await POST(request({ token: 'guess' }))).status)
+    }
+
+    // The pre-auth bucket is charged before the token is compared, so the run
+    // stops being merely refused and starts being rate limited.
+    expect(statuses).toContain(429)
+    expect(revalidateTagMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('the tags it revalidates', () => {
+  it('busts EXACTLY the organization tag for an organization target', async () => {
+    const response = await POST(
+      request({ targets: [{ type: 'organization', id: 'org-A' }] }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(revalidatedTags()).toEqual(['sanity:organization-org-A'])
+    await expect(response.json()).resolves.toEqual({
+      invalidated: 1,
+      tags: ['sanity:organization-org-A'],
+    })
+  })
+
+  it('busts EXACTLY the conference tag for a conference target', async () => {
+    const response = await POST(
+      request({ targets: [{ type: 'conference', id: 'conf-9' }] }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(revalidatedTags()).toEqual(['sanity:conference-conf-9'])
+  })
+
+  it('busts EXACTLY the domain tag, normalized, for a domain target', async () => {
+    const response = await POST(
+      request({ targets: [{ type: 'domain', domain: '  Oslo.Example.COM ' }] }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(revalidatedTags()).toEqual(['domain:oslo.example.com'])
+  })
+
+  it('busts one tag per target, in order, for a mixed batch', async () => {
+    await POST(
+      request({
+        targets: [
+          { type: 'organization', id: 'org-A' },
+          { type: 'conference', id: 'conf-9' },
+          { type: 'domain', domain: 'oslo.example.com' },
+        ],
+      }),
+    )
+
+    expect(revalidatedTags()).toEqual([
+      'sanity:organization-org-A',
+      'sanity:conference-conf-9',
+      'domain:oslo.example.com',
+    ])
+  })
+
+  it('DE-DUPLICATES repeated targets rather than charging them twice', async () => {
+    const response = await POST(
+      request({
+        targets: [
+          { type: 'organization', id: 'org-A' },
+          { type: 'organization', id: 'org-A' },
+          { type: 'domain', domain: 'OSLO.example.com' },
+          { type: 'domain', domain: 'oslo.example.com' },
+        ],
+      }),
+    )
+
+    expect(revalidatedTags()).toEqual([
+      'sanity:organization-org-A',
+      'domain:oslo.example.com',
+    ])
+    await expect(response.json()).resolves.toMatchObject({ invalidated: 2 })
+  })
+
+  it('cannot be talked into a BROAD content tag', async () => {
+    // Spelling a cross-tenant tag straight into an id is refused outright…
+    for (const id of ['content:organizations', 'content:conferences']) {
+      revalidateTagMock.mockClear()
+      const response = await POST(
+        request({ targets: [{ type: 'organization', id }] }),
+      )
+      expect(response.status).toBe(400)
+      expect(revalidateTagMock).not.toHaveBeenCalled()
+    }
+
+    // …and an id that IS accepted is still only ever wrapped by the builder,
+    // so the result cannot be a `content:` / `admin:` tag either way.
+    revalidateTagMock.mockClear()
+    await POST(
+      request({
+        targets: [{ type: 'organization', id: 'content-organizations' }],
+      }),
+    )
+    expect(revalidatedTags()).toEqual([
+      'sanity:organization-content-organizations',
+    ])
+  })
+})
+
+describe('a target that does not exist is a NO-OP, not an oracle', () => {
+  it('answers an unknown id exactly as it answers a known one, reading nothing', async () => {
+    const unknown = await POST(
+      request({
+        targets: [{ type: 'organization', id: 'org-does-not-exist' }],
+      }),
+    )
+
+    expect(unknown.status).toBe(200)
+    await expect(unknown.json()).resolves.toEqual({
+      invalidated: 1,
+      tags: ['sanity:organization-org-does-not-exist'],
+    })
+    // Nothing was looked up, so there is nothing for a prober to compare.
+    expect(contentFetches).toEqual([])
+  })
+})
+
+describe('bounds — one call cannot stampede the cache', () => {
+  it('refuses a batch over the per-call cap, revalidating NOTHING', async () => {
+    const targets = Array.from(
+      { length: MAX_INVALIDATION_TARGETS + 1 },
+      (_, i) => ({ type: 'organization', id: `org-${i}` }),
+    )
+
+    const response = await POST(request({ targets }))
+
+    expect(response.status).toBe(400)
+    expect(revalidateTagMock).not.toHaveBeenCalled()
+  })
+
+  it('accepts a batch AT the cap', async () => {
+    const targets = Array.from(
+      { length: MAX_INVALIDATION_TARGETS },
+      (_, i) => ({ type: 'organization', id: `org-${i}` }),
+    )
+
+    const response = await POST(request({ targets }))
+
+    expect(response.status).toBe(200)
+    expect(revalidatedTags()).toHaveLength(MAX_INVALIDATION_TARGETS)
+  })
+
+  it('METERS authenticated calls too — a sustained flood is cut off', async () => {
+    const statuses: number[] = []
+    for (let i = 0; i < 70; i++) {
+      statuses.push((await POST(request())).status)
+    }
+
+    expect(statuses).toContain(429)
+  })
+})
+
+describe('payload validation', () => {
+  it('refuses an empty batch, an absent batch and unparseable JSON', async () => {
+    const cases = [
+      request({ targets: [] }),
+      request({ payload: {} }),
+      request({ raw: '{' }),
+    ]
+
+    for (const req of cases) {
+      revalidateTagMock.mockClear()
+      const response = await POST(req)
+      expect(response.status).toBe(400)
+      expect(revalidateTagMock).not.toHaveBeenCalled()
+    }
+  })
+
+  it('refuses an unknown target type — the vocabulary is closed', async () => {
+    const response = await POST(
+      request({ targets: [{ type: 'speaker', id: 'spk-1' }] }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(revalidateTagMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses a malformed id or hostname, revalidating nothing', async () => {
+    const cases: Target[][] = [
+      [{ type: 'organization', id: '' }],
+      [{ type: 'organization', id: 'org *[_type=="organization"]' }],
+      [{ type: 'organization', id: 'a'.repeat(300) }],
+      [{ type: 'domain', domain: 'https://oslo.example.com' }],
+      [{ type: 'domain', domain: 'oslo.example.com/admin' }],
+      [{ type: 'domain', domain: '' }],
+    ]
+
+    for (const targets of cases) {
+      revalidateTagMock.mockClear()
+      const response = await POST(request({ targets }))
+      expect(response.status).toBe(400)
+      expect(revalidateTagMock).not.toHaveBeenCalled()
+    }
+  })
+
+  it('refuses a target that is not an object at all', async () => {
+    const response = await POST(
+      request({ payload: { targets: ['organization'] } }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(revalidateTagMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/provisioning/cache/invalidate/route.test.ts
+++ b/src/app/api/provisioning/cache/invalidate/route.test.ts
@@ -370,13 +370,56 @@ describe('bounds — one call cannot stampede the cache', () => {
     expect(revalidatedTags()).toHaveLength(MAX_INVALIDATION_TARGETS)
   })
 
-  it('METERS authenticated calls too — a sustained flood is cut off', async () => {
+  /**
+   * THE TWO METERS GET ONE TEST EACH, AND EACH TEST CAN ONLY BE SATISFIED BY
+   * ITS OWN.
+   *
+   * The pre-auth per-IP bucket and the post-auth global bucket carry the
+   * IDENTICAL 60/min cap, and the per-IP one is charged first. So a plain
+   * authenticated flood from a fixed address trips the per-IP bucket at call 61
+   * and never reaches the global bucket at all — such a test passes with the
+   * global bound deleted, which makes the platform's only anti-stampede cap
+   * (`INVALIDATION_RULES`, `@/lib/provisioning/constants`) unobservable.
+   *
+   * So each test below removes the OTHER bucket from the picture:
+   *  - fixed address, payload refused at validation ⇒ the global bucket is
+   *    never charged (it comes after validation), so only the per-IP bound can
+   *    produce the 429;
+   *  - one fresh address per call ⇒ every per-IP bucket sees exactly one hit
+   *    and none can ever trip, so only the global bound can produce the 429.
+   */
+  it('METERS a flood from ONE address before the payload is even read', async () => {
     const statuses: number[] = []
     for (let i = 0; i < 70; i++) {
-      statuses.push((await POST(request())).status)
+      statuses.push((await POST(request({ targets: [] }))).status)
     }
 
+    // Refused on content until the per-IP meter takes over from validation.
+    expect(statuses.slice(0, 60)).toEqual(Array(60).fill(400))
     expect(statuses).toContain(429)
+    expect(revalidateTagMock).not.toHaveBeenCalled()
+
+    // And the platform's invalidation budget is untouched by that run — a real
+    // call from a fresh address still goes through, which is the property that
+    // keeps a malformed caller from spending everyone else's quota.
+    const afterwards = await POST(request({ ip: '198.51.100.254' }))
+    expect(afterwards.status).toBe(200)
+  })
+
+  it('METERS a flood that ROTATES its client IP — the anti-stampede bound', async () => {
+    // `x-forwarded-for` is caller-controlled (see `@/lib/rate-limit/client-ip`),
+    // so this is the caller the per-IP bucket cannot stop: a fresh address every
+    // call. Only the single global bucket is left to say no.
+    const statuses: number[] = []
+    for (let i = 0; i < 70; i++) {
+      statuses.push((await POST(request({ ip: `198.51.100.${i}` }))).status)
+    }
+
+    expect(statuses.slice(0, 60)).toEqual(Array(60).fill(200))
+    expect(statuses).toContain(429)
+    // One target per call, so the revalidation work caused is exactly the
+    // number of calls that got through — the cap held platform-wide.
+    expect(revalidatedTags()).toHaveLength(60)
   })
 })
 

--- a/src/app/api/provisioning/cache/invalidate/route.ts
+++ b/src/app/api/provisioning/cache/invalidate/route.ts
@@ -1,0 +1,164 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { revalidateTag, unstable_noStore as noStore } from 'next/cache'
+import { clientIpFromHeaders } from '@/lib/rate-limit'
+import {
+  authenticateProvisioningRequest,
+  chargeInvalidation,
+  chargeInvalidationAttempt,
+} from '@/lib/provisioning'
+import {
+  InvalidationRequestSchema,
+  tagsForTargets,
+} from '@/lib/cache/invalidation'
+
+/**
+ * EXTERNAL CACHE INVALIDATION (RunKonf/platform#36) —
+ * `POST /api/provisioning/cache/invalidate`.
+ *
+ * `RunKonf/kontroll` (the control panel at my.konf.app) writes `organization`
+ * documents into the shared Sanity dataset with its OWN token. It never runs
+ * this app's code, so nothing it did could reach `revalidateTag` — and
+ * `getOrganizationById` caches `name`, `slug` and `contactEmail` for an hour and
+ * holds them for a day. An organizer renaming their organization in kontroll
+ * saw a success message and a conference site that kept serving the old name.
+ * This endpoint is the missing half: kontroll writes, then says what it wrote.
+ *
+ * IT SHARES `PROVISIONING_API_TOKEN` with the tenant-creation endpoint, on
+ * purpose. Same caller, same trust boundary, same rotation. More to the point,
+ * this endpoint is STRICTLY LESS POWERFUL than what that secret already grants:
+ * a holder can mint organizations, claim domains (an OAuth redirect grant) and
+ * attach organizers — busting a cache entry is a subset of that blast radius,
+ * so a second secret would protect nothing an attacker could not already do,
+ * while adding a rotation surface and one more env var to forget in a new
+ * environment. If a caller ever legitimately needs invalidation WITHOUT
+ * provisioning, split it then: `authenticateProvisioningRequest` is a pure
+ * function of the headers and takes an env name in one edit.
+ *
+ * WHAT KEEPS IT FROM BEING A CACHE-STAMPEDE PRIMITIVE:
+ *
+ *  - The caller names DOCUMENTS, never tags. The broad `content:*` tags (which
+ *    bust every tenant at once) are not in the vocabulary and cannot be
+ *    reached; see `@/lib/cache/invalidation`.
+ *  - At most `MAX_INVALIDATION_TARGETS` targets per call, and the global
+ *    post-auth bucket caps calls. The two together bound total revalidation
+ *    work no matter what is sent.
+ *  - The attempt limiter is charged BEFORE authentication, so guessing the
+ *    secret is metered rather than free.
+ *
+ * WHAT IT DELIBERATELY DOES NOT DO: look anything up. A tag is computed from
+ * the caller's own input, so invalidating an organization that does not exist
+ * revalidates a tag nothing is stored under — a real no-op, answered with the
+ * same 200 as a real hit. There is no existence check to leak, and therefore
+ * this endpoint is not an oracle for what is in the content lake.
+ *
+ * ── REQUEST ────────────────────────────────────────────────────────────────
+ *   POST /api/provisioning/cache/invalidate
+ *   Authorization: Bearer <PROVISIONING_API_TOKEN>
+ *   Content-Type: application/json
+ *
+ *   { "targets": [
+ *       { "type": "organization", "id": "<organization _id>" },
+ *       { "type": "conference",   "id": "<conference _id>"   },
+ *       { "type": "domain",       "domain": "oslo.example.com" }
+ *   ] }
+ *
+ * ── RESPONSES ──────────────────────────────────────────────────────────────
+ *   200 { invalidated: number, tags: string[] }   tags echo the caller's own
+ *       input; they reveal nothing the caller did not already send.
+ *   400 { error: "invalid_request", code, issues? }
+ *   401 { error: "unauthorized" }                 (uniform, always)
+ *   429 { error: "rate_limited" }                 (+ Retry-After)
+ *   500 { error: "internal_error" }
+ *
+ * NOT IDEMPOTENCY-KEYED, unlike provisioning: invalidation is naturally
+ * idempotent (revalidating a tag twice is indistinguishable from once), so a
+ * key would add a required header and a stored receipt to protect nothing.
+ */
+
+const RETRY_AFTER_SECONDS = 60
+
+/** The ONE unauthenticated response. Every auth failure mode shares it byte for
+ * byte, so a prober cannot distinguish "not configured" from "wrong token". */
+function unauthorized(): NextResponse {
+  return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+}
+
+function invalidRequest(
+  code: string,
+  issues?: Array<{ path: string; message: string }>,
+): NextResponse {
+  return NextResponse.json(
+    { error: 'invalid_request', code, ...(issues ? { issues } : {}) },
+    { status: 400 },
+  )
+}
+
+function rateLimited(): NextResponse {
+  return NextResponse.json(
+    { error: 'rate_limited' },
+    { status: 429, headers: { 'Retry-After': String(RETRY_AFTER_SECONDS) } },
+  )
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  noStore()
+  try {
+    // 1. METER FIRST, AUTHENTICATE SECOND — guessing the shared secret is
+    //    rate-limited rather than free.
+    if (
+      !(await chargeInvalidationAttempt(clientIpFromHeaders(request.headers)))
+    ) {
+      return rateLimited()
+    }
+
+    // 2. AUTHENTICATE. Only `ok` is branched on; the reason is logged for the
+    //    operator and never leaves the server.
+    const auth = authenticateProvisioningRequest(request.headers)
+    if (!auth.ok) {
+      console.warn(`[cache-invalidation] request refused (${auth.reason})`)
+      return unauthorized()
+    }
+
+    // 3. VALIDATE. The schema is the ONLY thing that decides what may be
+    //    invalidated — including the per-call target cap.
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return invalidRequest('invalid_json')
+    }
+
+    const parsed = InvalidationRequestSchema.safeParse(body)
+    if (!parsed.success) {
+      return invalidRequest(
+        'schema_validation_failed',
+        parsed.error.issues.map((issue) => ({
+          path: issue.path.join('.'),
+          message: issue.message,
+        })),
+      )
+    }
+
+    // 4. Charge the global bucket only now, so a malformed payload cannot
+    //    consume the platform's invalidation budget — it is already metered by
+    //    the attempt bucket above.
+    if (!(await chargeInvalidation())) {
+      return rateLimited()
+    }
+
+    const tags = tagsForTargets(parsed.data.targets)
+    for (const tag of tags) {
+      revalidateTag(tag, 'default')
+    }
+
+    return NextResponse.json(
+      { invalidated: tags.length, tags },
+      { status: 200 },
+    )
+  } catch (error) {
+    // Deliberately detail-free: this endpoint is reachable by anyone who can
+    // reach the network, and a stack-shaped message is reconnaissance.
+    console.error('[cache-invalidation] unhandled error', error)
+    return NextResponse.json({ error: 'internal_error' }, { status: 500 })
+  }
+}

--- a/src/lib/cache/invalidation.ts
+++ b/src/lib/cache/invalidation.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod'
+import { isValidDomainEntry, normalizeDomain } from '@/lib/conference/domains'
+import { conferenceTag, domainTag, organizationTag } from './tags'
+
+/**
+ * EXTERNAL CACHE INVALIDATION — the target vocabulary (RunKonf/platform#36).
+ *
+ * Two applications now write the same Sanity dataset. `RunKonf/kontroll` (the
+ * control panel at my.konf.app) writes `organization` documents with its own
+ * token, and this app caches exactly those fields: `getOrganizationById` is
+ * `'use cache'` with `cacheLife('hours')` — revalidate 1h, EXPIRE 24h — over
+ * `name`, `slug` and `contactEmail`. Until this module existed there was no way
+ * for a writer outside this deployment to bust that entry, so an organizer who
+ * renamed their organization in kontroll saw a success message and a conference
+ * site that kept serving the old name for up to a day.
+ *
+ * WHAT THIS MODULE IS. A total function from a caller-supplied TARGET to one of
+ * the tags `@/lib/cache/tags` already mints. It is the whole vocabulary the
+ * external endpoint accepts, and it is deliberately small.
+ *
+ * WHAT IT IS NOT, AND MUST NEVER BECOME:
+ *
+ *  1. A BLANKET FLUSH. There is no `{"type":"all"}` and no way to name the
+ *     broad `content:*` tags — those bust EVERY tenant at once, and an endpoint
+ *     that exposes them hands any holder of the shared secret (or anyone who
+ *     can make it retry) a cache-stampede primitive against the whole platform.
+ *     Every target here busts exactly one document's or one host's entries.
+ *  2. AN EXISTENCE ORACLE. Nothing in this module reads Sanity. A tag is a pure
+ *     function of the caller's own input, so invalidating an organization that
+ *     does not exist computes a tag nothing is stored under and revalidates
+ *     nothing — a genuine no-op that returns the same 200 as a real hit, with
+ *     nothing to compare against. There is no lookup to leak.
+ *
+ * EXTENDING IT. Add a member to the union and a `case` to {@link tagForTarget}.
+ * Do not widen an existing member to accept a tag NAME: the point of the union
+ * is that the caller names a DOCUMENT and this app decides which tag that
+ * implies, so the tag structure stays this repo's to change.
+ */
+
+/**
+ * The most targets one request may carry. This — not the rate limiter — is the
+ * bound on how much work a single accepted call can cause; the limiter bounds
+ * how many such calls there may be. Comfortably above kontroll's real batch (it
+ * writes one organization at a time), far below anything resembling a flush.
+ */
+export const MAX_INVALIDATION_TARGETS = 20
+
+/**
+ * A Sanity document id, by SHAPE only. Sanity ids are opaque; this rejects the
+ * obviously-not-an-id (empty, unbounded, control characters, GROQ punctuation)
+ * so a mangled caller gets a 400 instead of silently revalidating a nonsense
+ * tag. It deliberately does NOT check existence — see the module doc.
+ */
+const SanityDocumentId = z
+  .string()
+  .trim()
+  .min(1)
+  .max(200)
+  .regex(/^[A-Za-z0-9._-]+$/)
+
+/**
+ * A hostname, normalized to the canonical stored form FIRST and then validated
+ * with the same `isValidDomainEntry` the conference `domains[]` editor uses —
+ * so the tag computed here is byte-identical to the one the cached read
+ * registered for that host. A second, looser notion of "a domain" would produce
+ * a tag that matches nothing, which is the silent-no-op failure mode this whole
+ * feature exists to prevent.
+ */
+const DomainName = z
+  .string()
+  .transform(normalizeDomain)
+  .refine(isValidDomainEntry)
+
+export const InvalidationTargetSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('organization'), id: SanityDocumentId }),
+  z.object({ type: z.literal('conference'), id: SanityDocumentId }),
+  z.object({ type: z.literal('domain'), domain: DomainName }),
+])
+
+export type InvalidationTarget = z.infer<typeof InvalidationTargetSchema>
+
+export const InvalidationRequestSchema = z.object({
+  targets: z
+    .array(InvalidationTargetSchema)
+    .min(1)
+    .max(MAX_INVALIDATION_TARGETS),
+})
+
+/**
+ * The ONE tag a target implies. Every branch delegates to `@/lib/cache/tags` —
+ * the tag strings are not restated here, because a second copy is exactly how
+ * an invalidation quietly starts missing the read it is supposed to bust.
+ */
+export function tagForTarget(target: InvalidationTarget): string {
+  switch (target.type) {
+    case 'organization':
+      return organizationTag(target.id)
+    case 'conference':
+      return conferenceTag(target.id)
+    case 'domain':
+      return domainTag(target.domain)
+  }
+}
+
+/**
+ * The de-duplicated tags for a batch, in first-seen order. Duplicates in the
+ * payload (kontroll patching the same org twice in one flush) must not be
+ * charged twice against the platform's revalidation budget.
+ */
+export function tagsForTargets(
+  targets: readonly InvalidationTarget[],
+): string[] {
+  return [...new Set(targets.map(tagForTarget))]
+}

--- a/src/lib/features/platform.ts
+++ b/src/lib/features/platform.ts
@@ -1,10 +1,11 @@
 import 'server-only'
-import { getOrganizationById } from '@/lib/organization/sanity'
+import { getPlatformOrgId, resolvePlatformOrgSlug } from '@/lib/authz/platform'
 import { resolveCurrentOrgId } from '@/lib/authz/organizer'
 
 /**
  * PLATFORM-organization identification for cross-tenant management surfaces
- * (the entitlements management card + `platform` tRPC router).
+ * (the entitlements management card, the `platform` tRPC router, the workshops
+ * gate).
  *
  * There is no superadmin role in the codebase — the only "platform" concept is
  * the brand-fallback `PLATFORM_NAME` label (`src/lib/branding/platform.ts`),
@@ -20,34 +21,55 @@ import { resolveCurrentOrgId } from '@/lib/authz/organizer'
  *   with the org-scoped organizer waist: platform access = organizer of the
  *   platform org, on the platform org's own domain.
  *
+ * ── ONE RESOLVER, UNCACHED (RunKonf/platform#36) ────────────────────────────
+ *
+ * The slug→org resolution happens EXACTLY ONCE, in `getPlatformOrgId()`
+ * (`@/lib/authz/platform`), which reads Sanity uncached. Everything here
+ * compares ids against that one answer.
+ *
+ * It used to be derived twice. This module read the org document through the
+ * CACHED `getOrganizationById` and compared `org.slug` to the env var, while
+ * `getPlatformOrgId()` resolved the same relationship UNCACHED — so the same
+ * question got different answers depending on which code path asked, for up to
+ * the 24-hour expiry of the cached read. Production has one organization that
+ * is both the platform org and a tenant: an admin renaming its slug lost
+ * operator standing instantly on one path while the workshops gate — which
+ * decides whether attendees get emailed a sign-in link — kept serving on the
+ * revoked grant for a day.
+ *
+ * A cache is not an acceptable input to an authorization decision when a second
+ * application can change the underlying document without being able to
+ * invalidate it. `POST /api/provisioning/cache/invalidate` now closes that gap
+ * for content, but a grant must not depend on a caller remembering to call it,
+ * so the identity check reads through.
+ *
+ * WHAT IT COSTS: one extra `_id`-only Sanity fetch per gate evaluation, not
+ * deduplicated within a request (an admin page render that both hides the
+ * management card and resolves entitlements pays it twice). That is an indexed
+ * point lookup against a document the deployment has exactly one of. If it ever
+ * shows up in latency the fix is REQUEST-SCOPED memoization (React `cache()`),
+ * which removes the duplicate fetch without reintroducing cross-request
+ * staleness — never a `'use cache'` entry.
+ *
  * Server-side enforcement lives in the platform router's middleware — the
  * settings page merely also hides the card, which is presentation, not
  * security.
  */
 
-/** The configured platform org slug, or `null` when the contract is unset. */
-export function platformOrgSlug(): string | null {
-  const slug = process.env.PLATFORM_ORG_SLUG?.trim()
-  return slug ? slug : null
-}
-
-/** PURE slug comparison against the `PLATFORM_ORG_SLUG` contract. */
-export function isPlatformOrgSlug(slug: string | null | undefined): boolean {
-  const configured = platformOrgSlug()
-  return configured !== null && !!slug && slug === configured
-}
-
 /**
- * Whether the organization with this id IS the platform org. Uses the cached,
- * `organizationTag`-tagged org read; `false` for a missing/unknown org or an
- * unset contract.
+ * Whether the organization with this id IS the platform org. `false` for a
+ * missing/unknown org or an unset contract (fail closed, at every step).
+ *
+ * An ID comparison, not a slug comparison: the id is what `getPlatformOrgId()`
+ * already resolves the configured slug to, and routing every caller through it
+ * is what makes a second, staler derivation impossible to write by accident.
  */
 export async function isPlatformOrganization(
   orgId: string | null | undefined,
 ): Promise<boolean> {
-  if (!orgId || platformOrgSlug() === null) return false
-  const org = await getOrganizationById(orgId)
-  return isPlatformOrgSlug(org?.slug)
+  if (!orgId) return false
+  const platformOrgId = await getPlatformOrgId()
+  return platformOrgId !== null && orgId === platformOrgId
 }
 
 /**
@@ -55,7 +77,8 @@ export async function isPlatformOrganization(
  * settings page uses this to decide whether to render the management card).
  */
 export async function isPlatformOrgRequest(): Promise<boolean> {
-  if (platformOrgSlug() === null) return false
-  const orgId = await resolveCurrentOrgId()
-  return isPlatformOrganization(orgId)
+  // Short-circuits before either read when the contract is unset — the common
+  // case for deploys that never opt into a platform org.
+  if (resolvePlatformOrgSlug() === null) return false
+  return isPlatformOrganization(await resolveCurrentOrgId())
 }

--- a/src/lib/features/workshops.test.ts
+++ b/src/lib/features/workshops.test.ts
@@ -2,10 +2,20 @@
  * @vitest-environment node
  *
  * The workshop feature gate (#689) — the ONE resolver the portal, the admin
- * surfaces and (critically) the ticket-sold email all consult. The org document
- * read is mocked at the Sanity boundary so the REAL entitlement resolution runs:
- * plan/override semantics, override expiry, and the platform-org default that
- * keeps today's tenant working without a data migration.
+ * surfaces and (critically) the ticket-sold email all consult.
+ *
+ * TWO boundaries are mocked, and the distinction is the point (see
+ * RunKonf/platform#36):
+ *
+ *  - `@/lib/organization/sanity` — the CACHED org document, carrying `plan` and
+ *    `featureOverrides`. The real entitlement resolution runs on top of it.
+ *  - `@/lib/sanity/client` — the UNCACHED read `getPlatformOrgId()` uses to turn
+ *    `PLATFORM_ORG_SLUG` into an org id. The real `isPlatformOrganization` runs
+ *    on top of THAT.
+ *
+ * Because the two are mocked independently, a test can make the cached document
+ * disagree with the live slug→id resolution — which is exactly the production
+ * situation this gate got wrong, and what pins it now.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { Organization } from '@/lib/organization/types'
@@ -19,6 +29,14 @@ vi.mock('@/lib/organization/sanity', () => ({
     getOrganizationRefForCurrentConference(),
 }))
 
+const h = vi.hoisted(() => ({
+  fetch: vi.fn<(query: string, params?: unknown) => Promise<unknown>>(),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: h.fetch },
+}))
+
 import {
   isWorkshopsEnabledForOrg,
   isWorkshopsEnabledForConference,
@@ -26,6 +44,9 @@ import {
 } from './workshops'
 
 const PLATFORM_SLUG = 'platform-org'
+
+/** The id `PLATFORM_ORG_SLUG` resolves to in the live (uncached) read. */
+const PLATFORM_ORG_ID = 'org-A'
 
 function org(overrides: Partial<Organization> = {}): Organization {
   return {
@@ -36,12 +57,20 @@ function org(overrides: Partial<Organization> = {}): Organization {
   }
 }
 
+/** Point the LIVE slug→id resolution at an org id (or nothing). */
+function platformOrgResolvesTo(orgId: string | null): void {
+  h.fetch.mockResolvedValue(orgId)
+}
+
 const PAST = '2020-01-01T00:00:00.000Z'
 const FUTURE = '2999-01-01T00:00:00.000Z'
 
 beforeEach(() => {
   vi.clearAllMocks()
   vi.stubEnv('PLATFORM_ORG_SLUG', PLATFORM_SLUG)
+  // Default: the slug resolves to nobody, so only tests that opt in are
+  // platform-org tests.
+  platformOrgResolvesTo(null)
 })
 
 afterEach(() => {
@@ -120,28 +149,31 @@ describe('isWorkshopsEnabledForOrg — overrides', () => {
 })
 
 describe('isWorkshopsEnabledForOrg — the platform org keeps working', () => {
-  it('is ENABLED for the org named by PLATFORM_ORG_SLUG, with no override', async () => {
+  it('is ENABLED for the org PLATFORM_ORG_SLUG resolves to, with no override', async () => {
+    platformOrgResolvesTo(PLATFORM_ORG_ID)
     getOrganizationById.mockResolvedValue(org({ slug: PLATFORM_SLUG }))
-    await expect(isWorkshopsEnabledForOrg('org-A')).resolves.toBe(true)
+    await expect(isWorkshopsEnabledForOrg(PLATFORM_ORG_ID)).resolves.toBe(true)
   })
 
   it('is DISABLED for that same org when the contract is unset', async () => {
     vi.stubEnv('PLATFORM_ORG_SLUG', '')
     getOrganizationById.mockResolvedValue(org({ slug: PLATFORM_SLUG }))
-    await expect(isWorkshopsEnabledForOrg('org-A')).resolves.toBe(false)
+    await expect(isWorkshopsEnabledForOrg(PLATFORM_ORG_ID)).resolves.toBe(false)
   })
 
   it('lets an explicit DENY override revoke it from the platform org', async () => {
+    platformOrgResolvesTo(PLATFORM_ORG_ID)
     getOrganizationById.mockResolvedValue(
       org({
         slug: PLATFORM_SLUG,
         featureOverrides: [{ feature: 'workshops', enabled: false }],
       }),
     )
-    await expect(isWorkshopsEnabledForOrg('org-A')).resolves.toBe(false)
+    await expect(isWorkshopsEnabledForOrg(PLATFORM_ORG_ID)).resolves.toBe(false)
   })
 
   it('ignores an EXPIRED deny override on the platform org', async () => {
+    platformOrgResolvesTo(PLATFORM_ORG_ID)
     getOrganizationById.mockResolvedValue(
       org({
         slug: PLATFORM_SLUG,
@@ -150,12 +182,38 @@ describe('isWorkshopsEnabledForOrg — the platform org keeps working', () => {
         ],
       }),
     )
-    await expect(isWorkshopsEnabledForOrg('org-A')).resolves.toBe(true)
+    await expect(isWorkshopsEnabledForOrg(PLATFORM_ORG_ID)).resolves.toBe(true)
+  })
+})
+
+/**
+ * THE SLUG-SPLIT REGRESSION NET (RunKonf/platform#36).
+ *
+ * The grant used to be decided by `org.slug` off the CACHED document — up to 24
+ * hours stale, and writable from another application that could not invalidate
+ * it. These two tests make the cached document and the live resolution
+ * disagree, in both directions, and pin the gate to the live one. Restoring the
+ * cached-slug comparison flips both.
+ */
+describe('isWorkshopsEnabledForOrg — the grant follows the LIVE resolution', () => {
+  it('REVOKES immediately when the slug moved, even while the cached document still says platform', async () => {
+    // Another application renamed the platform org's slug seconds ago: the live
+    // read no longer resolves it, but this app's cached copy is unchanged.
+    platformOrgResolvesTo(null)
+    getOrganizationById.mockResolvedValue(org({ slug: PLATFORM_SLUG }))
+    await expect(isWorkshopsEnabledForOrg(PLATFORM_ORG_ID)).resolves.toBe(false)
+  })
+
+  it('GRANTS immediately when the slug moved TO this org, while the cached document still says otherwise', async () => {
+    platformOrgResolvesTo(PLATFORM_ORG_ID)
+    getOrganizationById.mockResolvedValue(org({ slug: 'stale-old-slug' }))
+    await expect(isWorkshopsEnabledForOrg(PLATFORM_ORG_ID)).resolves.toBe(true)
   })
 })
 
 describe('isWorkshopsEnabledForConference', () => {
   it('keys on the conference OWNER, not the request host', async () => {
+    platformOrgResolvesTo('org-owner')
     getOrganizationById.mockResolvedValue(org({ slug: PLATFORM_SLUG }))
     await expect(
       isWorkshopsEnabledForConference({

--- a/src/lib/features/workshops.ts
+++ b/src/lib/features/workshops.ts
@@ -2,7 +2,7 @@ import 'server-only'
 import { getOrganizationById } from '@/lib/organization/sanity'
 import { resolveCurrentOrgId } from '@/lib/authz/organizer'
 import { computeEntitlements, hasActiveOverride } from './entitlements'
-import { isPlatformOrgSlug } from './platform'
+import { isPlatformOrganization } from './platform'
 
 /**
  * THE single gate for the workshop feature (#689) — the portal, the organizer
@@ -39,9 +39,20 @@ import { isPlatformOrgSlug } from './platform'
  *     data migration.
  *  4. Anything else → DISABLED.
  *
- * The org document read is `getOrganizationById`, cached and tagged
- * `organizationTag(orgId)`, so flipping an override in the platform manager
- * takes effect immediately. Expiry is evaluated per call against a fresh `now`.
+ * TWO READS, DIFFERENT STALENESS ON PURPOSE (RunKonf/platform#36):
+ *
+ *  - `plan` and `featureOverrides` come from `getOrganizationById`, cached and
+ *    tagged `organizationTag(orgId)`. The platform manager revalidates that tag
+ *    when it flips an override, and an external writer can now do the same
+ *    through `POST /api/provisioning/cache/invalidate`, so a change takes
+ *    effect immediately by INVALIDATION.
+ *  - Rule 3's platform-org identity comes from `isPlatformOrganization`, which
+ *    resolves `PLATFORM_ORG_SLUG` UNCACHED on every call. It is not tag-busted
+ *    because it must not DEPEND on being tag-busted: a slug edit in another
+ *    application revokes this grant, and a revocation that waits on a caller
+ *    remembering to invalidate is not a revocation.
+ *
+ * Override expiry is evaluated per call against a fresh `now`.
  *
  * LONGER TERM (out of scope, see #689): if workshops become sellable, WorkOS
  * has no `redirectProxyUrl` equivalent and should be replaced by a signed
@@ -92,7 +103,12 @@ export async function isWorkshopsEnabledForOrg(
     return false
   }
 
-  return isPlatformOrgSlug(org.slug)
+  // ID comparison against the ONE uncached resolver, never `org.slug` off the
+  // cached read above — see `./platform`. This is a grant, and this deployment
+  // has an org that is both the platform org and a tenant, so a slug edit that
+  // revokes it must revoke it NOW rather than whenever the cached document
+  // happens to expire.
+  return isPlatformOrganization(orgId)
 }
 
 /** The minimum conference shape this gate reads — its owning tenant. */

--- a/src/lib/provisioning/constants.ts
+++ b/src/lib/provisioning/constants.ts
@@ -1,15 +1,20 @@
 import type { RateLimitRule } from '@/lib/rate-limit'
 
 /**
- * Machine PROVISIONING API — shared constants (#753).
+ * MACHINE API — shared constants (#753, RunKonf/platform#36).
  *
  * The control panel (`RunKonf/kontroll`, my.konf.app) is not a signed-in
  * platform operator, so it cannot use the concierge tRPC surface. It
  * authenticates with a shared bearer secret instead and reaches the SAME
  * tenant-creation transaction (`@/lib/onboarding/provision`).
+ *
+ * It is now TWO endpoints, not one: kontroll also WRITES `organization`
+ * documents with its own Sanity token, and must be able to bust this app's
+ * caches afterwards (RunKonf/platform#36). Both live behind the same bearer
+ * secret and the same durable limiter, so their constants live together here.
  */
 
-/** Env var holding the shared bearer secret. Unset ⇒ the endpoint is CLOSED. */
+/** Env var holding the shared bearer secret. Unset ⇒ the endpoints are CLOSED. */
 export const PROVISIONING_TOKEN_ENV = 'PROVISIONING_API_TOKEN'
 
 /**
@@ -59,4 +64,45 @@ export const PROVISIONING_CREATE_RULES: readonly RateLimitRule[] = [
   { windowSeconds: 60, max: 5 },
   { windowSeconds: 60 * 60, max: 30 },
   { windowSeconds: 24 * 60 * 60, max: 100 },
+]
+
+/**
+ * ATTEMPT limit for the CACHE-INVALIDATION endpoint, bucketed by client IP and
+ * charged BEFORE the token is checked — the same pre-auth meter provisioning
+ * uses, on its OWN buckets.
+ *
+ * Separate from {@link PROVISIONING_ATTEMPT_RULES} on purpose. Invalidation is
+ * the frequent call (every organizer edit in kontroll) and provisioning is the
+ * rare one; sharing a bucket would let a busy afternoon of settings edits eat
+ * the budget that keeps tenant creation reachable, and would force the rarer,
+ * far more dangerous endpoint to run at the looser cap. Two families, sized for
+ * what each actually does.
+ */
+export const INVALIDATION_ATTEMPT_RULES: readonly RateLimitRule[] = [
+  { windowSeconds: 60, max: 60 },
+  { windowSeconds: 60 * 60, max: 600 },
+  { windowSeconds: 24 * 60 * 60, max: 3000 },
+]
+
+/**
+ * INVALIDATION limit, charged only AFTER authentication, on a single GLOBAL
+ * bucket — global for the same reason creation is: `x-forwarded-for` is
+ * caller-controlled, so a per-IP cap on a post-auth operation is evadable by
+ * rotating a header.
+ *
+ * THIS IS THE ANTI-STAMPEDE BOUND, together with `MAX_INVALIDATION_TARGETS`
+ * (`@/lib/cache/invalidation`): at most 60 calls a minute × 20 targets a call =
+ * 1200 tag revalidations a minute, platform-wide, no matter what the caller
+ * sends. Without both halves a holder of the secret could drop every tenant's
+ * cached reads in a loop and turn the site into an uncached passthrough to
+ * Sanity.
+ *
+ * When it DOES trip, the cost is bounded and self-healing: the caller gets a
+ * 429, and the entry it wanted to bust still revalidates on its own within the
+ * hour (`cacheLife('hours')`). Staleness, never an outage.
+ */
+export const INVALIDATION_RULES: readonly RateLimitRule[] = [
+  { windowSeconds: 60, max: 60 },
+  { windowSeconds: 60 * 60, max: 600 },
+  { windowSeconds: 24 * 60 * 60, max: 5000 },
 ]

--- a/src/lib/provisioning/index.ts
+++ b/src/lib/provisioning/index.ts
@@ -1,11 +1,16 @@
 /**
- * The MACHINE provisioning surface (#753): bearer authentication, abuse
- * control and idempotency for `POST /api/provisioning/organizations`, the
- * endpoint RunKonf/kontroll (my.konf.app) calls to create a tenant.
+ * The MACHINE surface RunKonf/kontroll (my.konf.app) calls: bearer
+ * authentication, abuse control and idempotency for
  *
- * The tenant-creation transaction itself is NOT here — it lives once in
+ *   POST /api/provisioning/organizations     create a tenant            (#753)
+ *   POST /api/provisioning/cache/invalidate  bust this app's caches
+ *                                            (RunKonf/platform#36)
+ *
+ * Neither endpoint's EFFECT lives here. Tenant creation is
  * `@/lib/onboarding/provision`, shared with the operator wizard's tRPC
- * mutation. This directory is only the front door.
+ * mutation; the invalidation vocabulary is `@/lib/cache/invalidation`, built on
+ * the tag builders in `@/lib/cache/tags`. This directory is only the front
+ * door: who may knock, and how often.
  */
 export {
   MAX_IDEMPOTENCY_KEY_LENGTH,
@@ -15,6 +20,8 @@ export {
   PROVISIONING_TOKEN_ENV,
 } from './constants'
 export {
+  chargeInvalidation,
+  chargeInvalidationAttempt,
   chargeProvisioningAttempt,
   chargeProvisioningCreate,
   deleteExpiredProvisioningRateLimits,

--- a/src/lib/provisioning/rateLimit.ts
+++ b/src/lib/provisioning/rateLimit.ts
@@ -2,31 +2,39 @@ import { createHash } from 'crypto'
 import {
   deleteExpiredRateLimitBuckets,
   hitRateLimitBucket,
+  type RateLimitRule,
 } from '@/lib/rate-limit'
 import {
+  INVALIDATION_ATTEMPT_RULES,
+  INVALIDATION_RULES,
   PROVISIONING_ATTEMPT_RULES,
   PROVISIONING_CREATE_RULES,
   PROVISIONING_RATE_LIMIT_TYPE,
 } from './constants'
 
 /**
- * RATE LIMITING for the machine provisioning API.
+ * RATE LIMITING for the machine API kontroll calls.
  *
- * Two buckets, charged at different points in the route (see
- * `src/app/api/provisioning/organizations/route.ts`):
+ * FOUR buckets in two matching pairs — one pair per endpoint, each charged at
+ * the same two points in its route:
  *
- *  - `attempt`, keyed by client IP, charged BEFORE the token is checked. This
- *    is what bounds brute-forcing the shared secret.
- *  - `create`, ONE global bucket, charged AFTER authentication and before the
- *    write. This is what bounds bulk tenant minting if the secret leaks — it is
- *    deliberately not keyed on anything the caller controls.
+ *  - `attempt` / `invalidate-attempt`, keyed by client IP, charged BEFORE the
+ *    token is checked. This is what bounds brute-forcing the shared secret.
+ *  - `create` / `invalidate`, ONE global bucket each, charged AFTER
+ *    authentication and before the effect. This is what bounds bulk tenant
+ *    minting — and bulk cache dropping — if the secret leaks; neither is keyed
+ *    on anything the caller controls.
+ *
+ * The two endpoints share the SECRET but not the BUDGET: separate scopes mean
+ * separate documents, so frequent invalidation traffic can never crowd out the
+ * rare, far more dangerous provisioning call (see the rules in `constants.ts`).
  *
  * FAIL CLOSED IN BOTH DIRECTIONS, unlike the email sign-in limiter. That one
  * fails open on a read outage because locking everybody out of sign-in is worse
- * than an absent cap. Here the guarded operation is a rare privileged write, so
- * refusing it during a store outage costs a retry and nothing else — while
- * proceeding uncapped would leave tenant creation unmetered exactly when the
- * platform is already unhealthy.
+ * than an absent cap. Here the guarded operations are rare and their denial is
+ * cheap — a retried provisioning call, or a cached entry that revalidates on
+ * its own within the hour — while proceeding uncapped would leave them unmetered
+ * exactly when the platform is already unhealthy.
  */
 
 /**
@@ -45,8 +53,19 @@ function bucketId(scope: string, subject: string): string {
   return `provisioningRate.${digest}`
 }
 
+/** The four counter families. The scope is part of the bucket-id digest, so
+ * each one gets its own document even for the same subject. */
+type BucketScope = 'attempt' | 'create' | 'invalidate-attempt' | 'invalidate'
+
+const RULES_BY_SCOPE: Record<BucketScope, readonly RateLimitRule[]> = {
+  attempt: PROVISIONING_ATTEMPT_RULES,
+  create: PROVISIONING_CREATE_RULES,
+  'invalidate-attempt': INVALIDATION_ATTEMPT_RULES,
+  invalidate: INVALIDATION_RULES,
+}
+
 async function hit(
-  scope: 'attempt' | 'create',
+  scope: BucketScope,
   subject: string,
   now: number,
 ): Promise<boolean> {
@@ -63,10 +82,7 @@ async function hit(
     type: PROVISIONING_RATE_LIMIT_TYPE,
     id,
     scope,
-    rules:
-      scope === 'attempt'
-        ? PROVISIONING_ATTEMPT_RULES
-        : PROVISIONING_CREATE_RULES,
+    rules: RULES_BY_SCOPE[scope],
     now,
     label: '[provisioning]',
     onReadFailure: 'deny',
@@ -93,6 +109,25 @@ export async function chargeProvisioningCreate(
   now: number = Date.now(),
 ): Promise<boolean> {
   return hit('create', 'global', now)
+}
+
+/**
+ * Charge the pre-auth attempt bucket for one CACHE-INVALIDATION request. Same
+ * posture as {@link chargeProvisioningAttempt} — a missing IP charges a shared
+ * `unknown` bucket rather than skipping the meter — on its own counter family.
+ */
+export async function chargeInvalidationAttempt(
+  clientIp: string | undefined,
+  now: number = Date.now(),
+): Promise<boolean> {
+  return hit('invalidate-attempt', clientIp?.trim() || 'unknown', now)
+}
+
+/** Charge the single global cache-invalidation bucket. */
+export async function chargeInvalidation(
+  now: number = Date.now(),
+): Promise<boolean> {
+  return hit('invalidate', 'global', now)
 }
 
 /** Delete provisioning buckets whose longest window has fully elapsed. */

--- a/src/server/routers/platform.test.ts
+++ b/src/server/routers/platform.test.ts
@@ -5,8 +5,10 @@
  * property is the SERVER-SIDE platform gate: an ordinary tenant organizer
  * (admin of a non-platform org) gets FORBIDDEN on every procedure, because the
  * client hiding the card is presentation, not security. The gate runs FOR REAL
- * here — `PLATFORM_ORG_SLUG` env + the request org's document slug drive
- * `isPlatformOrganization`; only the external boundaries (the Sanity client,
+ * here — `PLATFORM_ORG_SLUG` env, resolved LIVE to an org id and compared
+ * against the request's org, drives `isPlatformOrganization` (see
+ * RunKonf/platform#36: it must not read through a cache another application can
+ * change but not invalidate); only the external boundaries (the Sanity client,
  * Next's cache API, the domain-conference resolution) are mocked. Also covers
  * the updateEntitlements write path: keyed overrides, empty-optional
  * stripping, and the `organizationTag` revalidation that busts the cached
@@ -41,6 +43,15 @@ const fetchMock = vi.fn(
   async (_query: string, params?: Record<string, unknown>) => {
     if (params && typeof params.orgId === 'string') {
       return ORG_DOCS[params.orgId] ?? null
+    }
+    // The UNCACHED slug→id resolution behind `PLATFORM_ORG_SLUG`
+    // (`getPlatformOrgId`). This — not the org document's cached `slug` — is
+    // what the gate compares against; see RunKonf/platform#36.
+    if (params && typeof params.slug === 'string') {
+      const slug = params.slug
+      return (
+        Object.values(ORG_DOCS).find((org) => org.slug === slug)?._id ?? null
+      )
     }
     return Object.values(ORG_DOCS)
   },
@@ -124,11 +135,27 @@ describe('platform gate', () => {
     const caller = callerFor(['org-A'])
     const orgs = await caller.listOrganizations()
     expect(orgs).toHaveLength(2)
-    // The gate resolved the REQUEST org's document (slug check), not client input.
+    // The gate resolved `PLATFORM_ORG_SLUG` LIVE and compared ids — never a
+    // cached document's slug, and never client input.
     expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining('_id == $orgId'),
-      { orgId: 'org-A' },
+      expect.stringContaining('slug.current == $slug'),
+      { slug: 'platform' },
     )
+  })
+
+  it('REVOKES the moment the slug moves, without waiting for a cached read', async () => {
+    // Another application renamed the platform org's slug: the live resolution
+    // no longer finds it, so operator standing is gone on the next request —
+    // no cache entry stands between the edit and the denial.
+    ORG_DOCS['org-A'].slug = 'renamed'
+    try {
+      const caller = callerFor(['org-A'])
+      await expect(caller.listOrganizations()).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+      })
+    } finally {
+      ORG_DOCS['org-A'].slug = 'platform'
+    }
   })
 })
 

--- a/src/server/routers/workshop.feature.test.ts
+++ b/src/server/routers/workshop.feature.test.ts
@@ -25,6 +25,22 @@ vi.mock('@/lib/conference/sanity', () => ({
     mockGetConference(...args),
 }))
 
+/**
+ * The UNCACHED slug→id read behind `PLATFORM_ORG_SLUG` (RunKonf/platform#36).
+ * The platform-org grant is an ID comparison against this LIVE read, never the
+ * cached org document's `slug` — mocked at the Sanity boundary so the real
+ * `isPlatformOrganization` runs, and set per test so a case has to OPT IN to
+ * being the platform org.
+ */
+const live = vi.hoisted(() => ({ platformOrgId: null as string | null }))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: {
+    fetch: async (_query: string, params?: Record<string, unknown>) =>
+      typeof params?.slug === 'string' ? live.platformOrgId : null,
+  },
+}))
+
 vi.mock('@/lib/workshop/sanity', () => ({
   getAllWorkshopSignups: (...args: unknown[]) =>
     mockGetAllWorkshopSignups(...args),
@@ -58,6 +74,7 @@ function caller() {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  live.platformOrgId = null
   vi.stubEnv('PLATFORM_ORG_SLUG', PLATFORM_SLUG)
   mockGetConference.mockResolvedValue({
     conference: {
@@ -100,6 +117,7 @@ describe('workshop.admin — feature gate', () => {
   })
 
   it('allows the platform org through — unchanged for CND', async () => {
+    live.platformOrgId = ORG_ID
     mockGetOrganizationById.mockResolvedValue({
       _id: ORG_ID,
       name: 'Platform',


### PR DESCRIPTION
Closes the cache-coherence gap tracked as **RunKonf/platform#36** (PRD RunKonf/platform#38, phase 2).

## The problem

Two applications write the same Sanity dataset and only one could invalidate the other's cache. `getOrganizationById` (`src/lib/organization/sanity.ts`) is `'use cache'` with `cacheLife('hours')` — revalidate 1h, **expire 24h** — over `name`, `slug` and `contactEmail`: exactly the fields `RunKonf/kontroll` writes when an organizer edits organization settings. The only `revalidateTag(organizationTag(...))` in the repo was a platform-operator tRPC mutation kontroll cannot reach.

So an organizer edited their organization in kontroll, saw a success message, and their conference site kept serving the old values for up to a day.

## The endpoint

```http
POST /api/provisioning/cache/invalidate
Authorization: Bearer <PROVISIONING_API_TOKEN>
Content-Type: application/json

{ "targets": [
    { "type": "organization", "id": "<organization _id>" },
    { "type": "conference",   "id": "<conference _id>"   },
    { "type": "domain",       "domain": "oslo.example.com" }
] }
```

`200 { invalidated: number, tags: string[] }` · `400 invalid_request` · `401 unauthorized` (uniform) · `429 rate_limited` + `Retry-After` · `500 internal_error`.

- **The caller names documents, never tags.** Which cache tag a target implies is this app's decision (`src/lib/cache/invalidation.ts` delegates to the existing builders in `src/lib/cache/tags.ts`), so the broad `content:*` tags — the ones that bust every tenant at once — are not in the vocabulary and cannot be spelled into existence. The tag structure is extended, not weakened.
- **A target that does not exist is a no-op, not an error.** Nothing in this path reads Sanity: a tag is a pure function of the caller's input, so an unknown id revalidates a tag nothing is stored under and gets the same `200`. There is no lookup, therefore no existence oracle.
- **No `Idempotency-Key`**, unlike provisioning: revalidating a tag twice is indistinguishable from once.

## The token decision: it shares `PROVISIONING_API_TOKEN`

Same caller, same trust boundary, same rotation — and the endpoint is **strictly less powerful** than what that secret already grants. A holder can mint organizations, claim domains (also an OAuth redirect grant) and attach organizers; busting a cache entry is a subset of that blast radius. A second secret would protect nothing an attacker with the first could not already do, while adding a rotation surface and one more env var to forget in a new environment — and a forgotten one here fails closed into silent staleness.

If a caller ever needs invalidation *without* provisioning, split then: `authenticateProvisioningRequest` is a pure function of the headers and takes a different env name in one edit.

## Anti-stampede bounds

- **20 targets max per call** (`MAX_INVALIDATION_TARGETS`) — the bound on one accepted call.
- `invalidate-attempt`, per client IP, charged **before** the token is compared — 60/min, 600/h, 3000/day. Bounds brute-forcing the secret.
- `invalidate`, a **single global** bucket, charged after auth and after validation — 60/min, 600/h, 5000/day. Global because `x-forwarded-for` is caller-controlled.

Together: at most **1200 tag revalidations a minute, platform-wide**. Own buckets on the existing `provisioningRateLimit` document type (so the cleanup cron already covers them) with their own scopes, so invalidation traffic can never crowd out the rarer, far more dangerous provisioning call. Both fail closed; a tripped limit costs a `429` and the entry revalidates on its own within the hour.

## The slug split

`org.slug` is an authorization input, and it was derived **twice with different staleness**: uncached in `getPlatformOrgId()` (`src/lib/authz/platform.ts`, deliberately, and the code says so), and off the **cached** org document in `isWorkshopsEnabledForOrg` and — the same defect, not named in the issue — `isPlatformOrganization`, the platform tRPC router's gate. Production has one organization that is both the platform org and a tenant, so an admin editing its slug in kontroll lost operator standing instantly on one path while the workshop portal, which emails attendees, stayed live on the revoked grant for up to 24 hours.

**Decision: uncached, and only once.** `getPlatformOrgId()` is now the single resolver; `isPlatformOrganization` compares ids against it, and `isWorkshopsEnabledForOrg` ends by calling `isPlatformOrganization`. `isPlatformOrgSlug` and the duplicate `platformOrgSlug` are deleted, so the cached derivation cannot be written back by accident.

Deliberately **not** solved by having kontroll invalidate a tag: a revocation that waits on a caller remembering to call an endpoint is not a revocation. This endpoint is for content, not grants. `plan`/`featureOverrides` stay on the cached read — those *are* tag-invalidated, now from both applications.

**What it costs:** one extra `_id`-only Sanity lookup per gate evaluation, not deduplicated within a request (an admin render that both hides the management card and resolves entitlements pays it twice). It is an indexed point lookup against a document the deployment has exactly one of. If it ever shows up in latency the fix is request-scoped memoization (React `cache()`), which removes the duplicate fetch without reintroducing cross-request staleness — never a `'use cache'` entry.

## Verification

`src/app/api/provisioning/cache/invalidate/coherence.test.ts` runs the whole property: cached read → external write → invalidation call → read returns the new value, plus the negative controls (a different org's target does not bust it; a refused call does not bust it).

**Stated plainly:** `'use cache'` is a compiler directive and nothing transforms it under vitest, so Next's memoization cannot be exercised. The storage and eviction are emulated by a tag-keyed map; the `getOrganizationById` body and its real `cacheTag(...)` calls are real, and the route and its real `revalidateTag(...)` calls are real. What the test pins is the only thing that can actually break — whether those two tag strings are the same string. It does not prove Next honours a tag it was given; that is Next's contract, not ours.

`route.test.ts` covers the guards, all on observable behaviour (status codes and which tags reached `revalidateTag`), never on error messages; the uniform-401 property is checked by comparing whole response bodies to each other.

## Sabotage evidence

Baseline: **473 files / 6800 tests, all passing.**

| Sabotage | Result |
| --- | --- |
| **(a)** `authenticateProvisioningRequest` returns `{ ok: true }` when the secret is unset | **9 failed / 6791 passed.** 4 in the new `route.test.ts` (unset secret; empty/whitespace secret; the identical-body check; the pre-auth meter), 1 in `coherence.test.ts` (a refused call must not have the side effect of a successful one), 4 in the existing provisioning suite. |
| **(b)** `tagForTarget` returns `sanity:org-<id>` instead of `organizationTag(id)` | **8 failed / 6792 passed.** 3 in `coherence.test.ts` — including "serves the NEW value after invalidation", which goes back to serving the stale name — and 5 in `route.test.ts`. |
| **(c)** `isPlatformOrganization` decides from the cached document's `slug` again | **3 failed / 6797 passed.** Both directions of the new `workshops.test.ts` staleness pair (REVOKES when the slug moved away while the cached doc still says platform; GRANTS when it moved to this org while the cached doc says otherwise), plus the platform-router gate test that pins which read the gate makes. |

All three restored; the suite is green.

## Gates

| Gate | Result |
| --- | --- |
| `pnpm test` | 473 files / 6800 tests passed |
| `pnpm typecheck` | clean |
| `npx eslint .` | **0 errors, 216 warnings** — identical to `origin/main` |
| `npx prettier --check .` | clean |
| `pnpm knip` | identical to `origin/main` (only the pre-existing `@workos-inc/node` config hint) |
| `pnpm build` | passes; `/api/provisioning/cache/invalidate` registered as a dynamic route |

Build note: `next build` fails on `origin/main` in this environment too, with `RESEND_API_KEY is not set` — the local keychain has no secrets. Verified green with placeholder values for the env vars the build asserts on.

## Wiring kontroll

After any write to an `organization` document, POST the endpoint with `{ "targets": [{ "type": "organization", "id": <the id you patched> }] }` using the `PROVISIONING_API_TOKEN` it already holds. Treat a `429` as retryable and a `401` as a configuration bug. Contract is documented in `docs/PROVISIONING_API.md`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a bearer-authenticated endpoint for externally invalidating organization, conference, and domain cache tags, and consolidates platform-organization authorization onto the uncached slug resolver.

- Adds bounded, schema-validated cache invalidation with dedicated durable rate-limit scopes.
- Reuses canonical cache-tag builders to keep external invalidations coherent with cached reads.
- Changes workshop and platform gates to compare organization IDs against the live platform-org resolution.
- Extends API documentation and regression coverage for invalidation and stale-slug behavior.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking hardening issue in the invalidation endpoint's spoofable pre-authentication rate-limit key.

The cache and authorization changes preserve fail-closed behavior and canonical tag construction, but unauthenticated callers can rotate `x-forwarded-for` to avoid the endpoint's documented attempt caps.

**Files Needing Attention:** src/app/api/provisioning/cache/invalidate/route.ts, src/lib/provisioning/rateLimit.ts

<details open><summary><h3>Security Review</h3></summary>

The invalidation endpoint's pre-authentication attempt cap can be bypassed by rotating its attacker-controlled `x-forwarded-for` bucket key. **How this was verified:** The route passes the leftmost forwarding-header value directly into the only pre-auth bucket, while the shared helper explicitly identifies that value as attacker-controllable.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/api/provisioning/cache/invalidate/route.ts | Adds the authenticated invalidation workflow; its pre-auth attempt bucket is evadable because it keys solely on a caller-controlled forwarding header. |
| src/lib/cache/invalidation.ts | Defines a narrow, validated target vocabulary and delegates tag construction to the canonical builders. |
| src/lib/provisioning/rateLimit.ts | Adds isolated invalidation limiter scopes, though the attempt scope inherits the spoofable client-address key. |
| src/lib/features/platform.ts | Replaces cached slug comparison with fail-closed ID comparison through the uncached platform resolver. |
| src/lib/features/workshops.ts | Preserves override precedence while moving the default platform grant to the live organization-ID resolution. |
| sanity/schemaTypes/provisioningRateLimit.ts | Extends the existing internal limiter schema's enumerated scopes without changing its stored shape. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Kontroll writes Sanity document] --> B[POST cache invalidation endpoint]
  B --> C[Per-address attempt limit]
  C --> D[Bearer authentication]
  D --> E[Validate up to 20 document targets]
  E --> F[Global invalidation limit]
  F --> G[Canonical tag builders]
  G --> H[revalidateTag]
  H --> I[Next cached read refreshes]
```

<sub>Reviews (1): Last reviewed commit: ["feat(cache): external invalidation endpo..."](https://github.com/cloudnativebergen/website/commit/3b4b15faa6303e4185ca91a724e614359ca56c21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50250308)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Sanity CMS Layer](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/sanity-cms.md)
- Knowledge Base — [Workshop management and volunteer sign-up](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/workshop-volunteer.md)

<!-- /greptile_comment -->