### PR TITLE
chore(deps-dev): bump @sanity/migrate to 8.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   "devDependencies": {
     "@qodo/command": "^0.36.0",
     "@sanity/client": "^7.26.0",
-    "@sanity/migrate": "^6.1.2",
+    "@sanity/migrate": "^8.0.1",
     "@sanity/vision": "^6.8.0",
     "@starefossen/sanity-plugin-inline-svg-input": "^1.3.7",
     "@storybook/addon-docs": "^10.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,8 +220,8 @@ importers:
         specifier: ^7.26.0
         version: 7.26.0
       '@sanity/migrate':
-        specifier: ^6.1.2
-        version: 6.1.2(@oclif/core@4.13.3)(@sanity/cli-core@2.8.0(@noble/hashes@2.2.0)(@types/node@26.1.2)(esbuild@0.28.1)(yaml@2.9.0))(@types/react@19.2.15)(xstate@5.32.5)
+        specifier: ^8.0.1
+        version: 8.0.1(@types/react@19.2.15)(xstate@5.32.5)
       '@sanity/vision':
         specifier: ^6.8.0
         version: 6.9.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sanity@6.9.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)))(@types/node@26.1.2)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rolldown@1.2.2)(styled-components@6.4.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3))(styled-components@6.4.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
@@ -3497,9 +3497,6 @@ packages:
     peerDependencies:
       react: ^18.3 || ^19.0.0-0
 
-  '@sanity/media-library-types@1.4.0':
-    resolution: {integrity: sha512-DZwNT+dDSc1JPW4e7U5C+IJELq5IAeU2A1UcY1079gl+Hakx2USvu5LyY1hrjb1eifRPAhL8uwOVcMNBUmSmzg==}
-
   '@sanity/media-library-types@1.6.0':
     resolution: {integrity: sha512-1Nqw8GSUr7E8AFue9luyTOM4Ev0ZlJ35SHcQrHZ6T68G5llfXw99e3GkLXzk6qYFk9r9fJaBTSpW5IyO2mObZQ==}
 
@@ -3507,26 +3504,9 @@ packages:
     resolution: {integrity: sha512-F/MwFVc3fN8uVvCIGuTxHN5EVo148wLhjL7h/u6wbShWJGMKgcGx0n6MwfCPyi6ftpdvRXsPZVDgZ1GMeeBf2Q==}
     engines: {node: '>=20.0.0'}
 
-  '@sanity/migrate@6.1.2':
-    resolution: {integrity: sha512-PWVZnngPZrjxT8qhvX6qvS3pjHhYVMHC+yOLKaaxvWW7tDwlWVMcIt++0iKtDxqBtg2hMmWS5VQxSX9dJMblSQ==}
-    engines: {node: '>=20.19 <22 || >=22.12'}
-    hasBin: true
-    peerDependencies:
-      '@oclif/core': ^4.10.5
-      '@sanity/cli-core': ^1
-
   '@sanity/migrate@8.0.1':
     resolution: {integrity: sha512-a0soNMIiSBdYgHoRp/Xf02uqmx5DL4Y2qwio4ux43fhxJCfmGkrbevoBt2J1Vf7risT+Gn9n7cL450J1P5j94w==}
     engines: {node: '>=22.12'}
-
-  '@sanity/mutate@0.16.1':
-    resolution: {integrity: sha512-400OooNtiafgJEOCzj0E5atuWlaKp1z6LU/LB/xZUVVywNj3WuT52U6qeVOfGlZeWKhYMCdGFX2ZnMbIrME95w==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      xstate: ^5.19.0
-    peerDependenciesMeta:
-      xstate:
-        optional: true
 
   '@sanity/mutate@0.18.1':
     resolution: {integrity: sha512-28iICKl33s9yr8XtgpoCHOb+l5kKVbd6CpFYi4Vx0fHNZcFiKDGdY+RzZrC34GWqb6M16wkxwtHSVbEmXbfTpw==}
@@ -3582,16 +3562,6 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@sanity/types@5.28.0':
-    resolution: {integrity: sha512-kfLwYx/8q1l76Hqt2dMS/apoXskj6NB2LKnGIa+nDh0JfHArWror1j9Zwqpm/aF1ywS7R0I5xXBsiygCLeGszg==}
-    peerDependencies:
-      '@types/react': ^19.2
-
-  '@sanity/types@5.31.1':
-    resolution: {integrity: sha512-Tl5+C6KTfGO1+QdbHFFaJd9Wyncbz2yznGg1P06JvBfzpexSdBVz476QyDtWBQaCtSkTk8eXzrwPVvW5emA8/g==}
-    peerDependencies:
-      '@types/react': ^19.2
-
   '@sanity/types@6.8.0':
     resolution: {integrity: sha512-VvhWNrupGjXxytz/tRbjOHeEHctUsZqf7AF+eT1MxP0pgOdhtRlXsroV6e4Uayoux/cbbuYTX5JpCnW6cAuZYw==}
     peerDependencies:
@@ -3609,10 +3579,6 @@ packages:
       react: ^18 || >=19.0.0-0
       react-dom: ^18 || >=19.0.0-0
       styled-components: ^5.2 || ^6
-
-  '@sanity/util@5.28.0':
-    resolution: {integrity: sha512-KDR2xMDdUwsgwRyBXEhWLm6yVUVoc/kwbH3ihOBcD+M2LO8Ab6xOaxfB3RIVskQzf13gHt5+GwZaAx9UxsqIkw==}
-    engines: {node: '>=20.19 <22 || >=22.12'}
 
   '@sanity/util@6.9.0':
     resolution: {integrity: sha512-6pvaMgSXnkryWtf+NyBqAQzW6AghRmq7Xpd3cEH+5s8OzB8WlvjH6dkxbw/aYybs+uAf/hOGc8c+P7hkh3fVWg==}
@@ -5652,9 +5618,6 @@ packages:
 
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
-
-  console-table-printer@2.16.0:
-    resolution: {integrity: sha512-X46F33vlP/jVYT3ajukzmOea4Bxet/jRjBKY/fhqr0IvTUNdfBYlrh+Juk0eiZJaTJYrzlEd4RFMF5cQac+m/w==}
 
   console-table-printer@2.16.1:
     resolution: {integrity: sha512-Sc9FRJ4O9xKGNrvulNdPfK5SyBcZ6lcaRnDE4AQ/uw6IDtjHhsqyzzqcnMikjyGaiOOF2tNOKoBhbVjRvFy9Lw==}
@@ -8544,10 +8507,6 @@ packages:
   p-map@3.0.0:
     resolution: {integrity: sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==}
     engines: {node: '>=8'}
-
-  p-map@7.0.4:
-    resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
-    engines: {node: '>=18'}
 
   p-map@7.0.5:
     resolution: {integrity: sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==}
@@ -14234,32 +14193,11 @@ snapshots:
       '@sanity/color': 3.0.8
       react: 19.2.6
 
-  '@sanity/media-library-types@1.4.0': {}
-
   '@sanity/media-library-types@1.6.0': {}
 
   '@sanity/message-protocol@0.24.0':
     dependencies:
       '@sanity/comlink': 4.0.1
-
-  '@sanity/migrate@6.1.2(@oclif/core@4.13.3)(@sanity/cli-core@2.8.0(@noble/hashes@2.2.0)(@types/node@26.1.2)(esbuild@0.28.1)(yaml@2.9.0))(@types/react@19.2.15)(xstate@5.32.5)':
-    dependencies:
-      '@oclif/core': 4.13.3
-      '@sanity/cli-core': 2.8.0(@noble/hashes@2.2.0)(@types/node@26.1.2)(esbuild@0.28.1)(yaml@2.9.0)
-      '@sanity/client': 7.26.0
-      '@sanity/mutate': 0.16.1(xstate@5.32.5)
-      '@sanity/types': 5.31.1(@types/react@19.2.15)
-      '@sanity/util': 5.28.0(@types/react@19.2.15)
-      arrify: 2.0.1
-      console-table-printer: 2.16.0
-      debug: 4.4.3(supports-color@8.1.1)
-      fast-fifo: 1.3.2
-      groq-js: 1.30.3
-      p-map: 7.0.4
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-      - xstate
 
   '@sanity/migrate@8.0.1(@types/react@19.2.15)(xstate@5.32.5)':
     dependencies:
@@ -14276,19 +14214,6 @@ snapshots:
       - '@types/react'
       - supports-color
       - xstate
-
-  '@sanity/mutate@0.16.1(xstate@5.32.5)':
-    dependencies:
-      '@sanity/client': 7.26.0
-      '@sanity/diff-match-patch': 3.2.0
-      '@sanity/uuid': 3.0.3
-      hotscript: 1.0.13
-      lodash: 4.18.1
-      mendoza: 3.0.8
-      nanoid: 5.1.16
-      rxjs: 7.8.2
-    optionalDependencies:
-      xstate: 5.32.5
 
   '@sanity/mutate@0.18.1(xstate@5.32.5)':
     dependencies:
@@ -14436,18 +14361,6 @@ snapshots:
       '@actions/github': 9.1.1
       yaml: 2.9.0
 
-  '@sanity/types@5.28.0(@types/react@19.2.15)':
-    dependencies:
-      '@sanity/client': 7.26.0
-      '@sanity/media-library-types': 1.6.0
-      '@types/react': 19.2.15
-
-  '@sanity/types@5.31.1(@types/react@19.2.15)':
-    dependencies:
-      '@sanity/client': 7.26.0
-      '@sanity/media-library-types': 1.4.0
-      '@types/react': 19.2.15
-
   '@sanity/types@6.8.0(@types/react@19.2.15)':
     dependencies:
       '@sanity/client': 7.26.0
@@ -14477,17 +14390,6 @@ snapshots:
       use-effect-event: 2.0.3(react@19.2.6)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
-
-  '@sanity/util@5.28.0(@types/react@19.2.15)':
-    dependencies:
-      '@date-fns/tz': 1.5.0
-      '@date-fns/utc': 2.1.1
-      '@sanity/client': 7.26.0
-      '@sanity/types': 5.28.0(@types/react@19.2.15)
-      date-fns: 4.4.0
-      rxjs: 7.8.2
-    transitivePeerDependencies:
-      - '@types/react'
 
   '@sanity/util@6.9.0(@types/react@19.2.15)':
     dependencies:
@@ -16680,10 +16582,6 @@ snapshots:
     dependencies:
       ini: 1.3.8
       proto-list: 1.2.4
-
-  console-table-printer@2.16.0:
-    dependencies:
-      simple-wcswidth: 1.1.2
 
   console-table-printer@2.16.1:
     dependencies:
@@ -20034,8 +19932,6 @@ snapshots:
   p-map@3.0.0:
     dependencies:
       aggregate-error: 3.1.0
-
-  p-map@7.0.4: {}
 
   p-map@7.0.5: {}
 


### PR DESCRIPTION
Split out of #773 (dependabot dev-dependencies group). One dependency per PR so the safe parts can land.

## Why this is a dedupe, not a risk

`sanity` 6.9.0 and `@sanity/cli` 7.17.0 **already depend on `@sanity/migrate` ^8.0.1**. Production migrations run through `pnpm sanity migration run` (`.github/workflows/run-migration.yml`), so they have been executing under v8 for a while. The direct devDependency pinned a *second* copy at 6.1.2, and `migrations/002-proposal-desc-to-portable-text/index.ts` imported from that one — v6 node builders handed to a v8 runner. This bump removes the duplicate (the lockfile shrinks by ~105 lines).

## Migration correctness, not just compilation

`scripts/` does not use `@sanity/migrate` at all. The real data migrations live in `migrations/`: 46 of the 47 import from `sanity/migrate` (which re-exports v8), and only `002` imports `@sanity/migrate` directly.

Diffed the two installed versions rather than trusting the changelog:

- identical public API — 44 exports in both, none added, none removed
- `at` / `set` / `unset` / `setIfMissing` / `del` / `patch` / `createIfNotExists` / `createOrReplace` produce byte-identical node structures on both, and `defineMigration` returns the same shape

The v7/v8 breaking changes do not reach us:

| Breaking change | Effect here |
|---|---|
| `@sanity/cli-core` peer moved to ^2 | v6.1.2 asked for ^1 and was already resolving against 2.8.0 — an unmet peer that this bump fixes |
| bundled CLI commands removed | we invoke `sanity migration run`, whose commands come from `@sanity/cli` |
| requires node >=22.12 | CI and Vercel both run node 24 |

## Gates (identical to main)

| Gate | Result |
|---|---|
| `pnpm test` | 474 test files / 6823 tests pass |
| `pnpm typecheck` | clean |
| `npx eslint .` | 0 errors, 216 warnings |
| `pnpm knip` | exit 0 |
| `pnpm format:check` | clean |

## Pre-existing issue found along the way

`pnpm sanity migration list` fails on `main` too, before and after this bump: it loads every migration, and `002` imports `@/lib/proposal`, whose barrel re-exports a `.tsx` file the CLI's loader cannot parse (`ParseError: Unexpected token, expected "," src/lib/proposal/ui/badges.tsx:55:6`). `migration run <id>` for any other migration is unaffected since it loads only the named one. Worth a separate fix.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades the direct `@sanity/migrate` development dependency from 6.1.2 to 8.0.1, aligning it with the version already used by Sanity’s migration tooling.
- Removes the redundant v6 migration package and its obsolete transitive dependency graph.
- Updates the lockfile so direct migration imports and the Sanity runner resolve the same v8 implementation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no changed-code-triggered defects identified.

The dependency resolution is consolidated onto the migration version already used by Sanity, the declared runtime satisfies its Node.js requirement, and the reported compatibility and validation gates cover the affected migration APIs.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Aligns the direct `@sanity/migrate` dependency with the v8 version already used transitively by the migration runner. |
| pnpm-lock.yaml | Resolves `@sanity/migrate` to 8.0.1 and removes the now-unused v6 transitive dependency graph. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps-dev): bump @sanity/migrate to..."](https://github.com/cloudnativebergen/website/commit/350bd44b0890d0672e0d4fa0ec5c7334706722ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50268224)</sub>

<!-- /greptile_comment -->