### PR TITLE
fix(tenancy): close the two blind spots in no-unscoped-groq (#676)

### DIFF
--- a/docs/TENANT_SCOPING.md
+++ b/docs/TENANT_SCOPING.md
@@ -113,14 +113,66 @@ Both parts matter, and both were once wrong (#676):
   queries in #675 were written. All three patterns now use `\*\s*\[`.
 - **`_id ==` as well as `_type ==`.** A document id is a **dataset-wide key**, so
   a by-id read is not self-scoping: a client-supplied id resolves documents in
-  any tenant. The rule once required `_type ==` and never examined that class at
-  all. It now matches both, which is why by-id reads in this repo carry an
+  any tenant. The rule once required `_type ==` and never examined `_id` at all.
+  It now matches `_id ==` too, which is why the by-id reads in this repo carry an
   explicit `groq-global:` / `groq-global-scoped:` note saying what constrains
-  them.
+  them. Note the narrowness: **`_id ==` is closed, the `_id` _class_ is not** —
+  `_id in $ids` is still invisible (see below).
 
-Still **not** matched: a root filter opening on anything else, e.g.
-`` `*[references($x)]` `` or `` `*[slug.current == $slug]` ``. Those are visible
-to review but not to the rule.
+### Known gaps — what the rule still cannot see
+
+The patterns are a syntactic first-token match, not a GROQ parser. Everything
+below is a shape that runs across every tenant and is reported **clean**. Each
+is verified by probe, not assumed.
+
+| Shape                                           | Example                                                                            | Why it slips                                       |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `_type` / `_id` not first                       | `` `*[defined(foo) && _type == "x"]` ``                                            | pattern anchors on the token right after `[`       |
+| reversed comparison                             | `` `*["x" == _type]` ``                                                            | pattern expects the field on the left              |
+| non-`==` operators                              | `` `*[_type match "x*"]` ``, `` `*[_type in ["a","b"]]` ``, `` `*[_id in $ids]` `` | pattern requires `==`                              |
+| other opening fields                            | `` `*[references($x)]` ``, `` `*[slug.current == $slug]` ``                        | neither `_type` nor `_id`                          |
+| nested roots in a projection                    | `` `*[_type == "a"]{ "x": *[_type == "b"] }` ``                                    | only the first root filter is examined — see below |
+| a root filter split across string concatenation | `"*" + "[_type == \"x\"]"`                                                         | each literal is checked on its own                 |
+
+**Nested roots, in detail.** The scan reports the FIRST root filter its pattern
+matches and stops, so a nested root is examined only when no _earlier_ root
+filter matched — e.g. under an invisible outer `*[slug.current == …]`. Two
+consequences follow from the fact that "is this inside `scopedFetch`" and "is
+this suppressed" are decided **once for the whole literal**:
+
+- `scopedFetch` prepends its predicate into the first `*[` only, so a nested root
+  inside a scoped body runs **unscoped at runtime** while the rule stays silent;
+- an outer `// groq-global-scoped:` silently covers nested roots it never
+  vouched for.
+
+Measured: **26 literals in `src/` carry 37 such nested roots**, none of which the
+rule examines.
+
+**The live census.** Scanning every string and template literal in `src/`
+(excluding tests and stories) for root filters the `unscoped` pattern cannot
+match yields **9 rule-invisible sites** — all inbound-reference or by-id-set
+reads, and **none dangerous today**:
+
+- `src/server/tenancy.ts` 197, 324, 419, 423, 463 — the tenant guard machinery
+  itself. 197/419/423/463 already carry an explicit `$conferenceId` / `$orgId`
+  predicate the pattern simply cannot parse; 324 is deliberately cross-tenant
+  (it counts OTHER tenants' inbound refs in order to refuse a destructive op).
+- `src/lib/speaker/merge.ts` 664 (`references($loserId)`), 681 (`_id in $ids`) —
+  both ids pass `requireSpeakerInCurrentOrg` at the tRPC entry points, and 681's
+  ids are derived from 664's result, not from input.
+- `src/lib/proposal/data/sanity.ts` 406 — inbound-reference enumeration before a
+  delete; projects `{ _id, _type }` only, never tenant data.
+- `src/lib/gallery/sanity.ts` 572 — `count(*[references($assetId)])`, an
+  is-this-asset-still-used probe that returns a number and must see all refs.
+
+That list is the thing to re-derive when the rule changes; an unquantified "there
+are gaps" caveat is not actionable, a named set of 9 is. Interpolated bodies
+(`` `*[${…}]` ``) are **not** in it — those are caught by `interpolatedFilter`.
+
+Closing the nested-root gap needs per-root-filter suppression and reporting (a
+rule redesign) plus an audit of all 37 sites; it is tracked as a characterization
+test in `eslint-rules/no-unscoped-groq.test.ts` so a future fix flips a
+documented expectation rather than changing behaviour silently.
 
 **Severity is `warn`, deliberately.** The repo carries ~230 pre-existing unscoped
 queries; an error would block CI. Warn makes NEW unscoped queries visible in

--- a/docs/TENANT_SCOPING.md
+++ b/docs/TENANT_SCOPING.md
@@ -98,10 +98,29 @@ A local flat-config rule (`eslint-rules/no-unscoped-groq.js`, registered in
 
 | messageId              | Shape                                                                                      | Why                                                                                                                        |
 | ---------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `unscoped`             | `` `*[_type == "x" && …]` `` with no tenant predicate                                      | reads every tenant                                                                                                         |
+| `unscoped`             | `` `*[_type == "x" && …]` `` or `` `*[_id == $id …]` `` with no tenant predicate           | reads every tenant                                                                                                         |
 | `interpolatedFilter`   | `` `*[${filter}]` `` — the root predicate STARTS with an interpolation                     | the scoping is invisible to review and to the rule; several leaks shipped in this shape                                    |
 | `optionalTenantFilter` | `!defined($conferenceId) \|\| conference._ref == $conferenceId`, or `!defined(conference)` | a CONDITIONAL tenant predicate: no key ⇒ every tenant, and tenant-less documents leak to everyone (the gallery leak, #616) |
 | `nullScope`            | `scopedFetch(client, { orgId: null }, …)`                                                  | the callee looks scoped, but a null tenant key makes the builder drop the predicate                                        |
+
+### What the root-filter patterns match
+
+Both parts matter, and both were once wrong (#676):
+
+- **Whitespace.** `*[`, `* [` and `*  [ ` are the same GROQ. The patterns were
+  once anchored on the literal two characters `*[`, so a spaced root filter
+  matched nothing and was reported clean — which is how the cross-tenant staff
+  queries in #675 were written. All three patterns now use `\*\s*\[`.
+- **`_id ==` as well as `_type ==`.** A document id is a **dataset-wide key**, so
+  a by-id read is not self-scoping: a client-supplied id resolves documents in
+  any tenant. The rule once required `_type ==` and never examined that class at
+  all. It now matches both, which is why by-id reads in this repo carry an
+  explicit `groq-global:` / `groq-global-scoped:` note saying what constrains
+  them.
+
+Still **not** matched: a root filter opening on anything else, e.g.
+`` `*[references($x)]` `` or `` `*[slug.current == $slug]` ``. Those are visible
+to review but not to the rule.
 
 **Severity is `warn`, deliberately.** The repo carries ~230 pre-existing unscoped
 queries; an error would block CI. Warn makes NEW unscoped queries visible in
@@ -180,6 +199,13 @@ annotations sat quietly ineffective in this repo). Blank lines between the block
 and the query are skipped; a line carrying **code** is a hard stop, so a marker
 separated from the query by a statement does not suppress, and neither does one
 placed below it.
+
+The practical consequence: for a query that starts on a **later line than its
+statement** — the common `await client.fetch<T>(` + query-on-the-next-line shape
+— the annotation goes _inside the call, immediately above the query_, not above
+the `const`. Above the `const` the walk hits the `await client.fetch<T>(` opener,
+which is code, and stops. The rule keeps warning when you get this wrong, so a
+misplaced annotation is loud rather than silent.
 
 ## Migration playbook
 

--- a/eslint-rules/no-unscoped-groq.js
+++ b/eslint-rules/no-unscoped-groq.js
@@ -9,8 +9,8 @@
  *
  * FOUR shapes are recognized:
  *
- *  1. `unscoped` — a literal root filter `*[_type == …` with no tenant
- *     predicate. The original check.
+ *  1. `unscoped` — a literal root filter (`*[_type == …` or `*[_id == …`) with
+ *     no tenant predicate. The original check.
  *  2. `interpolatedFilter` — a root filter whose predicate STARTS with an
  *     interpolation (`` *[${filter}] ``). The filter text is not visible to this
  *     rule, so scoping cannot be established; it must be routed through
@@ -27,6 +27,41 @@
  * Severity is WARN, not ERROR: the repo carries a large tail of pre-existing
  * unscoped queries, so an error would block CI. Warn makes NEW ones visible in
  * review and keeps the outstanding count trackable while sites migrate.
+ *
+ * ---------------------------------------------------------------------------
+ * TWO BLIND SPOTS CLOSED (#676, back-ported from RunKonf/kontroll)
+ * ---------------------------------------------------------------------------
+ *
+ * kontroll reads the SAME Sanity dataset and was given a copy of this rule; the
+ * port surfaced two holes in the patterns here, both fixed below.
+ *
+ *  1. WHITESPACE. Every root-filter pattern used to be anchored on the literal
+ *     two characters `*[`. GROQ tolerates space between them, so
+ *
+ *         `* [_type == "staff"]`
+ *
+ *     — one keystroke from the normal form, and how the #675 cross-tenant staff
+ *     leak was actually written — matched NOTHING and was reported as clean.
+ *     Every pattern now uses `\*\s*\[`. This was latent at the time of the fix
+ *     (zero occurrences on main), which is exactly when it is cheapest to close.
+ *
+ *  2. `_id ==` ROOT FILTERS WERE INVISIBLE. The `unscoped` pattern required
+ *     `_type ==`, so an entire class of read —
+ *
+ *         `*[_id == $id][0]{ ... }`
+ *
+ *     — was never examined. A by-id read is NOT self-scoping: `_id` is a
+ *     dataset-wide key, so a client-supplied id resolves documents belonging to
+ *     any tenant. That is precisely the shape ownership checks are made of, and
+ *     precisely the shape a missing ownership check has. The pattern now matches
+ *     `_type` and `_id` alike; the by-id reads that survive are the ones that
+ *     carry an annotation saying which mechanism constrains them.
+ *
+ * NOT back-ported: kontroll's notion of "scoped". It has no ambient tenant and
+ * no query builder — a read there is scoped when the filter binds a proven
+ * `$orgId`/`$userKey` parameter. This repo scopes by the conference/organization
+ * a document REFERENCES, applied by `scopedFetch`. The predicate semantics below
+ * are unchanged; only the shapes the rule can SEE were widened.
  *
  * ---------------------------------------------------------------------------
  * ANNOTATION VOCABULARY — two markers, deliberately distinct
@@ -92,16 +127,20 @@
 
 'use strict'
 
-// Matches a GROQ root filter opener: `*[_type ==` with optional inner spacing.
-const GROQ_ROOT_FILTER = /\*\[\s*_type\s*==/
+// Matches a GROQ root filter opener: `*[_type ==` or `*[_id ==`, with optional
+// whitespace ANYWHERE inside — including between the `*` and the `[`, which is
+// the whitespace hole from #676. `_id` is matched as well as `_type` because a
+// by-id root filter reads the whole dataset by a key that is not tenant-bound.
+const GROQ_ROOT_FILTER = /\*\s*\[\s*_(?:type|id)\s*==/
 
 // A root filter whose predicate begins with an interpolation: `*[${…}`. The
 // placeholder `${}` is what `joinTemplate` below substitutes for expressions.
-const GROQ_INTERPOLATED_FILTER = /\*\[\s*\$\{\}/
+const GROQ_INTERPOLATED_FILTER = /\*\s*\[\s*\$\{\}/
 
 // Any root filter opener at all (used to decide whether an optional-tenant
-// predicate is part of a query rather than incidental text).
-const GROQ_ANY_ROOT = /\*\[/
+// predicate is part of a query rather than incidental text). Loose on purpose;
+// it only ever gates a check that additionally requires a `!defined(...)`.
+const GROQ_ANY_ROOT = /\*\s*\[/
 
 // A tenant predicate that evaporates when its own parameter (or the document's
 // tenant ref) is absent — `!defined($conferenceId) ||`, `!defined(conference) ||`
@@ -178,7 +217,7 @@ module.exports = {
     schema: [],
     messages: {
       unscoped:
-        'Unscoped GROQ query (`*[_type == ...`). Scope it to a tenant via src/lib/sanity/scoped.ts (scopedFetch, or the CONFERENCE_FILTER / ORG_FILTER predicate constants). If it IS tenant-scoped but this rule cannot see how, annotate `// groq-global-scoped: <how>`. If it is intentionally cross-tenant, annotate `// groq-global: <reason>`. See docs/TENANT_SCOPING.md (#616).',
+        'Unscoped GROQ root filter (`*[_type == ...` / `*[_id == ...`). A document id is a dataset-wide key, so a by-id read is NOT self-scoping. Scope it to a tenant via src/lib/sanity/scoped.ts (scopedFetch, or the CONFERENCE_FILTER / ORG_FILTER predicate constants). If it IS tenant-scoped but this rule cannot see how, annotate `// groq-global-scoped: <how>`. If it is intentionally cross-tenant, annotate `// groq-global: <reason>`. See docs/TENANT_SCOPING.md (#616).',
       interpolatedFilter:
         'GROQ root filter built by interpolation (`*[${...}]`) — its tenant scoping is invisible to review and to this rule. Pass the body to scopedFetch, or put the literal `_type == ...` + tenant predicate in the template. If the interpolated predicate provably always carries the tenant, annotate `// groq-global-scoped: <how>`; if the read is intentionally cross-tenant, `// groq-global: <reason>`. See docs/TENANT_SCOPING.md (#616).',
       optionalTenantFilter:

--- a/eslint-rules/no-unscoped-groq.js
+++ b/eslint-rules/no-unscoped-groq.js
@@ -54,8 +54,41 @@
  *     dataset-wide key, so a client-supplied id resolves documents belonging to
  *     any tenant. That is precisely the shape ownership checks are made of, and
  *     precisely the shape a missing ownership check has. The pattern now matches
- *     `_type` and `_id` alike; the by-id reads that survive are the ones that
- *     carry an annotation saying which mechanism constrains them.
+ *     `_type ==` and `_id ==` alike; the by-id reads that survive are the ones
+ *     that carry an annotation saying which mechanism constrains them. Note the
+ *     narrowness: `_id ==` is closed, the `_id` CLASS is not — `_id in $ids` is
+ *     still invisible. See KNOWN GAPS.
+ *
+ * ---------------------------------------------------------------------------
+ * KNOWN GAPS — shapes that read every tenant and are still reported CLEAN
+ * ---------------------------------------------------------------------------
+ *
+ * These patterns are a syntactic first-token match, not a GROQ parser. Verified
+ * by probe, not assumed. Do NOT read a clean run as proof a file is scoped.
+ *
+ *  - `_type` / `_id` NOT the first token:  `*[defined(foo) && _type == "x"]`
+ *  - REVERSED comparison:                  `*["x" == _type]`
+ *  - operators other than `==`:            `*[_type match "x*"]`,
+ *                                          `*[_type in ["a","b"]]`,
+ *                                          `*[_id in $ids]`
+ *  - a root filter opening on another field: `*[references($x)]`,
+ *                                            `*[slug.current == $slug]`
+ *  - NESTED roots in a projection:
+ *        `*[_type == "a"]{ "x": *[_type == "b"] }`
+ *    `checkQuery` reports the FIRST match in the literal and stops, so a nested
+ *    root is examined only when no EARLIER root filter matched. Worse, the
+ *    "inside scopedFetch" and "is suppressed" decisions are made once for the
+ *    whole literal: `scopedFetch` prepends into the first `*[` only, so a nested
+ *    root inside a scoped body runs UNSCOPED with the rule silent, and an outer
+ *    `groq-global-scoped:` covers nested roots it never vouched for. Measured:
+ *    26 literals in src/ carry 37 such nested roots. Closing this needs
+ *    per-root-filter suppression and reporting plus an audit of all 37 — out of
+ *    scope for #676, pinned by a characterization test in the test file.
+ *  - a root filter SPLIT across string concatenation: `"*" + "[_type == \"x\"]"`
+ *
+ * A live census of the sites these gaps hide (9 in src/, none dangerous today)
+ * is kept in docs/TENANT_SCOPING.md → "Known gaps"; re-derive it when these
+ * patterns change.
  *
  * NOT back-ported: kontroll's notion of "scoped". It has no ambient tenant and
  * no query builder — a read there is scoped when the filter binds a proven

--- a/eslint-rules/no-unscoped-groq.test.ts
+++ b/eslint-rules/no-unscoped-groq.test.ts
@@ -443,11 +443,16 @@ ruleTester.run(
         code: "const p = client.patch({ query: '*[_id == $id && status in $stages]' })",
         errors: [{ messageId: 'unscoped' }],
       },
-      // A by-id root filter nested in a projection is a root filter too: it
-      // reads the whole dataset, not the enclosing document.
+      // The rule scans a literal for the FIRST root filter its pattern can
+      // match, wherever that sits — NOT for the outermost one. Here the outer
+      // `*[slug.current ==` is a shape the pattern cannot see (see the known
+      // gaps in docs/TENANT_SCOPING.md), so the single report comes from the
+      // NESTED by-id filter in the projection. That is the one situation in
+      // which a nested root is examined at all; see the characterization test
+      // in the block below for the situation in which it is not.
       {
         filename: 'src/lib/messaging/sanity.ts',
-        code: 'const q = `*[_type == "conversation"]{ "pref": *[_id == ^._id + $suffix] }`',
+        code: 'const q = `*[slug.current == $slug]{ "pref": *[_id == ^._id + $suffix] }`',
         errors: [{ messageId: 'unscoped' }],
       },
     ],
@@ -491,6 +496,28 @@ ruleTester.run(
       {
         filename: 'src/lib/badge/issuance.ts',
         code: 'const q = `*[_id == $id && references($conferenceId)][0]`',
+      },
+      // ---------------------------------------------------------------------
+      // CHARACTERIZATION — a KNOWN GAP, not desired behaviour.
+      //
+      // `scopedFetch` prepends its tenant predicate into the FIRST `*[` only,
+      // so the NESTED root filter below runs unscoped at runtime. The rule
+      // still reports nothing: it decides "inside scopedFetch ⇒ scoped" once
+      // for the whole literal, and its root-filter scan stops at the first
+      // match (the outer one) rather than walking every root in the string.
+      // The same one-shot decision means a `groq-global-scoped:` annotation
+      // aimed at an outer filter silently covers nested ones too.
+      //
+      // Measured: 26 literals in src/ (non-test) carry 37 such nested root
+      // filters the rule never examines. Closing this needs per-root-filter
+      // suppression and reporting — a rule redesign plus an audit of all 37,
+      // deliberately out of scope for #676. This case exists so that fix flips
+      // a documented expectation instead of changing behaviour silently.
+      // Tracked in docs/TENANT_SCOPING.md → "Known gaps".
+      // ---------------------------------------------------------------------
+      {
+        filename: 'src/lib/messaging/sanity.ts',
+        code: 'const r = await scopedFetch(client, { conferenceId }, `*[_type == "conversation"]{ "pref": *[_id == ^._id + $suffix] }`)',
       },
     ],
     invalid: [

--- a/eslint-rules/no-unscoped-groq.test.ts
+++ b/eslint-rules/no-unscoped-groq.test.ts
@@ -424,7 +424,13 @@ ruleTester.run(
       // A document id is a DATASET-WIDE key, so a by-id read is not
       // self-scoping: a client-supplied id resolves documents in any tenant.
       // The rule used to require `_type ==` and never examined this class at
-      // all — 11 live sites, including the tenant guard itself.
+      // all — 10 live query sites, including the tenant guard itself
+      // (`server/tenancy.ts`, which was already annotated; the other 9 were
+      // silently clean and had to be justified when this landed).
+      //
+      // Count them with an AST or by eye, not with a bare grep: the naive
+      // pattern returns 12 because `schedule/sanity.ts` discusses `*[_id ==`
+      // in two of its own comments.
       // ---------------------------------------------------------------------
       {
         filename: 'src/lib/x/sanity.ts',

--- a/eslint-rules/no-unscoped-groq.test.ts
+++ b/eslint-rules/no-unscoped-groq.test.ts
@@ -380,6 +380,136 @@ ruleTester.run(
         code: 'const q = `*[${filter} && references($conferenceId)]`',
         errors: [{ messageId: 'interpolatedFilter' }],
       },
+
+      // ---------------------------------------------------------------------
+      // BLIND SPOT 1 (#676): WHITESPACE BETWEEN `*` AND `[`.
+      //
+      // PERMANENT REGRESSION COVER. `* [_type == "staff"]` is valid GROQ and one
+      // keystroke from the normal form; it is how the #675 cross-tenant staff
+      // leak was actually written, and every pattern in this rule used to be
+      // anchored on the literal two characters `*[`, so the rule reported it
+      // clean. These cases must never be deleted: the repo had ZERO spaced root
+      // filters when the hole was closed, so nothing else would notice a
+      // regression until the next leak shipped.
+      // ---------------------------------------------------------------------
+      {
+        filename: 'src/lib/staff/sanity.ts',
+        code: 'const q = `* [_type == "staff"]`',
+        errors: [{ messageId: 'unscoped' }],
+      },
+      // Whitespace on BOTH sides of the bracket, and more than one space.
+      {
+        filename: 'src/lib/staff/sanity.ts',
+        code: 'const q = `*  [ _type == "staff" ]`',
+        errors: [{ messageId: 'unscoped' }],
+      },
+      // The interpolated shape has the same hole.
+      {
+        filename: 'src/lib/x/sanity.ts',
+        code: 'const q = `* [${filter}]`',
+        errors: [{ messageId: 'interpolatedFilter' }],
+      },
+      // …and so does the loose opener that gates the fail-open check.
+      {
+        filename: 'src/lib/gallery/sanity.ts',
+        code: 'const q = `* [_type == "imageGallery" && (!defined($conferenceId) || conference._ref == $conferenceId)]`',
+        errors: [
+          { messageId: 'unscoped' },
+          { messageId: 'optionalTenantFilter' },
+        ],
+      },
+      // ---------------------------------------------------------------------
+      // BLIND SPOT 2 (#676): `_id ==` ROOT FILTERS.
+      //
+      // A document id is a DATASET-WIDE key, so a by-id read is not
+      // self-scoping: a client-supplied id resolves documents in any tenant.
+      // The rule used to require `_type ==` and never examined this class at
+      // all — 11 live sites, including the tenant guard itself.
+      // ---------------------------------------------------------------------
+      {
+        filename: 'src/lib/x/sanity.ts',
+        code: 'const q = `*[_id == $id][0]{ title }`',
+        errors: [{ messageId: 'unscoped' }],
+      },
+      // Spaced AND by id — both holes in one query.
+      {
+        filename: 'src/lib/x/sanity.ts',
+        code: 'const q = `* [ _id == $id ][0]`',
+        errors: [{ messageId: 'unscoped' }],
+      },
+      // A by-id read inside a `patch({ query })` conditional write.
+      {
+        filename: 'src/lib/sponsor-crm/activity.ts',
+        code: "const p = client.patch({ query: '*[_id == $id && status in $stages]' })",
+        errors: [{ messageId: 'unscoped' }],
+      },
+      // A by-id root filter nested in a projection is a root filter too: it
+      // reads the whole dataset, not the enclosing document.
+      {
+        filename: 'src/lib/messaging/sanity.ts',
+        code: 'const q = `*[_type == "conversation"]{ "pref": *[_id == ^._id + $suffix] }`',
+        errors: [{ messageId: 'unscoped' }],
+      },
+    ],
+  },
+)
+
+// The counterparts: the newly-visible shapes, correctly suppressed. Kept in a
+// second run so the shapes closed by #676 read as one block.
+ruleTester.run(
+  'no-unscoped-groq (#676: shapes the rule could not previously see)',
+  rule as unknown as Parameters<typeof ruleTester.run>[1],
+  {
+    valid: [
+      // A spaced form is still suppressible the normal way — the fix widened
+      // what the rule SEES, it did not change what an annotation clears.
+      {
+        filename: 'src/lib/staff/sanity.ts',
+        code: 'const q = `* [_type == "staff"]` // groq-global: platform staff roster',
+      },
+      // The ownership-check shape: reads the tenant OF an id in order to refuse
+      // it (src/server/tenancy.ts, src/lib/schedule/sanity.ts).
+      {
+        filename: 'src/server/tenancy.ts',
+        code: [
+          '// groq-global: resolves the tenant OF a client-supplied id so the',
+          '// caller can refuse it — scoping would defeat the guard.',
+          'const q = `*[_id == $id][0]{ _type, "orgId": organization._ref }`',
+        ].join('\n'),
+      },
+      // The server-minted-id shape.
+      {
+        filename: 'src/lib/schedule/sanity.ts',
+        code: 'const q = `*[_id == $id][0]{ _rev }` // groq-global-scoped: id is a randomUUID minted here',
+      },
+      // A by-id read routed through the builder needs no annotation at all.
+      {
+        filename: 'src/lib/x/sanity.ts',
+        code: 'const r = await scopedFetch(client, { conferenceId }, `*[_id == $id][0]`, { id })',
+      },
+      // A by-id read with a bound tenant `references()` is a tenant predicate.
+      {
+        filename: 'src/lib/badge/issuance.ts',
+        code: 'const q = `*[_id == $id && references($conferenceId)][0]`',
+      },
+    ],
+    invalid: [
+      // A bare marker with no reason suppresses nothing — unchanged by #676,
+      // pinned here because the new shapes go through the same gate.
+      {
+        filename: 'src/lib/x/sanity.ts',
+        code: ['// groq-global:', 'const q = `*[_id == $id][0]`'].join('\n'),
+        errors: [{ messageId: 'unscoped' }],
+      },
+      // An annotation BELOW the query never reaches it.
+      {
+        filename: 'src/lib/x/sanity.ts',
+        code: [
+          'const q = `* [_id == $id][0]`',
+          '// groq-global-scoped: too late',
+        ].join('\n'),
+        errors: [{ messageId: 'unscoped' }],
+      },
     ],
   },
 )

--- a/src/lib/legal/resolve.ts
+++ b/src/lib/legal/resolve.ts
@@ -20,6 +20,10 @@ async function fetchOrganizationLegal(
   if (!orgRef) return null
   try {
     return await clientReadUncached.fetch<OrganizationLegalFields | null>(
+      // groq-global-scoped: `orgRef` is the request conference's OWN
+      // `organization._ref` (see `resolveLegalConfig`, whose only input is the
+      // conference already resolved for the request host). The id read here IS
+      // the tenant, so the read cannot reach another one.
       `*[_id == $id][0]{
         name,
         contactEmail,

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -105,6 +105,12 @@ const CONVERSATION_PROJECTION = `{
  * filtered; `$speakerId` is the caller. `count()` is 0 or 1 (the id is unique).
  */
 const PREF_ARCHIVED_SUBQUERY =
+  // groq-global-scoped: the matched id is CONSTRUCTED, not supplied — it is
+  // `'convpref.' + ^._id + '.' + $speakerId`, where `^._id` is the conversation
+  // the (already tenant-scoped) outer filter is currently evaluating and
+  // `$speakerId` is the session caller. It can therefore only ever resolve the
+  // one preference document belonging to that conversation and that user; no
+  // input exists that would make it resolve a row in another tenant.
   "*[_id == 'convpref.' + ^._id + '.' + $speakerId && defined(archivedAt) && archivedAt >= ^.lastMessageAt]"
 const NOT_USER_ARCHIVED = `count(${PREF_ARCHIVED_SUBQUERY}) == 0`
 const USER_ARCHIVED = `count(${PREF_ARCHIVED_SUBQUERY}) > 0`

--- a/src/lib/organization/sanity.ts
+++ b/src/lib/organization/sanity.ts
@@ -76,6 +76,13 @@ export async function getOrganizationRefViaParentConference(
   if (!parentId) return null
   try {
     const ref = await clientReadUncached.fetch<string | null>(
+      // groq-global: the same shape as `getDocumentTenant` in
+      // `src/server/tenancy.ts` — a read whose whole job is to RESOLVE THE
+      // TENANT of an arbitrary id, so it must be able to see a document in any
+      // tenant. It projects nothing but the organization ref (the tenant key
+      // itself, no tenant data), and the value is used to STAMP the child being
+      // created so it is born inside the parent's tenant rather than outside
+      // one. Authorization over the parent id belongs to the calling procedure.
       `*[_id == $parentId][0].conference->organization._ref`,
       { parentId },
     )

--- a/src/lib/schedule/sanity.ts
+++ b/src/lib/schedule/sanity.ts
@@ -143,6 +143,12 @@ async function fetchPriorPlacements(
 ): Promise<SlotPlacement[] | null> {
   try {
     const doc = await clientWrite.fetch<PriorScheduleSlots | null>(
+      // groq-global-scoped: `scheduleId` is the id `saveScheduleToSanity` has
+      // ALREADY proven is a `schedule` belonging to the conference being served
+      // — the `*[_id == $id][0]{ _type, conferenceRef, status }` guard below
+      // returns 'Schedule not found or not accessible' before this function is
+      // reached. It is module-private and that post-guard branch is its only
+      // caller, so the id can never be an unvalidated client value here.
       `*[_id == $id][0]{
         date,
         tracks[]{
@@ -267,6 +273,12 @@ export async function saveScheduleToSanity(
         conferenceRef: string | null
         status: string | null
       } | null>(
+        // groq-global: this read IS the ownership check. It resolves the type
+        // and tenant OF a client-supplied id so the comparison below can REFUSE
+        // it; scoping the query would make a foreign id indistinguishable from a
+        // missing one and defeat the guard's purpose. It projects only `_type`,
+        // the conference ref and `status`, and every failure returns the same
+        // generic message, so nothing about a foreign document is disclosed.
         `*[_id == $id][0]{ _type, "conferenceRef": conference._ref, status }`,
         {
           id: schedule._id,
@@ -417,6 +429,11 @@ export async function saveScheduleToSanity(
       // session carries a revision and participates in optimistic concurrency
       // (rather than always taking the unconditional-write path).
       const created = await clientWrite.fetch<{ _rev: string } | null>(
+        // groq-global-scoped: `newId` is a `randomUUID()` minted a few lines
+        // above and committed in the same transaction with
+        // `conference: createReference(conference._id)`. The id never leaves this
+        // function and is never client-supplied, so this read can only resolve
+        // the document this call just created in this tenant.
         `*[_id == $id][0]{ _rev }`,
         { id: newId },
       )

--- a/src/lib/speaker/merge.ts
+++ b/src/lib/speaker/merge.ts
@@ -623,6 +623,13 @@ export interface MergeSpeakersResult {
 
 async function fetchRawSpeaker(id: string): Promise<MergeSpeakerDoc | null> {
   return clientRead.fetch<MergeSpeakerDoc | null>(
+    // groq-global-scoped: a speaker is a GLOBAL person document with no
+    // `conference`/`organization` ref to filter on — tenancy is the
+    // `organizations[]` membership array, which `requireSpeakerInCurrentOrg`
+    // checks. Both `mergeSpeakers` entry points (`speaker.mergePreview` and
+    // `speaker.merge` in `src/server/routers/speaker.ts`) call it on the
+    // survivor AND the loser — the loser with `requireExclusive` — before this
+    // module reads anything, so neither id can be a foreign speaker.
     groq`*[_id == $id][0]`,
     { id },
     { cache: 'no-store' },

--- a/src/lib/speaker/sanity.ts
+++ b/src/lib/speaker/sanity.ts
@@ -352,6 +352,12 @@ async function ensureSpeakerOrgMembership(speakerId: string): Promise<void> {
     const orgRef = await getOrganizationRefForCurrentConference()
     if (!orgRef) return
     const alreadyMember = await clientRead.fetch<boolean>(
+      // groq-global-scoped: the filter DOES carry a tenant predicate —
+      // `$orgRef in organizations[]._ref` — the rule just doesn't recognise
+      // `$orgRef` as a tenant parameter name. `$orgRef` is resolved server-side
+      // from the request domain (`getOrganizationRefForCurrentConference`, one
+      // line above), never from input, so this counts membership in the CURRENT
+      // tenant only.
       `count(*[_id == $speakerId && $orgRef in coalesce(organizations, [])[]._ref]) > 0`,
       { speakerId, orgRef },
     )

--- a/src/lib/sponsor-crm/activity.ts
+++ b/src/lib/sponsor-crm/activity.ts
@@ -208,6 +208,14 @@ export async function promoteToClosedWonOnContract(
   try {
     const result = await clientWrite
       .patch({
+        // groq-global-scoped: not a listing — a conditional patch aimed at ONE
+        // id that every caller has already resolved through a tenant gate.
+        // `sponsor.sendContract` and `contract-send` reach it via
+        // `getSponsorForCurrentConference` / `getSponsorForConference`, and
+        // `signing.submitSignature` via `getSigningContract(token)`, a bearer
+        // lookup — the id is never taken straight from client input. `$id`
+        // matches at most one document, and `status in $earlyStages` narrows it
+        // further, so nothing outside that record can be touched.
         query: '*[_id == $id && status in $earlyStages]',
         params: {
           id: sponsorForConferenceId,

--- a/src/lib/sponsor-crm/activity.ts
+++ b/src/lib/sponsor-crm/activity.ts
@@ -209,13 +209,31 @@ export async function promoteToClosedWonOnContract(
     const result = await clientWrite
       .patch({
         // groq-global-scoped: not a listing — a conditional patch aimed at ONE
-        // id that every caller has already resolved through a tenant gate.
-        // `sponsor.sendContract` and `contract-send` reach it via
-        // `getSponsorForCurrentConference` / `getSponsorForConference`, and
-        // `signing.submitSignature` via `getSigningContract(token)`, a bearer
-        // lookup — the id is never taken straight from client input. `$id`
-        // matches at most one document, and `status in $earlyStages` narrows it
-        // further, so nothing outside that record can be touched.
+        // id. Both LIVE callers resolve that id through a tenant check rather
+        // than taking it from client input:
+        //
+        //   • `sponsor.sendContract` (src/server/routers/sponsor.ts) →
+        //     `getSponsorForCurrentConference`, the ROUTER-side wrapper that
+        //     compares the record's `conference._id` against
+        //     `resolveConferenceId()` and rejects a mismatch. Note the name:
+        //     the lib-level `getSponsorForConference` it wraps is a plain
+        //     unscoped `*[_type == "sponsorForConference" && _id == $id][0]`
+        //     and gates NOTHING on its own. The wrapper is the gate.
+        //   • `signing.submitSignature` (src/server/routers/signing.ts) →
+        //     `getSigningContract(token)`, a bearer lookup on
+        //     `signatureId == $signingToken` where the token is a server-minted
+        //     `randomUUID()`. The id patched here is the matched document's own
+        //     `_id`, so it cannot name a document the bearer did not unlock.
+        //
+        // NOT covered: `generateAndSendContract` in `contract-send.ts` also
+        // calls this function, resolving the id with the UNGATED
+        // `getSponsorForConference` and comparing no tenant at all. It is a
+        // PARKED feature wired to no live route, so it reaches nothing today —
+        // but it MUST grow its own tenant gate before it is wired up. A warning
+        // to that effect sits at its definition.
+        //
+        // `$id` matches at most one document, and `status in $earlyStages`
+        // narrows it further, so nothing outside that record can be touched.
         query: '*[_id == $id && status in $earlyStages]',
         params: {
           id: sponsorForConferenceId,

--- a/src/lib/sponsor-crm/contract-send.ts
+++ b/src/lib/sponsor-crm/contract-send.ts
@@ -32,6 +32,23 @@ export interface SendContractResult {
  *
  * Used both by the admin manual send flow and the automated
  * registration completion flow.
+ *
+ * ⚠️ TENANCY — THIS FUNCTION HAS NO TENANT GATE. It resolves
+ * `sponsorForConferenceId` with `getSponsorForConference`, which is a plain
+ * unscoped by-id read (`*[_type == "sponsorForConference" && _id == $id][0]`)
+ * that compares no conference. Any id reaching here resolves a record in ANY
+ * tenant, and everything downstream — the PDF, the signing send, the CRM patch,
+ * the `promoteToClosedWonOnContract` promotion — then acts on it.
+ *
+ * That is harmless only because the whole contract-signing feature is PARKED
+ * and no live route calls this. BEFORE WIRING IT UP, gate the id: compare the
+ * resolved `sfc.conference?._id` against `resolveConferenceId()` and refuse a
+ * mismatch — i.e. do what `getSponsorForCurrentConference` in
+ * `src/server/routers/sponsor.ts` does for the live `sendContract` path (do not
+ * confuse the two names; they differ by one word and only the router-side
+ * wrapper gates anything). The `groq-global-scoped:` annotation on the patch in
+ * `promoteToClosedWonOnContract` vouches for the two live callers only, and
+ * explicitly not for this one.
  */
 export async function generateAndSendContract(
   sponsorForConferenceId: string,


### PR DESCRIPTION
Closes #676. Phase 3 of RunKonf/platform#38 — making the tenant boundary mechanical rather than conventional.

## What was wrong

`eslint-rules/no-unscoped-groq.js` had two holes, both surfaced by porting the rule into `RunKonf/kontroll` (which reads the **same Sanity dataset**) and running identical snippets through both copies:

| snippet | rule before | rule now |
| --- | --- | --- |
| `*[_type ==` | unscoped ✓ | unscoped ✓ |
| `* [_type ==` | **not flagged** | unscoped ✓ |
| `*  [ _type ==` | **not flagged** | unscoped ✓ |
| `* [${f}]` | **not flagged** | interpolatedFilter ✓ |
| `*[_id == $x]…` | **not flagged** | unscoped ✓ |

1. **Whitespace** (the filed bug). Every root-filter pattern was anchored on the literal two characters `*[`. GROQ tolerates a space, so `* [_type == "staff"]` — how the cross-tenant staff queries in #675 were actually written — matched nothing. **0 occurrences on main today**, which is why the RuleTester cases covering it are permanent: nothing else in the repo would notice a regression.
2. **`_id ==` root filters were invisible** — the wider half, and the live one. The `unscoped` pattern required `_type ==`, so an entire class of read was never examined. A document id is a **dataset-wide key**: a by-id read is not self-scoping. **10 live sites**, and `src/lib/schedule/sanity.ts:62` already carried a comment worrying about exactly this class while nothing enforced it.

Both patterns now use `\*\s*\[` and match `_(?:type|id)\s*==`.

**Not back-ported:** kontroll's notion of "scoped" (explicit `$orgId` / `$userKey`, no ambient tenant). This repo scopes by the conference/organization a document *references*, applied by `scopedFetch`. Only the shapes the rule can **see** were widened; the predicate semantics are unchanged.

## The 10 by-id sites

The 10th (`src/server/tenancy.ts:73`) already carried `groq-global:` and stayed silent. The other 9 were each worked out and annotated with **what actually constrains them**, not annotated away:

**`groq-global:`** — the read IS cross-tenant, and that is correct:
- `src/lib/schedule/sanity.ts` (save guard) — this read *is* the ownership check; scoping it would make a foreign id indistinguishable from a missing one.
- `src/lib/organization/sanity.ts` `getOrganizationRefViaParentConference` — same shape as `getDocumentTenant`; projects the tenant **key**, never tenant data, and the value is used to stamp a child *into* its parent's tenant.

**`groq-global-scoped:`** — constrained through something the rule cannot see:
- `schedule/sanity.ts` `fetchPriorPlacements` — module-private, reached only after the ownership guard above passes.
- `schedule/sanity.ts` create read-back — a `randomUUID()` minted in the same function, committed with the conference ref.
- `legal/resolve.ts` — the id **is** the request conference's own organization.
- `messaging/sanity.ts` archive probe — the id is *constructed* from the outer `^._id` and the session `$speakerId`; no input reaches it.
- `speaker/merge.ts` — both ids pass `requireSpeakerInCurrentOrg` (loser with `requireExclusive`) at both tRPC entry points.
- `speaker/sanity.ts` membership check — it *does* carry a tenant predicate (`$orgRef in organizations[]._ref`); the rule just doesn't know that parameter name.
- `sponsor-crm/activity.ts` — a conditional patch at one id every caller resolved through a tenant gate or a bearer-token lookup.

Nothing had to be annotated dishonestly.

## Dynamic `import()`

In kontroll, `no-restricted-imports` was found not to inspect dynamic `import()` at all, letting `await import('@sanity/client')` walk around the write-client restriction. **This repo has no such boundary to walk around** — `no-restricted-imports`, `no-restricted-syntax` and `import/no-restricted-paths` are absent from `eslint.config.js` (the `import` plugin is registered only to turn `no-anonymous-default-export` off), there is no dependency-cruiser/madge, and `eslint-rules/` contains only this one rule. `no-unscoped-groq` matches **query literals and callee names**, so it is indifferent to how a module was loaded — verified below. Nothing to close; no rule added.

## Verification

Sabotage probe (`src/lib/__sabotage__/probe.ts`, deleted after):

    // (a) spaced root filter
    clientRead.fetch(`* [_type == "staff"]{ name }`)
    // (b) unscoped, unannotated by-id read
    clientRead.fetch(`*[_id == $x][0]{ title }`, { x })
    // (d) dynamic import of the write client, then an unscoped query
    const { clientWrite } = await import('@/lib/sanity/client')
    clientWrite.fetch(`* [_id == $id][0]`, { id: 'x' })

- **New rule:** `✖ 3 problems (0 errors, 3 warnings)` — lines 5, 10, 16, all `unscoped`.
- **Old rule, same file, unchanged:** *no output at all.* Zero problems. That is the whole point: (a) and (b) were silently clean before this PR, and (d) shows the rule never depended on how the client was imported.

Sabotage (c) — remove tenant predicates from genuinely scoped queries in `src/lib/schedule/sanity.ts`:
- `getTalkStatuses`: `scopedFetch(clientWrite, { conferenceId }, …)` → raw `clientWrite.fetch(…)` ⇒ flagged `unscoped` at 47:5.
- `getScheduleStatusById`: dropped `&& conference._ref == $conferenceId` ⇒ flagged `unscoped` at 65:5.

Both restored.

Annotations proven load-bearing: pattern fix alone = **225** warnings with the 9 named sites listed; after annotating = **216**.

## Gates

| gate | before | after |
| --- | --- | --- |
| `npx eslint .` | 0 errors, **216** warnings | 0 errors, **216** warnings |
| `pnpm test` | 474 files, **6823** tests | 474 files, **6838** tests |
| `pnpm typecheck` | pass | pass |
| `npx prettier --check .` | pass | pass |
| `pnpm knip` | exit 0 | exit 0 |

**Warning delta accounted for: +9 newly-visible by-id sites, −9 annotated ⇒ net 0.** Test delta +15 = exactly the 15 RuleTester cases added (rule tests 47 → 62); file count unchanged because they live in the existing test file.

Severity stays `warn` — flipping to `error` against the ~216-warning tail is a separate decision.

## Known remaining gaps (not addressed here)

- Root filters opening on **neither** `_type ==` nor `_id ==` are still invisible, e.g. `` `*[references($loserId) && _id != $loserId]` `` in `src/lib/speaker/merge.ts` (a deliberate global inbound-reference sweep) and `` `*[slug.current == $slug]` `` shapes. Widening to "any `*[`" would be a much larger sweep; kontroll's copy has the same boundary.
- The `scripts/**` allowlist remains a known gap (documented in the rule header) — those run with the write token.


---

## Corrections after adversarial review (commit `a235c4a0`)

Three claims above were truer of the intent than of the code. Fixed; the rule diff is comment-only, behaviour unchanged.

**1. "every caller resolved through a tenant gate" was wrong on two counts.** The annotation on `sponsor-crm/activity.ts` cited `getSponsorForConference` as the gate. It is not one — it is a plain unscoped `*[_type == "sponsorForConference" && _id == $id][0]` that compares no conference. The real gate is the router-side wrapper `getSponsorForCurrentConference` (one word longer), which compares `conference._id` against `resolveConferenceId()`.

Two callers *are* genuinely gated and are now named precisely: `sponsor.sendContract` via that wrapper, and `signing.submitSignature` via `getSigningContract(token)` on a server-minted `randomUUID()`. The third — `generateAndSendContract` in `contract-send.ts` — is gated by **nothing**. It is a parked feature wired to no live route, so it reaches nothing today, but the annotation read as though it were covered. It now says the opposite, and the warning is repeated at that function's own definition. So: "nothing had to be annotated dishonestly" was itself the dishonest bit.

**2. A RuleTester case passed for the wrong reason.** The invalid case commented "a by-id root filter nested in a projection is a root filter too" passed only because `GROQ_ROOT_FILTER.exec()` runs once and matched the **outer** `*[_type ==`; the nested filter was never examined. It survived a sabotage that removed `_id` from the pattern. Replaced with two sabotage-verified cases: an invalid one whose outer filter the pattern cannot see (so the report provably comes from the nested `_id` filter), and a **valid** one labelled a characterization of a known gap — a nested root inside a `scopedFetch` body, which runs unscoped at runtime while the rule stays silent.

**3. `_id ==` is closed; the `_id` *class* is not.** The gap list documented only `references()` and `slug.current`. Probed and added: `_type`/`_id` not the first token (`*[defined(foo) && _type == "x"]`), reversed comparisons (`*["x" == _type]`), `_type match`, `_type in [...]`, `_id in $ids`, nested roots, and split string concatenation.

The unquantified caveat is replaced by a live census: exactly **9 rule-invisible root filters in `src/`** (non-test), each named and assessed, **none dangerous today** — 5 in `server/tenancy.ts` (the guard machinery itself), `speaker/merge.ts` 664/681, `proposal/data/sanity.ts` 406, `gallery/sanity.ts` 572. Separately, 26 literals carry 37 nested roots the rule never examines; closing that needs per-root-filter suppression and reporting plus an audit of all 37, so it is pinned by the characterization test rather than fixed here.

Gates: **474 files / 6,839 tests** (+1, the characterization case), typecheck clean, prettier clean, **216 warnings / 0 errors** — unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR broadens the tenancy lint rule to detect whitespace-separated GROQ root filters and dataset-wide `_id` lookups, with regression tests and documentation for both cases.
- Adds reviewed annotations explaining why existing by-id reads are global or constrained outside the query.
- Preserves the existing tenant-predicate semantics and warning-level rollout.
- Adds permanent RuleTester coverage for detection, suppression, and annotation-placement cases.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no concrete changed-code defect remains.

The regex expansion is covered by targeted tests, existing newly visible by-id queries carry attached explanations, and the reviewed runtime paths support those annotations without changing application behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| eslint-rules/no-unscoped-groq.js | Broadens root-filter recognition to optional whitespace and `_id` equality while preserving existing exemptions and suppression behavior. |
| eslint-rules/no-unscoped-groq.test.ts | Adds focused regression coverage for the two newly recognized query forms and their valid suppression cases. |
| docs/TENANT_SCOPING.md | Documents the expanded detection boundary, annotation placement, and intentionally unsupported root-filter forms. |
| src/lib/schedule/sanity.ts | Annotates ownership probes, guarded prior-placement reads, and server-minted-id read-back without changing runtime behavior. |
| src/lib/organization/sanity.ts | Annotates the intentionally global tenant-key resolution query used to stamp child documents. |
| src/lib/speaker/merge.ts | Documents the caller-side organization and exclusivity checks constraining merge-related global reads. |
| src/lib/sponsor-crm/activity.ts | Documents the upstream tenant or token gates constraining the conditional by-id patch. |
| src/lib/messaging/sanity.ts | Documents how the preference id is derived from a tenant-scoped conversation and session speaker. |
| src/lib/legal/resolve.ts | Documents that the organization id comes from the request host’s resolved conference. |
| src/lib/speaker/sanity.ts | Documents the explicit organization-membership predicate on the by-id query. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tenancy): close the two blind spots ..."](https://github.com/cloudnativebergen/website/commit/08a25887bb3729ab244ec831cbf41a79ae72adb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50261439)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Admin Schedule Editor](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/admin-schedule.md)
- Knowledge Base — [Messaging System](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/messaging-system.md)
- Knowledge Base — [Speaker and Sponsor Management](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/speaker-sponsor-management.md)
</details>

<!-- /greptile_comment -->
