### PR TITLE
feat(badge): fail-closed platform-org tripwire on issuance (platform#46)

### DIFF
--- a/src/lib/badge/issuance.orgscope.test.ts
+++ b/src/lib/badge/issuance.orgscope.test.ts
@@ -15,8 +15,16 @@ const getSpeakerMock = vi.fn()
 const checkBadgeExistsMock = vi.fn()
 const getConferenceMock = vi.fn()
 
+// The org these scenarios issue for; also the PLATFORM org here, so the Phase 0
+// tripwire (platform#46) passes and the ORGANIZER eligibility logic under test is
+// still reached. The tripwire itself is pinned by issuance.platform-gate.test.ts.
+const ORG = 'org-A'
+
 vi.mock('@/lib/sanity/client', () => ({
   clientReadUncached: { fetch: (...a: unknown[]) => fetchMock(...a) },
+}))
+vi.mock('@/lib/authz/platform', () => ({
+  getPlatformOrgId: vi.fn().mockResolvedValue('org-A'),
 }))
 vi.mock('@/lib/speaker/sanity', () => ({
   getSpeaker: (...a: unknown[]) => getSpeakerMock(...a),
@@ -41,8 +49,10 @@ vi.mock('@/lib/time', () => ({
 
 import { issueBadgeForSpeaker } from './issuance'
 
-// fetch is called twice for the org check: (1) orgRef of the conference,
-// (2) count of the recipient's org-scoped organizer membership.
+// fetch is called three times: (0) the Phase 0 platform tripwire resolves the
+// issuing conference's org (returns ORG === platform org, so the gate passes),
+// then the organizer eligibility check: (1) orgRef of the conference, (2) count
+// of the recipient's org-scoped organizer membership.
 function mockOrgCheck({
   orgRef,
   isMember,
@@ -51,6 +61,7 @@ function mockOrgCheck({
   isMember: boolean
 }) {
   fetchMock.mockReset()
+  fetchMock.mockResolvedValueOnce(ORG) // tripwire: conference → org (platform, passes)
   fetchMock.mockResolvedValueOnce(orgRef) // conference → organization._ref
   fetchMock.mockResolvedValueOnce(isMember) // count(...) > 0
 }

--- a/src/lib/badge/issuance.platform-gate.test.ts
+++ b/src/lib/badge/issuance.platform-gate.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @vitest-environment node
+ *
+ * PLATFORM-ORG TRIPWIRE (Phase 0, RunKonf/platform#46). Badge credentials are
+ * signed with ONE GLOBAL key pair shared by every tenant, and issued Open Badge
+ * bytes verify PERMANENTLY on platforms we do not control — a badge minted for a
+ * second tenant on the global keys could never be un-issued. The full per-tenant
+ * signing rework is deferred until a second tenant is about to issue; this gate
+ * makes that deferral SAFE by refusing any non-platform org at the issuance
+ * chokepoint (`issueBadgeForSpeaker`, inherited by `issue` + `bulkIssue`).
+ *
+ * These pin the standing bar: a non-platform org is REFUSED; the platform org
+ * still passes the gate (no regression); an unresolvable platform org id FAILS
+ * CLOSED. Each assertion targets the exact refusal string so the sabotage check
+ * (delete the guard → the refusal test fails) is meaningful.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const fetchMock = vi.fn()
+const getSpeakerMock = vi.fn()
+const checkBadgeExistsMock = vi.fn()
+const getConferenceMock = vi.fn()
+const getPlatformOrgIdMock = vi.fn()
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: (...a: unknown[]) => fetchMock(...a) },
+}))
+vi.mock('@/lib/authz/platform', () => ({
+  getPlatformOrgId: (...a: unknown[]) => getPlatformOrgIdMock(...a),
+}))
+vi.mock('@/lib/speaker/sanity', () => ({
+  getSpeaker: (...a: unknown[]) => getSpeakerMock(...a),
+}))
+vi.mock('./sanity', () => ({
+  checkBadgeExists: (...a: unknown[]) => checkBadgeExistsMock(...a),
+  createBadge: vi.fn(),
+  uploadBadgeSVGAsset: vi.fn(),
+}))
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...a: unknown[]) => getConferenceMock(...a),
+}))
+// Unused-before-return generation deps — inert stubs.
+vi.mock('./generator', () => ({ generateBadgeCredential: vi.fn() }))
+vi.mock('./config', () => ({ createBadgeConfiguration: vi.fn() }))
+vi.mock('./svg', () => ({ generateBadgeSVG: vi.fn() }))
+vi.mock('@/lib/openbadges', () => ({ bakeBadge: vi.fn() }))
+vi.mock('@/lib/time', () => ({
+  formatConferenceDateForBadge: vi.fn(),
+  getCurrentDateTime: vi.fn(),
+}))
+
+import { issueBadgeForSpeaker } from './issuance'
+
+const PLATFORM_ORG = 'org-platform'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  fetchMock.mockReset()
+  checkBadgeExistsMock.mockResolvedValue({ exists: false })
+  getSpeakerMock.mockResolvedValue({
+    speaker: { _id: 'sp-x', name: 'Pat', email: 'pat@x.test', slug: 'pat' },
+    err: null,
+  })
+  // Force a distinct LATER failure so a caller who PASSES the platform gate is
+  // provable without mocking the whole issuance pipeline: if we reach the
+  // conference load, the gate did not refuse.
+  getConferenceMock.mockResolvedValue({
+    error: new Error('boom'),
+    conference: null,
+  })
+})
+
+describe('issueBadgeForSpeaker — platform-org tripwire (platform#46)', () => {
+  it('REFUSES a non-platform org, naming per-tenant keys and platform#46', async () => {
+    getPlatformOrgIdMock.mockResolvedValue(PLATFORM_ORG)
+    fetchMock.mockResolvedValueOnce('org-tenant-B') // issuing conference → org
+    const res = await issueBadgeForSpeaker({
+      speakerId: 'sp-x',
+      badgeType: 'speaker',
+      conferenceId: 'conf-B',
+      isDevelopment: false,
+    })
+    expect(res).toEqual({
+      success: false,
+      error:
+        'Badge issuance for this organization requires per-tenant signing keys — see RunKonf/platform#46',
+    })
+  })
+
+  it('does NOT refuse the PLATFORM org — the gate is passed (no regression)', async () => {
+    getPlatformOrgIdMock.mockResolvedValue(PLATFORM_ORG)
+    fetchMock.mockResolvedValueOnce(PLATFORM_ORG) // issuing conference → platform org
+    fetchMock.mockResolvedValueOnce(true) // speaker branch: has accepted talk
+    const res = await issueBadgeForSpeaker({
+      speakerId: 'sp-x',
+      badgeType: 'speaker',
+      conferenceId: 'conf-platform',
+      isDevelopment: false,
+    })
+    // Past the platform gate AND the speaker-eligibility gate; stops at the
+    // conference load (mocked to error), NOT at the tripwire.
+    expect(res).toEqual({ success: false, error: 'Conference not found' })
+  })
+
+  it('FAILS CLOSED when the platform org id cannot be resolved', async () => {
+    getPlatformOrgIdMock.mockResolvedValue(null) // PLATFORM_ORG_SLUG unset / unknown
+    const res = await issueBadgeForSpeaker({
+      speakerId: 'sp-x',
+      badgeType: 'speaker',
+      conferenceId: 'conf-platform',
+      isDevelopment: false,
+    })
+    expect(res).toEqual({
+      success: false,
+      error:
+        'Badge issuance is unavailable: the platform organization could not be resolved — see RunKonf/platform#46',
+    })
+    // The issuing-org lookup must never run once the guard input is unresolvable.
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/badge/issuance.platform-gate.test.ts
+++ b/src/lib/badge/issuance.platform-gate.test.ts
@@ -21,6 +21,7 @@ const getSpeakerMock = vi.fn()
 const checkBadgeExistsMock = vi.fn()
 const getConferenceMock = vi.fn()
 const getPlatformOrgIdMock = vi.fn()
+const createBadgeMock = vi.fn()
 
 vi.mock('@/lib/sanity/client', () => ({
   clientReadUncached: { fetch: (...a: unknown[]) => fetchMock(...a) },
@@ -33,7 +34,7 @@ vi.mock('@/lib/speaker/sanity', () => ({
 }))
 vi.mock('./sanity', () => ({
   checkBadgeExists: (...a: unknown[]) => checkBadgeExistsMock(...a),
-  createBadge: vi.fn(),
+  createBadge: (...a: unknown[]) => createBadgeMock(...a),
   uploadBadgeSVGAsset: vi.fn(),
 }))
 vi.mock('@/lib/conference/sanity', () => ({
@@ -71,7 +72,45 @@ beforeEach(() => {
 })
 
 describe('issueBadgeForSpeaker — platform-org tripwire (platform#46)', () => {
-  it('REFUSES a non-platform org, naming per-tenant keys and platform#46', async () => {
+  it('(a) FAILS CLOSED when the issuing-org lookup THROWS — structured refusal, not a throw, no badge', async () => {
+    getPlatformOrgIdMock.mockResolvedValue(PLATFORM_ORG)
+    // A Sanity service/network/timeout/auth error rejecting the lookup must not
+    // escape the structured-return contract (single 500 / bulk abort mid-batch).
+    fetchMock.mockRejectedValueOnce(new Error('sanity unavailable'))
+    const res = await issueBadgeForSpeaker({
+      speakerId: 'sp-x',
+      badgeType: 'speaker',
+      conferenceId: 'conf-platform',
+      isDevelopment: false,
+    })
+    expect(res).toEqual({
+      success: false,
+      error:
+        'Badge issuance is unavailable: the issuing organization could not be resolved — see RunKonf/platform#46',
+    })
+    // No badge is ever minted on the error path.
+    expect(createBadgeMock).not.toHaveBeenCalled()
+  })
+
+  it('(b) FAILS CLOSED when the issuing org is unresolvable (null) — unavailable message, not per-tenant-keys', async () => {
+    getPlatformOrgIdMock.mockResolvedValue(PLATFORM_ORG)
+    // Unknown conferenceId, or a conference missing its organization ref.
+    fetchMock.mockResolvedValueOnce(null)
+    const res = await issueBadgeForSpeaker({
+      speakerId: 'sp-x',
+      badgeType: 'speaker',
+      conferenceId: 'conf-unknown',
+      isDevelopment: false,
+    })
+    expect(res).toEqual({
+      success: false,
+      error:
+        'Badge issuance is unavailable: the issuing organization could not be resolved — see RunKonf/platform#46',
+    })
+    expect(createBadgeMock).not.toHaveBeenCalled()
+  })
+
+  it('(c) REFUSES a RESOLVED non-platform org, naming per-tenant keys and platform#46', async () => {
     getPlatformOrgIdMock.mockResolvedValue(PLATFORM_ORG)
     fetchMock.mockResolvedValueOnce('org-tenant-B') // issuing conference → org
     const res = await issueBadgeForSpeaker({
@@ -87,7 +126,7 @@ describe('issueBadgeForSpeaker — platform-org tripwire (platform#46)', () => {
     })
   })
 
-  it('does NOT refuse the PLATFORM org — the gate is passed (no regression)', async () => {
+  it('(d) does NOT refuse the PLATFORM org — the gate is passed (no regression)', async () => {
     getPlatformOrgIdMock.mockResolvedValue(PLATFORM_ORG)
     fetchMock.mockResolvedValueOnce(PLATFORM_ORG) // issuing conference → platform org
     fetchMock.mockResolvedValueOnce(true) // speaker branch: has accepted talk

--- a/src/lib/badge/issuance.ts
+++ b/src/lib/badge/issuance.ts
@@ -8,6 +8,7 @@ import { getCurrentDateTime } from '@/lib/time'
 import { getSpeaker } from '@/lib/speaker/sanity'
 import { createBadge, uploadBadgeSVGAsset, checkBadgeExists } from './sanity'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { getPlatformOrgId } from '@/lib/authz/platform'
 import { BADGE_GENERATOR_VERSION } from './version'
 
 /**
@@ -71,6 +72,48 @@ export async function issueBadgeForSpeaker(
     currentUserEmail,
     isDevelopment,
   } = params
+
+  // PLATFORM-ORG TRIPWIRE (Phase 0, RunKonf/platform#46). Badge credentials are
+  // signed with ONE GLOBAL key pair shared by every tenant (config.ts:113-115),
+  // and issued Open Badge bytes verify PERMANENTLY on platforms we do not control
+  // (Credly, 1EdTech, LinkedIn) — a badge minted for a second tenant on the global
+  // keys could never be un-issued or re-signed. The per-tenant signing rework
+  // (platform#46) is deliberately DEFERRED until a second tenant is about to issue;
+  // this gate makes that deferral safe by turning the otherwise SILENT trigger (a
+  // non-platform org's first badge succeeding on the global keys) into an explicit
+  // refusal. This is the issuance chokepoint: both `issue` and `bulkIssue` — and
+  // any future caller — route through here, so the gate cannot be bypassed. The
+  // issuing org is derived from the domain-authoritative `conferenceId` (the same
+  // tenant key the authz waist gated on, trpc.ts:150-168), never from client input.
+  // FAIL CLOSED: an unresolvable platform org (PLATFORM_ORG_SLUG unset / unknown /
+  // transient) OR an unresolvable issuing org DENIES — an unresolvable guard input
+  // must never allow (the scopedFetch fail-open lesson). Relaxes at Phase 2 to
+  // "org must have resolvable per-tenant signing keys".
+  const platformOrgId = await getPlatformOrgId()
+  if (!platformOrgId) {
+    return {
+      success: false,
+      error:
+        'Badge issuance is unavailable: the platform organization could not be resolved — see RunKonf/platform#46',
+    }
+  }
+  {
+    const { clientReadUncached } = await import('@/lib/sanity/client')
+    const issuingOrgId = await clientReadUncached.fetch<string | null>(
+      // groq-global-scoped: a by-id read of the conference's OWN org from the
+      // domain-authoritative conferenceId (the tenant key the authz waist gated
+      // on), compared against the platform org id for the Phase 0 tripwire.
+      `*[_type == "conference" && _id == $conferenceId][0].organization._ref`,
+      { conferenceId },
+    )
+    if (issuingOrgId !== platformOrgId) {
+      return {
+        success: false,
+        error:
+          'Badge issuance for this organization requires per-tenant signing keys — see RunKonf/platform#46',
+      }
+    }
+  }
 
   const { exists } = await checkBadgeExists(speakerId, conferenceId, badgeType)
   if (exists) {

--- a/src/lib/badge/issuance.ts
+++ b/src/lib/badge/issuance.ts
@@ -97,21 +97,44 @@ export async function issueBadgeForSpeaker(
         'Badge issuance is unavailable: the platform organization could not be resolved — see RunKonf/platform#46',
     }
   }
-  {
+  let issuingOrgId: string | null
+  try {
     const { clientReadUncached } = await import('@/lib/sanity/client')
-    const issuingOrgId = await clientReadUncached.fetch<string | null>(
+    issuingOrgId = await clientReadUncached.fetch<string | null>(
       // groq-global-scoped: a by-id read of the conference's OWN org from the
       // domain-authoritative conferenceId (the tenant key the authz waist gated
       // on), compared against the platform org id for the Phase 0 tripwire.
       `*[_type == "conference" && _id == $conferenceId][0].organization._ref`,
       { conferenceId },
     )
-    if (issuingOrgId !== platformOrgId) {
-      return {
-        success: false,
-        error:
-          'Badge issuance for this organization requires per-tenant signing keys — see RunKonf/platform#46',
-      }
+  } catch {
+    // A thrown lookup (Sanity service/network/timeout/auth) must NOT escape this
+    // function's structured-return contract: an unwrapped throw makes single
+    // issuance 500 and, worse, ABORTS a bulk issue mid-batch, leaving the
+    // remaining speakers unprocessed. Fail closed as an unresolvable input so the
+    // caller's per-item handling keeps working.
+    return {
+      success: false,
+      error:
+        'Badge issuance is unavailable: the issuing organization could not be resolved — see RunKonf/platform#46',
+    }
+  }
+  // Unresolvable issuing org (unknown conferenceId, or a conference with no
+  // organization ref) is NOT a tenant-keying decision — it is a bad/unknown input.
+  // Fail closed as unresolvable, DISTINCT from the resolved-but-non-platform org
+  // refusal below, so a bad conferenceId is not masked as a tenant-keying refusal.
+  if (!issuingOrgId) {
+    return {
+      success: false,
+      error:
+        'Badge issuance is unavailable: the issuing organization could not be resolved — see RunKonf/platform#46',
+    }
+  }
+  if (issuingOrgId !== platformOrgId) {
+    return {
+      success: false,
+      error:
+        'Badge issuance for this organization requires per-tenant signing keys — see RunKonf/platform#46',
     }
   }
 


### PR DESCRIPTION
## Phase 0 tripwire — RunKonf/platform#46

Implements the Phase 0 tripwire guard from RunKonf/platform#46. Full context in that PRD; summary below.

### The hole (verified in this repo)
Badge credentials sign with **one global key pair** shared by every tenant (`src/lib/badge/config.ts:113-115`), and issued Open Badge bytes verify **permanently** on platforms we don't control (Credly, 1EdTech, LinkedIn). The full per-tenant signing rework is deferred until a second tenant is about to issue — but that trigger currently passes **silently**.

Caller trace: `badgeRouter.admin.issue` / `admin.bulkIssue` (`src/server/routers/badge.ts:152,202`) use `adminProcedure`, whose authz waist (`src/server/trpc.ts:149-168`) only checks the caller organizes the **request's own** org. Both call `issueBadgeForSpeaker` (`src/lib/badge/issuance.ts`), whose eligibility gates (badge-exists, speaker, dev-mode, organizer org-scope, accepted-talk) never distinguish the platform org. So any tenant admin, on their own domain, can reach issuance and mint a badge on the global keys — frozen forever. The hole is real; no existing guard closes it.

### The guard
A single fail-closed gate at the issuance chokepoint (`issueBadgeForSpeaker`), so `issue`, `bulkIssue`, and any future caller inherit it — it cannot be bypassed by another caller. The issuing org is derived from the **domain-authoritative `conferenceId`** (the same tenant key the waist gated on), never from client input, and compared against `getPlatformOrgId()` (`src/lib/authz/platform.ts`).

- Non-platform org → **refused**: `Badge issuance for this organization requires per-tenant signing keys — see RunKonf/platform#46`
- Unresolvable platform org (`PLATFORM_ORG_SLUG` unset/unknown/transient) → **refused** (fail closed): `Badge issuance is unavailable: the platform organization could not be resolved — see RunKonf/platform#46`
- Unresolvable issuing org → refused (fail closed)
- Platform org (Cloud Native Bergen) → **unchanged**, issues exactly as today

Relaxes at Phase 2 to "org must have resolvable per-tenant signing keys".

### Tests (standing bar: guard fails a test when removed)
New `src/lib/badge/issuance.platform-gate.test.ts`: non-platform refused; platform org passes the gate (no regression); unresolvable platform-org-id fails closed. Sabotage check — with the guard removed, **2 of 3 fail** (the two guard-proof tests); restored, **3/3 green**. `issuance.orgscope.test.ts` updated to account for the gate (platform org == the scenario org, so the E11 organizer logic is still exercised).

### Numbers
- `pnpm test`: **478 files / 6878 tests** pass (baseline 477 / 6875; +1 file, +3 tests)
- `pnpm typecheck`: clean
- `npx prettier --check .`: clean
- `npx eslint .`: **0 errors, 216 warnings** (net zero vs baseline; the guard's by-id GROQ is annotated `groq-global-scoped`)

Do not merge — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a fail-closed platform-organization tripwire to the badge issuance chokepoint and updates issuance tests for the new guard.

- Resolves the configured platform organization before issuing a badge.
- Resolves the issuing organization from the domain-authoritative conference ID and refuses non-platform tenants.
- Adds tests for platform, non-platform, and unresolved-platform behavior.
- Leaves issuing-organization lookup exceptions outside the structured failure path.

<h3>Confidence Score: 4/5</h3>

The issuing-organization lookup must handle Sanity failures before this PR is safe to merge, otherwise single requests return internal errors and bulk issuance can terminate partway through.

The platform resolver fails closed correctly, but the subsequent uncached issuing-org fetch can reject, bypassing IssueBadgeResult and escaping through both router callers.

**Files Needing Attention:** src/lib/badge/issuance.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/badge/issuance.ts | Adds the platform-org gate, but the issuing-org fetch can reject outside the function’s structured fail-closed result contract. |
| src/lib/badge/issuance.platform-gate.test.ts | Covers resolved platform, non-platform, and unresolved platform-org results, but not a rejected issuing-org lookup. |
| src/lib/badge/issuance.orgscope.test.ts | Updates existing organizer-scope fixtures so they continue exercising their intended logic after the new gate. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Admin
  participant Router as Badge Router
  participant Issuance as issueBadgeForSpeaker
  participant Platform as getPlatformOrgId
  participant Sanity
  Admin->>Router: issue / bulkIssue
  Router->>Issuance: conferenceId + speaker
  Issuance->>Platform: resolve platform org
  Platform->>Sanity: lookup org by configured slug
  Sanity-->>Platform: platformOrgId or null
  Issuance->>Sanity: lookup conference.organization._ref
  alt lookup succeeds and org matches
    Issuance->>Issuance: continue eligibility and issuance
  else org differs or is missing
    Issuance-->>Router: structured refusal
  else lookup rejects
    Sanity--xIssuance: exception
    Issuance--xRouter: rejected promise / aborted bulk operation
  end
```

<sub>Reviews (1): Last reviewed commit: ["feat(badge): fail-closed platform-org tr..."](https://github.com/cloudnativebergen/website/commit/bbec7817d5e03bbca65b49ac4be0cc3e2c9b75dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50356334)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->