### PR TITLE
fix(security): require exclusive standing to rewrite a speaker's login email

### DIFF
--- a/src/lib/profile/sanity.ts
+++ b/src/lib/profile/sanity.ts
@@ -12,9 +12,19 @@ import { canonicalEmail } from '../speaker/email'
  * account takeover (an attacker could poison a victim's address into the set and
  * absorb the victim's next verified login).
  *
- * Callers are responsible for proving the caller owns `email` before invoking
- * this (see `isEmailVerifiedForSession`, used by `speaker.updateEmail`). Because
- * the display email is itself a login match key, it must always be verified-owned.
+ * The display `email` is itself a login match key (`findSpeakersByEmails`), so
+ * every caller owes SOME control over who ends up able to sign in as the target:
+ *
+ *  - `speaker.updateEmail` (self-service) proves the CALLER owns the address —
+ *    `isEmailVerifiedForSession`.
+ *  - `speaker.admin.updateEmail` (organizer) cannot prove that; it is contact-
+ *    detail maintenance. It instead proves the TARGET is exclusive to the
+ *    caller's own tenant (`requireSpeakerInCurrentOrg(..., { requireExclusive:
+ *    true })`, #742), so an unverified value can never be pointed at a person
+ *    another organization also holds.
+ *
+ * Do not add a third caller with neither guarantee. #807 tracks removing the
+ * need for the second one by narrowing what counts as a login match key.
  *
  * The value is CANONICALIZED before it is written (#684): trimmed + lowercased,
  * deliberately WITHOUT NFKC, because this field is a real recipient address that

--- a/src/lib/speaker/sanity.ts
+++ b/src/lib/speaker/sanity.ts
@@ -443,14 +443,30 @@ export async function getOrCreateSpeaker(
 
   // 3. Attempt to match an existing speaker by verified email intersection.
   //
-  //    SECURITY — stored-side-verified invariant: matching here is safe because
-  //    every stored match key is verified-owned. `knownEmails` is written only
-  //    by this login path from `computeVerifiedEmails` output (never from
-  //    `updateEmail`/admin edits). The legacy display `email` is also safe: it
-  //    is either a pre-existing value seeded from the provider primary at
-  //    creation (verified), or set post-hardening only after ownership was
-  //    proven (login primary, or `speaker.updateEmail` which now requires the
-  //    caller's provider-verified set). So both keys are kept.
+  //    SECURITY — the two stored match keys do NOT have the same standing, and
+  //    this comment used to claim they did. Read it as a statement of what each
+  //    key is actually worth:
+  //
+  //    `knownEmails` is verified-owned as far as THIS path is concerned: it is
+  //    written here from `computeVerifiedEmails` output, never by `updateEmail`
+  //    or an admin edit. (The speaker MERGE is a second writer and does not hold
+  //    to that — it promotes both documents' display emails into the set. That
+  //    is #808, not something this path can defend against.)
+  //
+  //    The legacy display `email` is NOT, in general. Most values are fine (a
+  //    provider primary seeded at creation, or `speaker.updateEmail`, which
+  //    requires the caller's provider-verified set), but `speaker.admin.
+  //    updateEmail` sets this field from ORGANIZER input with no proof of
+  //    ownership — it exists so an organizer can maintain contact details for a
+  //    speaker they administer. An unverified value therefore reaches an
+  //    authentication decision here, which is the wrong shape.
+  //
+  //    That endpoint is now scoped to speakers EXCLUSIVE to the organizer's own
+  //    tenant (#742), so the primitive cannot cross a tenant boundary or reach
+  //    a person another org also holds. Both keys are kept on that basis.
+  //    Whether the display `email` should be a match key at all — and how to
+  //    stop being one without breaking the invitee-claim flow that depends on
+  //    it — is #807.
   if (verifiedIncoming.length > 0) {
     const { speakers, err } = await findSpeakersByEmails(verifiedIncoming)
     if (err) {

--- a/src/server/routers/speaker.ts
+++ b/src/server/routers/speaker.ts
@@ -626,14 +626,38 @@ export const speakerRouter = router({
       )
       .mutation(async ({ input }) => {
         try {
-          // OWNERSHIP (#730): `input.id` is client input and
-          // `updateProfileEmail` patches it directly.
-          await requireSpeakerInCurrentOrg(input.id)
-          // Organizer action: set the speaker's display `email` only. Post-C1,
-          // updateProfileEmail no longer writes `knownEmails`, so an admin edit
-          // can never inject an address into the verified match-set. (The admin
-          // is not required to prove ownership — this is a trusted organizer
-          // correcting contact details, not the self-service path.)
+          // OWNERSHIP (#742): `input.id` is client input and
+          // `updateProfileEmail` patches it directly — but the ORDINARY
+          // standing that guards the rest of this router is NOT enough here,
+          // because this endpoint writes a LOGIN MATCH KEY.
+          //
+          // The display `email` is one of the two keys `findSpeakersByEmails`
+          // resolves a sign-in against (`src/lib/speaker/sanity.ts`), and this
+          // endpoint deliberately does not make the organizer prove they own
+          // the address. So "may administer" would otherwise mean "may become":
+          // point a speaker's display email at an address you control, sign in
+          // with it (OAuth or the email link), and the login path links your
+          // provider account into their document.
+          //
+          // Ordinary standing is membership OR participation — and BOTH accrue
+          // to any tenant the person merely signs into or submits to
+          // (`ensureSpeakerOrgMembership` stamps the current org on every
+          // login). That made this a CROSS-TENANT escalation: an organizer of A
+          // could take over the account of anyone who had ever touched A,
+          // including an organizer of B, inheriting their `organizerOrgIds`.
+          //
+          // `requireExclusive` is therefore the right standing, exactly as for
+          // `delete` and `merge`: this org may rewrite the identity of a person
+          // who is theirs ALONE, never of one another tenant also holds. Its
+          // reference-graph arm is stricter than a single-field patch strictly
+          // needs, but it errs closed with an actionable message and keeps this
+          // guard identical to its destructive siblings.
+          //
+          // Post-C1, `updateProfileEmail` no longer writes `knownEmails`, so an
+          // admin edit still cannot inject an address into the VERIFIED
+          // match-set. Whether the display `email` should be a match key at all
+          // is tracked separately — see #807.
+          await requireSpeakerInCurrentOrg(input.id, { requireExclusive: true })
           const { error } = await updateProfileEmail(input.email, input.id)
 
           if (error) {

--- a/src/server/routers/tenancy.writes.test.ts
+++ b/src/server/routers/tenancy.writes.test.ts
@@ -46,6 +46,8 @@ const h = vi.hoisted(() => ({
   probes: 0,
   /** How many documents OUTSIDE the request org reference the id under test. */
   foreignReferencingDocs: 0,
+  /** Make the participation probe throw, so fail-closed can be asserted. */
+  failParticipationProbe: false,
   updateSpeaker: vi.fn(),
   getSpeaker: vi.fn(),
   mergeSpeakers: vi.fn(),
@@ -88,6 +90,7 @@ vi.mock('@/lib/sanity/client', () => {
     // test can make participation real rather than asserted.
     if (query.includes('references($speakerId)')) {
       h.probes++
+      if (h.failParticipationProbe) throw new Error('probe unavailable')
       const speakerId = String(params.speakerId)
       const orgIds = new Set<string>()
       for (const doc of h.docs.values()) {
@@ -328,6 +331,19 @@ function seed() {
     _type: 'speaker',
     organizations: [{ _ref: ORG_A }, { _ref: ORG_B }],
   })
+  // #742: a person ORG_A legitimately administers (they are a member here) who
+  // ALSO has a talk at ORG_B. Ordinary standing admits them — which is the whole
+  // point, ORG_A must be able to list and edit them — but ORG_B holds the same
+  // identity, so ORG_A must not be able to re-point their login match key.
+  h.docs.set('speaker-A-also-at-B', {
+    _type: 'speaker',
+    organizations: [{ _ref: ORG_A }],
+  })
+  h.docs.set('talk-B2', {
+    _type: 'talk',
+    organization: { _ref: ORG_B },
+    speakers: [{ _ref: 'speaker-A-also-at-B' }],
+  })
   // #731 F2: a person with a TALK at ORG_B but NO membership anywhere — the
   // population `ensureSpeakerOrgMembership`'s swallowed failures and the
   // pre-044 dataset produce. Exclusivity used to ignore them entirely.
@@ -355,6 +371,7 @@ beforeEach(() => {
   h.writes.length = 0
   h.probes = 0
   h.foreignReferencingDocs = 0
+  h.failParticipationProbe = false
   seed()
   host(ORG_A)
   h.getSpeaker.mockResolvedValue({ speaker: { _id: 'speaker-A' }, err: null })
@@ -540,6 +557,7 @@ describe('speaker admin mutations refuse a foreign id (#730)', () => {
     await expect(
       speaker().admin.updateEmail({ id: 'speaker-B', email: 'x@example.com' }),
     ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(h.updateProfileEmail).not.toHaveBeenCalled()
     expect(h.writes).toEqual([])
   })
 
@@ -856,6 +874,103 @@ describe('destructive speaker ops see participation, not just membership (#731 F
       }),
     ).rejects.toMatchObject({ code: 'NOT_FOUND' })
     expect(h.mergeSpeakers).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * #742 — rewriting a LOGIN MATCH KEY needs the exclusive standing, not the
+ * ordinary one.
+ *
+ * `speaker.admin.updateEmail` sets the display `email`, and
+ * `findSpeakersByEmails` resolves a sign-in against that field. The endpoint
+ * deliberately does not make the organizer prove they own the address, so
+ * "may administer this person" would otherwise read as "may become this
+ * person": point the display email at an address you control, sign in with it,
+ * and the login path links your provider account into their document.
+ *
+ * Ordinary standing is membership OR participation, and BOTH accrue to any
+ * tenant the person merely signs into — `ensureSpeakerOrgMembership` stamps the
+ * current org on every login. That made it a CROSS-TENANT escalation: an
+ * organizer of A could take over anyone who had ever touched A, including an
+ * organizer of B, inheriting their `organizerOrgIds`.
+ *
+ * These assertions must fail if `{ requireExclusive: true }` is weakened back to
+ * plain `requireSpeakerInCurrentOrg(input.id)` — every subject below satisfies
+ * the ordinary predicate and is refused only by exclusivity.
+ */
+describe('updateEmail needs EXCLUSIVE standing — it writes a login key (#742)', () => {
+  it('refuses a person ORG_B also holds, even though ORG_A administers them', async () => {
+    // Membership in ORG_A: the ordinary guard admits them. A talk at ORG_B: the
+    // same identity answers to another tenant, so their login key is not ours
+    // to re-point.
+    await expect(
+      speaker().admin.updateEmail({
+        id: 'speaker-A-also-at-B',
+        email: 'attacker@example.com',
+      }),
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('also belongs to another organization'),
+    })
+    expect(h.updateProfileEmail).not.toHaveBeenCalled()
+    expect(h.writes).toEqual([])
+  })
+
+  it('refuses a person who is an explicit member of BOTH tenants', async () => {
+    await expect(
+      speaker().admin.updateEmail({
+        id: 'speaker-shared',
+        email: 'attacker@example.com',
+      }),
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('also belongs to another organization'),
+    })
+    expect(h.updateProfileEmail).not.toHaveBeenCalled()
+    expect(h.writes).toEqual([])
+  })
+
+  it('refuses while another tenant’s documents still reference them', async () => {
+    h.foreignReferencingDocs = 1
+    await expect(
+      speaker().admin.updateEmail({
+        id: 'speaker-A',
+        email: 'attacker@example.com',
+      }),
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('still reference this speaker'),
+    })
+    expect(h.updateProfileEmail).not.toHaveBeenCalled()
+    expect(h.writes).toEqual([])
+  })
+
+  it('refuses when exclusivity cannot be PROVEN — fail closed', async () => {
+    // The participation probe failing must not read as "belongs to nobody
+    // else". `speakerParticipationOrgIds` returns null on a read error.
+    h.failParticipationProbe = true
+    await expect(
+      speaker().admin.updateEmail({
+        id: 'speaker-A',
+        email: 'attacker@example.com',
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    expect(h.updateProfileEmail).not.toHaveBeenCalled()
+    expect(h.writes).toEqual([])
+  })
+
+  it('still updates a speaker this org holds ALONE — the guard is not a blanket deny', async () => {
+    await expect(
+      speaker().admin.updateEmail({
+        id: 'speaker-A',
+        email: 'Fixed@Example.COM',
+      }),
+    ).resolves.toEqual({ success: true, email: 'fixed@example.com' })
+    expect(h.updateProfileEmail).toHaveBeenCalledWith(
+      'Fixed@Example.COM',
+      'speaker-A',
+    )
+    expect(h.writes.map((w) => w.op)).toEqual(['updateProfileEmail'])
   })
 })
 

--- a/src/server/tenancy.ts
+++ b/src/server/tenancy.ts
@@ -235,6 +235,15 @@ export async function requireDocumentsInCurrentConference(
  * computed over the SAME dimensions as ownership (membership ∪ participation):
  * checking only membership left the pre-backfill population — a speaker with a
  * talk at B but no B membership — mergeable and deletable by A.
+ *
+ * IT IS NOT ONLY FOR DESTRUCTIVE OPS (#742). A write that changes WHO A
+ * DOCUMENT IS needs the same standing as one that removes it. `speaker.admin.
+ * updateEmail` sets the display `email`, which `findSpeakersByEmails` accepts
+ * as a login match key, so ordinary standing there would mean "an organizer of
+ * any tenant this person has ever signed into may become them". Ordinary
+ * standing is deliberately wide — `ensureSpeakerOrgMembership` stamps the
+ * current org on every login — and wide is right for administering a person,
+ * wrong for re-pointing their identity.
  */
 export async function requireSpeakerInCurrentOrg(
   id: string,
@@ -276,8 +285,8 @@ export async function requireSpeakerInCurrentOrg(
       throw new TRPCError({
         code: 'BAD_REQUEST',
         message:
-          'This speaker also belongs to another organization. Removing them ' +
-          'here would delete a person another tenant still owns.',
+          'This speaker also belongs to another organization. Only an ' +
+          'organization that holds them alone may change or remove them.',
       })
     }
 
@@ -295,7 +304,8 @@ export async function requireSpeakerInCurrentOrg(
         code: 'BAD_REQUEST',
         message:
           'Another organization’s documents still reference this speaker. ' +
-          'Removing them here would rewrite that tenant’s data.',
+          'Only an organization that holds them alone may change or remove ' +
+          'them.',
       })
     }
   }


### PR DESCRIPTION
Closes #742.

## What was already fixed, and what was not

#742 was filed at 08:07 on 2026-08-04; #731 merged at 11:48 the same day and swept the cross-tenant write class across every router, including this endpoint. So the literal hole in the issue — `speaker.admin.updateEmail` patching an unscoped `input.id` — has been closed since then, and `tenancy.writes.test.ts` already pins it.

What #731 gave it was **ordinary** standing, and the issue anticipated that this endpoint needs the narrower one:

> Note the ownership predicate there admits participation as well as membership […] so this endpoint likely needs the *narrower* standing, not the wider one.

That is what remained live, and it is what this PR fixes.

## The residual hole

`speaker.admin.updateEmail` writes the display `email`, which `findSpeakersByEmails` accepts as a login match key, and it deliberately does not make the organizer prove they own the address ("the admin is not required to prove ownership — this is a trusted organizer correcting contact details").

Ordinary standing is membership **or** participation, and `ensureSpeakerOrgMembership` stamps the current org on **every login**. So the gate read as: *any organizer of any tenant a person has ever signed into may become that person.*

1. Victim V organizes tenant B and has, at some point, signed into tenant A's site — so `V.organizations` contains A.
2. Attacker X organizes A. `speaker.admin.updateEmail({ id: V, email: 'x2@attacker.example' })` passes the guard.
3. X signs in as `x2@attacker.example` (OAuth, or the #740 email link, which reaches the same matcher via `getOrCreateSpeakerForVerifiedEmail`).
4. `findSpeakersByEmails` returns V; `linkAndAccrue` welds X's provider account onto V's document. X's session now carries V's `organizerOrgIds` — including tenant B.

## The fix

One line, the existing helper, the same shape `delete` and `merge` already use:

```ts
await requireSpeakerInCurrentOrg(input.id, { requireExclusive: true })
```

An org may re-point the identity of a person it holds **alone**; never of one another tenant also holds. Exclusivity is computed over membership ∪ participation and fails closed when it cannot be proven.

Its reference-graph arm is stricter than a single-field patch strictly needs — that arm exists to bound what the merge transaction touches — but it errs closed with an actionable message and keeps this guard identical to its siblings, which seemed worth more than a new option on the helper.

The organizer's fallback when refused is the self-service path (`speaker.updateEmail`), which already requires the caller's provider-verified set.

Also in here:

- Corrects the **stored-side-verified invariant** comment in `getOrCreateSpeaker`, which enumerated the writers of the display `email` to justify matching on it and missed this one. It now says what each key is actually worth.
- Makes the two shared exclusivity refusals operation-neutral ("Only an organization that holds them alone may change or remove them") now that a non-destructive caller shares them. No test or UI asserted the old strings.

## Sabotage

Targeting exact strings, not line numbers.

| state | `tenancy.writes.test.ts` |
|---|---|
| guard present | **55 passed** |
| weakened to `requireSpeakerInCurrentOrg(input.id)` | **4 failed / 51 passed** |
| guard deleted entirely | **6 failed / 49 passed** |

The four that fail on weakening are the new exclusivity cases — each subject satisfies the ordinary predicate and is refused only by exclusivity, so the refusal is provably about scoping and not incidental. Deleting the guard adds the pre-existing cross-tenant case and the positive case (caught by the suite's `afterEach` unguarded-write tripwire).

## Tests

Five cases in `src/server/routers/tenancy.writes.test.ts`, plus one new fixture pair (`speaker-A-also-at-B` + a talk at ORG_B) and a `failParticipationProbe` switch on the fake dataset:

- a person ORG_B also holds, whom ORG_A legitimately administers — the sharp case
- a person who is an explicit member of both tenants
- another tenant's documents still referencing them
- the participation probe failing — must not read as "belongs to nobody else"
- the positive case: a speaker this org holds alone still updates, so the guard is not a blanket deny

## Filed, not fixed here

**#807 — the display `email` is a login match key but has an unverified writer.** The root question #742 raised. Narrowing the matcher is not a one-liner: `speaker.admin.create` writes a speaker's email before that person has ever signed in, and the display-email arm is the only thing that lets their first sign-in resolve to the record the organizer prepared. Removing it reintroduces #267/#440 duplicates at exactly that moment. The issue lays out three options with their costs.

**#808 — SECURITY: speaker merge injects an attacker-chosen address into the victim's VERIFIED match-set.** Found while checking siblings, and **worse than what this PR fixes**. `merge`'s loser arm is `requireExclusive`, but its **survivor** arm is ordinary standing, and `computeSurvivorFieldMerge` unions **both display emails** into the survivor's `knownEmails`. So: create a throwaway speaker with `attacker@evil.example` (allowed, arbitrary email, exclusive to your org), merge it into any speaker you have ordinary standing over, and the attacker's address is now in the victim's *verified* set. It survives every narrowing #807 is considering, because it writes the other key.

It is the same one-line shape (`{ requireExclusive: true }` on the survivor arm), but the right answer is genuinely ambiguous — tightening the survivor blocks de-duplicating exactly the cross-tenant people most likely to have duplicates, whereas not promoting display emails into `knownEmails` fixes it with no loss of reach but changes documented merge semantics. That is a product decision, not a scoping fix, so it is filed with the full chain and both options rather than bundled here. **Worth prioritising ahead of #807.**

## Numbers

Re-derived on `origin/main` @ `2cd68fdb`.

| | baseline | this branch |
|---|---|---|
| `pnpm test` | 477 files / 6875 tests | **477 files / 6880 tests**, all passing |
| `pnpm typecheck` | clean | **clean** |
| `npx prettier --check .` | clean | **clean** |
| `npx eslint .` | 216 warnings / 0 errors | **216 warnings / 0 errors** |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR strengthens the organizer email-update authorization boundary so only an organization that exclusively holds a speaker can rewrite that speaker’s login-match email.

- Requires exclusive membership/participation standing before `speaker.admin.updateEmail` writes.
- Adds cross-tenant, foreign-reference, probe-failure, and successful-update coverage.
- Clarifies speaker identity-match invariants and makes shared exclusivity errors operation-neutral.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and correctly closes the residual cross-tenant identity-rewrite path.

The changed mutation performs the exclusive-standing check before every organizer-controlled email write, fails closed when exclusivity cannot be established, and retains the successful path for speakers held solely by the current organization.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/routers/speaker.ts | Strengthens the admin email-update mutation with an exclusive-tenant guard before the login-match key is written. |
| src/server/tenancy.ts | Documents the identity-rewrite use case and generalizes existing exclusive-standing refusal messages without changing guard behavior. |
| src/server/routers/tenancy.writes.test.ts | Adds focused coverage proving shared speakers, foreign references, and failed probes are refused while exclusively held speakers remain editable. |
| src/lib/profile/sanity.ts | Corrects documentation of the distinct ownership guarantees required from self-service and organizer email writers. |
| src/lib/speaker/sanity.ts | Clarifies the differing trust levels of display email and known verified emails in speaker login matching. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Organizer
  participant Router as speaker.admin.updateEmail
  participant Guard as requireSpeakerInCurrentOrg
  participant Sanity
  Organizer->>Router: updateEmail(speakerId, email)
  Router->>Guard: "requireExclusive=true"
  Guard->>Sanity: Read membership and participation
  Guard->>Sanity: Check foreign references
  alt Another organization holds or references speaker
    Guard-->>Router: BAD_REQUEST
    Router-->>Organizer: Refuse update
  else Current organization holds speaker alone
    Guard-->>Router: Authorized
    Router->>Sanity: Patch canonical display email
    Router-->>Organizer: Success
  end
```

<sub>Reviews (1): Last reviewed commit: ["fix(security): require exclusive standin..."](https://github.com/cloudnativebergen/website/commit/ffe5f96e111b0dd7be90c9b36f1d1328fb2e9c96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50355797)</sub>

**Context used:**

- Knowledge Base — [Speaker and Sponsor Management](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/speaker-sponsor-management.md)
- Knowledge Base — [tRPC API Layer](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/trpc-api-layer.md)

<!-- /greptile_comment -->