### PR TITLE
fix(security): close SSRF in proxy-image host allowlist

### DIFF
--- a/src/app/api/proxy-image/route.test.ts
+++ b/src/app/api/proxy-image/route.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+const authMock = vi.fn()
+vi.mock('@/lib/auth', () => ({
+  auth: () => authMock(),
+}))
+
+vi.mock('next/cache', () => ({
+  unstable_noStore: () => {},
+}))
+
+import { GET } from './route'
+
+/**
+ * The route only ever reads `request.url`, so a bare stand-in keeps these tests
+ * free of Next's request plumbing.
+ */
+const requestFor = (target: string) =>
+  ({
+    url: `https://conference.example/api/proxy-image?url=${encodeURIComponent(target)}`,
+  }) as unknown as NextRequest
+
+const imageResponse = () =>
+  new Response(new Uint8Array([1, 2, 3]), {
+    status: 200,
+    headers: { 'content-type': 'image/png' },
+  })
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  authMock.mockResolvedValue({
+    user: { email: 'a@b.c' },
+    speaker: { _id: 's' },
+  })
+  fetchMock = vi.fn().mockResolvedValue(imageResponse())
+  vi.stubGlobal('fetch', fetchMock)
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('/api/proxy-image — host allowlist', () => {
+  it('proxies a genuine cdn.sanity.io image', async () => {
+    const res = await GET(
+      requestFor('https://cdn.sanity.io/images/p/d/abc123-400x400.jpg'),
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('image/png')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      'https://cdn.sanity.io/images/p/d/abc123-400x400.jpg',
+    )
+  })
+
+  it('proxies a Sanity URL that carries transform query params', async () => {
+    const res = await GET(
+      requestFor('https://cdn.sanity.io/images/p/d/abc123-400x400?w=400&q=85'),
+    )
+
+    expect(res.status).toBe(200)
+  })
+
+  it('accepts an uppercase host, since URL parsing lowercases it', async () => {
+    const res = await GET(
+      requestFor('HTTPS://CDN.SANITY.IO/images/p/d/abc123-400x400.jpg'),
+    )
+
+    expect(res.status).toBe(200)
+  })
+
+  /**
+   * The reported bug (#732): `hostname.includes('sanity.io')` is a SUBSTRING
+   * test, so every host below passed it and turned this route into an
+   * authenticated SSRF primitive with `Access-Control-Allow-Origin: *` and a
+   * one-year CDN cache.
+   */
+  it.each([
+    // Contains the allowed domain but does not end with it.
+    'https://sanity.io.attacker.example/x.jpg',
+    'https://attacker-sanity.io-cdn.example/x.jpg',
+    'https://cdn.sanity.io.attacker.example/x.jpg',
+    // Ends with the domain but is not the allowed host.
+    'https://evil.sanity.io/x.jpg',
+    'https://notsanity.io/x.jpg',
+    // Trailing-dot FQDN: resolves the same, but is a different string — the
+    // classic defeat for an `endsWith` allowlist.
+    'https://cdn.sanity.io./x.jpg',
+    // Userinfo trick: everything before `@` is credentials, not the host.
+    'https://cdn.sanity.io@attacker.example/x.jpg',
+    'https://cdn.sanity.io%2f@attacker.example/x.jpg',
+    // Homograph / IDN: parsed to punycode, so it never equals the ASCII host.
+    'https://cdn.sanitỵ.io/x.jpg',
+    // The domain smuggled somewhere other than the host.
+    'https://attacker.example/x.jpg?ref=cdn.sanity.io',
+    'https://attacker.example/cdn.sanity.io/x.jpg',
+    // Internal targets, the payoff of the bug.
+    'http://169.254.169.254/latest/meta-data/',
+    'http://127.0.0.1:6379/x.jpg',
+    'http://localhost/x.jpg',
+  ])('rejects %s without fetching it', async (target) => {
+    const res = await GET(requestFor(target))
+
+    expect(res.status).toBe(403)
+    expect(await res.text()).toBe('Invalid image source')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    // Plaintext to the allowed host is still a downgrade.
+    'http://cdn.sanity.io/x.jpg',
+    // Non-default port on the allowed address.
+    'https://cdn.sanity.io:8080/x.jpg',
+    // Embedded credentials would be forwarded as an Authorization header.
+    'https://user:pass@cdn.sanity.io/x.jpg',
+  ])('rejects %s even though the host matches', async (target) => {
+    const res = await GET(requestFor(target))
+
+    expect(res.status).toBe(403)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it.each(['file:///etc/passwd', 'data:image/png;base64,AAAA'])(
+    'rejects the non-https scheme %s',
+    async (target) => {
+      const res = await GET(requestFor(target))
+
+      expect(res.status).toBe(403)
+      expect(fetchMock).not.toHaveBeenCalled()
+    },
+  )
+
+  it('rejects a target that does not parse as a URL', async () => {
+    const res = await GET(requestFor('not-a-url'))
+
+    expect(res.status).toBe(400)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a missing url parameter', async () => {
+    const res = await GET({
+      url: 'https://conference.example/api/proxy-image',
+    } as unknown as NextRequest)
+
+    expect(res.status).toBe(400)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('/api/proxy-image — redirects', () => {
+  it('does not let the fetch follow redirects', async () => {
+    await GET(requestFor('https://cdn.sanity.io/images/p/d/a-1x1.jpg'))
+
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ redirect: 'manual' })
+  })
+
+  it('refuses a 302 off the allowed host instead of chasing it', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'http://169.254.169.254/latest/meta-data/' },
+      }),
+    )
+
+    const res = await GET(requestFor('https://cdn.sanity.io/images/a-1x1.jpg'))
+
+    expect(res.status).toBe(502)
+    expect(await res.text()).toBe('Image source redirected')
+  })
+
+  it('refuses an opaqueredirect response from a spec-strict runtime', async () => {
+    fetchMock.mockResolvedValue({
+      type: 'opaqueredirect',
+      status: 0,
+      ok: false,
+      headers: new Headers(),
+      arrayBuffer: async () => new ArrayBuffer(0),
+    })
+
+    const res = await GET(requestFor('https://cdn.sanity.io/images/a-1x1.jpg'))
+
+    expect(res.status).toBe(502)
+  })
+})
+
+describe('/api/proxy-image — response hardening', () => {
+  it('serves proxied bytes with sniffing and scripting neutered', async () => {
+    const res = await GET(requestFor('https://cdn.sanity.io/images/a-1x1.svg'))
+
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff')
+    expect(res.headers.get('content-security-policy')).toBe(
+      "default-src 'none'; sandbox",
+    )
+  })
+
+  it('rejects a non-image content type from the allowed host', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('{"secret":1}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    const res = await GET(requestFor('https://cdn.sanity.io/images/a-1x1.jpg'))
+
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('/api/proxy-image — authentication', () => {
+  it('requires a signed-in speaker before touching the network', async () => {
+    authMock.mockResolvedValue(null)
+
+    const res = await GET(
+      requestFor('https://sanity.io.attacker.example/x.jpg'),
+    )
+
+    expect(res.status).toBe(401)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/proxy-image/route.ts
+++ b/src/app/api/proxy-image/route.ts
@@ -3,6 +3,47 @@ import { auth } from '@/lib/auth'
 import { PLATFORM_NAME } from '@/lib/branding/platform'
 import { unstable_noStore as noStore } from 'next/cache'
 
+/**
+ * The ONLY origin this proxy is allowed to fetch. Every Sanity image asset is
+ * served from `cdn.sanity.io` — see `SANITY_CDN_PREFIX` in
+ * `src/lib/sanity/client.ts` and the `remotePatterns` entry in `next.config.ts`
+ * — so an exact host match covers every legitimate caller
+ * (`DownloadableImage`, `SpeakerSharingActions`) while keeping the reachable
+ * surface as small as it can be.
+ */
+const ALLOWED_IMAGE_HOST = 'cdn.sanity.io'
+
+/**
+ * Guards a server-side fetch primitive, so it must fail CLOSED.
+ *
+ * Compare the PARSED hostname for equality — never `includes` (which let
+ * `sanity.io.attacker.example` and `attacker-sanity.io-cdn.example` through)
+ * and never `endsWith` (which lets the trailing-dot FQDN `cdn.sanity.io.`
+ * through, since that resolves to the same name but is a different string).
+ * `URL` already lowercases and punycodes the host, so `CDN.SANITY.IO` matches
+ * and homograph spellings such as `cdn.sanitỵ.io` do not.
+ *
+ * The remaining URL components matter just as much as the host:
+ * - `protocol`: https only. `http:` would downgrade the hop; `file:`/`data:`
+ *   parse with an empty hostname and are rejected by the host check too.
+ * - `port`: default only, so the allowed host cannot be used to reach
+ *   non-HTTPS services bound to other ports on that address.
+ * - `username`/`password`: an `@` in the authority is the classic way to make
+ *   a URL *look* like it points at the allowlisted host. Parsing already
+ *   resolves that correctly (`https://cdn.sanity.io@evil.example/` has hostname
+ *   `evil.example`), but embedded credentials are never legitimate here and
+ *   would be forwarded as an `Authorization` header, so reject them outright.
+ */
+function isAllowedImageTarget(url: URL): boolean {
+  return (
+    url.protocol === 'https:' &&
+    url.hostname === ALLOWED_IMAGE_HOST &&
+    url.port === '' &&
+    url.username === '' &&
+    url.password === ''
+  )
+}
+
 export async function GET(request: NextRequest) {
   noStore()
   try {
@@ -25,7 +66,7 @@ export async function GET(request: NextRequest) {
       return new NextResponse('Invalid URL format', { status: 400 })
     }
 
-    if (!url.hostname.includes('sanity.io')) {
+    if (!isAllowedImageTarget(url)) {
       return new NextResponse('Invalid image source', { status: 403 })
     }
 
@@ -43,15 +84,31 @@ export async function GET(request: NextRequest) {
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), 10000)
 
-    const response = await fetch(imageUrl, {
+    // Fetch the PARSED url, not the raw string, so the request target is
+    // provably the one that passed `isAllowedImageTarget`.
+    const response = await fetch(url, {
       headers: {
         'User-Agent': `${PLATFORM_NAME} Website/1.0`,
         Accept: 'image/*',
       },
       signal: controller.signal,
+      // A host allowlist is worthless if the allowed host can redirect us
+      // somewhere else: one 302 to `http://169.254.169.254/` would hand back an
+      // internal response through this proxy. Do not follow — surface the
+      // redirect as an error instead. Node/undici answers `manual` with the
+      // real 3xx response; a spec-strict runtime answers with an opaqueredirect
+      // (status 0), so check for both.
+      redirect: 'manual',
     })
 
     clearTimeout(timeoutId)
+
+    if (
+      response.type === 'opaqueredirect' ||
+      (response.status >= 300 && response.status < 400)
+    ) {
+      return new NextResponse('Image source redirected', { status: 502 })
+    }
 
     if (!response.ok) {
       return new NextResponse(`Failed to fetch image: ${response.status}`, {
@@ -78,9 +135,18 @@ export async function GET(request: NextRequest) {
     return new NextResponse(imageBuffer, {
       headers: {
         'Content-Type': contentType,
+        // Safe to cache publicly and share cross-origin ONLY because the body
+        // can now come from one public CDN host and is keyed by the full URL —
+        // it never contains anything the caller's session made visible.
         'Cache-Control': 'public, max-age=86400, s-maxage=31536000',
         'Access-Control-Allow-Origin': '*',
         'Content-Length': imageBuffer.byteLength.toString(),
+        // `image/svg+xml` passes the content-type check, and this response is
+        // served from OUR origin — a navigation straight to the proxy URL would
+        // otherwise run the SVG's script as us. Neuter it: no sniffing, no
+        // subresources, and a unique opaque origin if it is ever navigated to.
+        'X-Content-Type-Options': 'nosniff',
+        'Content-Security-Policy': "default-src 'none'; sandbox",
       },
     })
   } catch (error) {


### PR DESCRIPTION
Closes #732.

## The bug

`src/app/api/proxy-image/route.ts` validated the fetch target with
`url.hostname.includes('sanity.io')` — a **substring** test. Every one of these
passed:

- `https://sanity.io.attacker.example/x.jpg`
- `https://attacker-sanity.io-cdn.example/x.jpg`
- `https://cdn.sanity.io.attacker.example/x.jpg`

The proxied body was then returned with `Access-Control-Allow-Origin: *` and
`s-maxage=31536000`, so a signed-in speaker could turn the server into a
durable, publicly readable, cross-origin mirror of anything the runtime could
route to — including link-local metadata endpoints and internal services.

## The fix

Exact equality against a one-entry allowlist:

```ts
const ALLOWED_IMAGE_HOST = 'cdn.sanity.io'

function isAllowedImageTarget(url: URL): boolean {
  return (
    url.protocol === 'https:' &&
    url.hostname === ALLOWED_IMAGE_HOST &&
    url.port === '' &&
    url.username === '' &&
    url.password === ''
  )
}
```

**Why exact, not `endsWith('.sanity.io')`:** the only thing this route is used
for is re-serving Sanity image assets so `html2canvas` can rasterize them
(`DownloadableImage`, `SpeakerSharingActions` are the sole callers). Sanity
serves every asset from `cdn.sanity.io` — the same single host `next.config.ts`
lists in `remotePatterns` and that `SANITY_CDN_PREFIX` in
`src/lib/sanity/client.ts` builds. A suffix check would additionally admit every
other `*.sanity.io` host for no caller's benefit, and is itself defeated by the
trailing-dot FQDN `cdn.sanity.io.`.

Note this does not narrow what works today: hosts such as
`avatars.githubusercontent.com` or `placehold.co` (which `speakerImageUrl` can
return) were already rejected by the old `sanity.io` check, so they are
unchanged — still 403, just for a correctly stated reason.

## Other SSRF levers

| Lever | Status |
| --- | --- |
| Substring host match | **Fixed** — exact `===` on the parsed hostname. |
| Trailing-dot FQDN `cdn.sanity.io.` | **Fixed** — different string, so `===` rejects it. Tested. |
| Userinfo `@` (`https://cdn.sanity.io@attacker.example/`) | **Fixed** — `URL` resolves the real host to `attacker.example`; additionally any non-empty `username`/`password` is rejected so credentials are never forwarded as an `Authorization` header. Tested. |
| Uppercase / mixed case host | **N/A by parsing** — `URL` lowercases; `HTTPS://CDN.SANITY.IO/...` still works. Regression-tested. |
| IDN / homograph (`cdn.sanitỵ.io`) | **N/A by parsing** — `URL` punycodes, so it never equals the ASCII host. Tested. |
| Non-https schemes | **Fixed** — `https:` only. `http://cdn.sanity.io` (downgrade) now 403s; `file:`/`data:` parse with an empty hostname and were already caught, now doubly so. Tested. |
| Non-default port | **Fixed** — `url.port === ''`. Tested. |
| **Redirect following** | **Fixed** — the fetch used the default `redirect: 'follow'`, so one 302 from a permitted host to `http://169.254.169.254/` would have defeated the allowlist entirely. Now `redirect: 'manual'`, and any 3xx (or `opaqueredirect` on a spec-strict runtime) returns 502. Tested both shapes. |
| Raw-string vs parsed target | **Fixed** — `fetch(url)` instead of `fetch(imageUrl)`, so the request target is provably the value that passed validation. |
| DNS rebinding on the allowed host | **N/A** — `cdn.sanity.io` is not attacker-controlled DNS. |
| `Access-Control-Allow-Origin: *` + 1-year public cache | **Kept, deliberately** — the body can now only come from one public CDN and is keyed by the full URL, so it carries nothing the caller's session made visible. Removing the header risks breaking `html2canvas` with `useCORS: true` for no security gain. Comment added at the call site stating the precondition. |
| SVG served from **our** origin | **Fixed (adjacent)** — `.svg` passes the extension and `image/*` content-type checks, so a navigation straight at a proxy URL would run CDN-hosted SVG script in our origin. Response now sets `X-Content-Type-Options: nosniff` and `Content-Security-Policy: default-src 'none'; sandbox`. Neither affects `<img>` rendering. |
| Status-code passthrough as a probe oracle | **Accepted** — with the host pinned to one public CDN there is nothing to probe. |

Auth was already correct: the route 401s before any network access unless
`session.user` **and** `session.speaker` are present. Covered by a test.

## Sabotage proof

New suite: `src/app/api/proxy-image/route.test.ts`, **30 tests**.

1. Reverted the host check to the original `url.hostname.includes('sanity.io')`
   → **9 failed / 21 passed**. The failures are exactly the substring hosts, the
   trailing-dot FQDN, the `evil.sanity.io` suffix case, and the
   scheme/port/credential cases.
2. Restored, then removed `redirect: 'manual'` and the 3xx guard →
   **3 failed / 27 passed**.
3. Restored both → **30 passed**.

## Numbers

| Check | Result |
| --- | --- |
| `pnpm test` | **478 files / 6905 tests passed** (baseline 477 / 6875; +1 file, +30 tests — all new) |
| `pnpm typecheck` | clean, exit 0 |
| `npx prettier --check .` | "All matched files use Prettier code style!" |
| `npx eslint .` | 216 problems — **0 errors**, 216 warnings (unchanged from baseline) |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR closes the proxy-image SSRF path by restricting requests to parsed, credential-free HTTPS URLs on `cdn.sanity.io`, disabling redirect following, and hardening successful image responses.
- Replaces substring hostname matching with an exact URL-component allowlist.
- Fetches the validated `URL` object and rejects redirect responses.
- Adds response protections against MIME sniffing and active SVG navigation.
- Adds focused coverage for malicious targets, redirects, authentication, and response headers.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable regressions identified in the changed proxy behavior.

The route now validates the complete parsed target before network access, prevents fetch redirects from escaping the allowlist, and safely hardens image responses; the tests cover the principal reachable attack paths.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/api/proxy-image/route.ts | Correctly closes the hostname-substring and redirect-based SSRF paths while preserving the intended Sanity image-proxy flow. |
| src/app/api/proxy-image/route.test.ts | Adds comprehensive regression coverage for target validation, redirects, authentication ordering, and response hardening. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Speaker
  participant Proxy as proxy-image route
  participant Auth
  participant Sanity as cdn.sanity.io
  Speaker->>Proxy: "GET ?url=encoded target"
  Proxy->>Auth: Validate signed-in speaker
  Auth-->>Proxy: Authorized
  Proxy->>Proxy: Parse URL and verify HTTPS, exact host, port, credentials
  alt Target rejected
    Proxy-->>Speaker: 403 Invalid image source
  else Target allowed
    Proxy->>Sanity: fetch(validated URL, redirect: manual)
    alt Redirect response
      Sanity-->>Proxy: 3xx / opaqueredirect
      Proxy-->>Speaker: 502 Image source redirected
    else Valid image response
      Sanity-->>Proxy: image bytes
      Proxy-->>Speaker: Image with CORS, cache, nosniff, and CSP headers
    end
  end
```

<sub>Reviews (1): Last reviewed commit: ["fix(security): close SSRF in proxy-image..."](https://github.com/cloudnativebergen/website/commit/4942836bb2409f4a4985050a268cc927e9885570) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50354288)</sub>

<!-- /greptile_comment -->