### PR TITLE
chore(deps-dev): bump msw-storybook-addon to 3.0.0 and migrate the preview

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,12 +1,9 @@
 import type { Preview } from '@storybook/nextjs-vite'
 import type { Decorator } from '@storybook/nextjs-vite'
-import { initialize, mswLoader } from 'msw-storybook-addon'
+import { mswLoader } from 'msw-storybook-addon/csf3'
 import { TRPCDecorator } from './decorators/TRPCDecorator'
 import { SessionDecorator } from './decorators/SessionDecorator'
 import '../src/styles/tailwind.css'
-
-// Initialize MSW
-initialize()
 
 const preview: Preview = {
   parameters: {
@@ -208,7 +205,9 @@ const preview: Preview = {
       )
     }) as Decorator,
   ],
-  loaders: [mswLoader],
+  // msw-storybook-addon 3 creates and starts the worker inside the loader
+  // (v2 started it eagerly via a top-level `initialize()` call).
+  loaders: [mswLoader()],
 }
 
 export default preview

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "http-server": "^14.1.1",
     "knip": "^6.15.0",
     "msw": "^2.15.0",
-    "msw-storybook-addon": "^2.0.7",
+    "msw-storybook-addon": "^3.0.0",
     "playwright": "^1.62.1",
     "prettier": "^3.9.6",
     "prettier-plugin-tailwindcss": "^0.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,8 +307,8 @@ importers:
         specifier: ^2.15.0
         version: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
       msw-storybook-addon:
-        specifier: ^2.0.7
-        version: 2.0.7(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))
+        specifier: ^3.0.0
+        version: 3.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(storybook@10.5.6(@types/react@19.2.15)(prettier@3.9.6)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       playwright:
         specifier: ^1.62.1
         version: 1.62.1
@@ -8215,10 +8215,12 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw-storybook-addon@2.0.7:
-    resolution: {integrity: sha512-TGmlxXy2TsaB6QcClVKRxqvay5f93xoLguHOihRFQ+gIEIyiyvcoQjkEeuOe7Y9qvddzGB1LyFomzPo9/EpnuQ==}
+  msw-storybook-addon@3.0.0:
+    resolution: {integrity: sha512-tyYmYAwSGcfFSHhrE5yzun/OXuVIkBGOt4YTsH5IR94N38F+hzZhvGqe5scu1ENJh/hOApI/8ZRQkWdFNFsKcw==}
+    hasBin: true
     peerDependencies:
-      msw: ^2.0.0
+      msw: '>=2'
+      storybook: '>=9'
 
   msw@2.15.0:
     resolution: {integrity: sha512-2wQAmKkQKxRuXvYJxVhPGG0wZNBQyD06oJvxqw90XqLvptdqxdlHrFUfEteKkpaNORX3Xzc+HtEl/q0nfmN2wQ==}
@@ -19597,10 +19599,10 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw-storybook-addon@2.0.7(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3)):
+  msw-storybook-addon@3.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(storybook@10.5.6(@types/react@19.2.15)(prettier@3.9.6)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
     dependencies:
-      is-node-process: 1.2.0
       msw: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
+      storybook: 10.5.6(@types/react@19.2.15)(prettier@3.9.6)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3):
     dependencies:


### PR DESCRIPTION
Split out of #773 (dependabot dev-dependencies group). Greptile flagged this correctly on that PR: the version bump alone breaks the Storybook preview, which is why #773's Storybook Tests job failed. This carries the migration with it.

## What v3 changed for us

This repo is CSF 3.0, so it takes the CSF 3.0 path from the addon's MIGRATION.md:

- `initialize` is no longer exported from the package root (the root is now the CSF Next `addonMsw` factory), so the top-level `initialize()` call in `.storybook/preview.tsx` had to go. v3 creates and starts the worker lazily inside the loader on the first story.
- `mswLoader` moved to the `msw-storybook-addon/csf3` entrypoint and became a factory: `loaders: [mswLoader]` -> `loaders: [mswLoader()]`.

**The 62 story files that set `parameters.msw` need no changes.** v3's `resolveHandlers` still accepts the `{ handlers: ... }` object form this repo uses, as well as a bare array.

## One deliberate deviation from the README

The v3 README tells CSF 3.0 users to also add `'msw-storybook-addon'` to `.storybook/main.ts` `addons`. Not doing that. The preview-annotation path (`createPreviewAnnotations`) keeps its own worker instance in a different module scope from the loader's, so registering both would call `setupWorker()` twice. The loader alone is sufficient and is what v2 did.

## Behavioural difference worth knowing

v3's unhandled-request filter is `msw`'s `isCommonAssetRequest` plus a Storybook-internal regex. It drops v2's extra entries for `node_modules`, `node-modules`, `hot-update.json` and the JS/TS/font extension pattern, so `storybook dev` can print MSW warnings that v2 swallowed. Console noise only — no test or build effect.

## Gates

| Gate | Result |
|---|---|
| Storybook test-runner (against the production Storybook build) | 290 suites / 1493 tests pass |
| `pnpm test` | 474 test files / 6823 tests pass |
| `pnpm typecheck` | clean |
| `npx eslint .` | 0 errors, 216 warnings |
| `pnpm knip` | exit 0 |
| `pnpm format:check` | clean |

Caveat I cannot close locally: Chromatic. #773's Visual Regression job failed alongside the Storybook one, and I have no way to tell here whether that was the broken preview or something unrelated. Worth an eye on the Chromatic result for this PR specifically.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR upgrades `msw-storybook-addon` to v3 and migrates the Storybook preview to its CSF3 loader API.
- Imports `mswLoader` from the CSF3 entrypoint and invokes its factory.
- Removes obsolete eager MSW initialization because v3 initializes the worker lazily.
- Updates the dependency manifest and lockfile for v3.0.0.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the preview migration matches the v3 CSF3 API and the repository satisfies the updated dependency requirements.

The changed loader import, factory invocation, lazy worker lifecycle, and existing handler shapes align with the resolved package contract, while Storybook-focused CI covers the affected build and runtime path.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .storybook/preview.tsx | Correctly migrates the preview from v2 eager initialization to the v3 CSF3 loader factory while preserving existing handler parameter compatibility. |
| package.json | Upgrades the development dependency to v3.0.0, whose peer requirements are satisfied by the repository’s Storybook and MSW versions. |
| pnpm-lock.yaml | Consistently resolves msw-storybook-addon 3.0.0 with the repository’s pinned MSW and Storybook dependency graph. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps-dev): bump msw-storybook-addo..."](https://github.com/cloudnativebergen/website/commit/4c15720cd5ccae915a3f11a8f855685a3d413e59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50268323)</sub>

<!-- /greptile_comment -->