### PR TITLE
fix(speaker): stop laundering display emails into knownEmails on merge (#808)

### DIFF
--- a/src/lib/speaker/merge.test.ts
+++ b/src/lib/speaker/merge.test.ts
@@ -164,7 +164,7 @@ describe('computeSurvivorFieldMerge', () => {
     expect(set.providers).toBeUndefined()
   })
 
-  it('unions and normalizes knownEmails, folding both display emails', () => {
+  it('unions and normalizes knownEmails from the two verified match-sets', () => {
     const survivor = speaker({
       email: 'Ada@Example.com',
       knownEmails: ['ada@example.com'],
@@ -176,6 +176,57 @@ describe('computeSurvivorFieldMerge', () => {
     })
     const { set } = computeSurvivorFieldMerge(survivor, loser)
     expect(set.knownEmails).toEqual(['ada@example.com', 'ada.l@work.io'])
+  })
+
+  // SECURITY (#808): the display `email` must NEVER be folded into knownEmails
+  // (the verified login match-set). Its unverified writer, speaker.admin.create,
+  // would otherwise let an organizer launder an attacker-chosen address into a
+  // victim's verified set via a throwaway merge — a cross-tenant takeover.
+  it('does NOT fold either display email into knownEmails (#808)', () => {
+    const survivor = speaker({
+      email: 'victim-display@example.com',
+      knownEmails: ['victim-verified@example.com'],
+    })
+    const loser = speaker({
+      _id: LOSER,
+      email: 'attacker@evil.example', // organizer-typed, never signed in
+      knownEmails: [], // throwaway has no verified match-set
+    })
+    const { set, identity } = computeSurvivorFieldMerge(survivor, loser)
+    // Only the survivor's own verified email survives; neither display email is
+    // promoted into the verified set.
+    expect(set.knownEmails).toBeUndefined() // union adds nothing → no patch
+    expect(identity.knownEmails.after).toEqual(['victim-verified@example.com'])
+    expect(identity.knownEmails.after).not.toContain('attacker@evil.example')
+    expect(identity.knownEmails.after).not.toContain(
+      'victim-display@example.com',
+    )
+  })
+
+  it('unions ONLY the genuine verified knownEmails of two real duplicates (#808)', () => {
+    // A legitimate de-duplication: both accounts are real, each with its own
+    // verified match-set AND display email. The merge must still union the two
+    // verified sets (no regression) while ignoring the display emails.
+    const survivor = speaker({
+      email: 'ada@example.com',
+      knownEmails: ['ada@example.com', 'ada.old@example.com'],
+    })
+    const loser = speaker({
+      _id: LOSER,
+      email: 'ada.l@work.io',
+      knownEmails: ['ada.l@work.io'],
+    })
+    const { set, identity } = computeSurvivorFieldMerge(survivor, loser)
+    expect(set.knownEmails).toEqual([
+      'ada@example.com',
+      'ada.old@example.com',
+      'ada.l@work.io',
+    ])
+    expect(identity.knownEmails.after).toEqual([
+      'ada@example.com',
+      'ada.old@example.com',
+      'ada.l@work.io',
+    ])
   })
 
   it('preserves the survivor display email when non-empty', () => {

--- a/src/lib/speaker/merge.ts
+++ b/src/lib/speaker/merge.ts
@@ -4,8 +4,9 @@
  * An ADMIN-only, destructive operation that folds a duplicate ("loser") speaker
  * document into a canonical ("survivor") one:
  *  1. Every inbound reference to the loser is repointed to the survivor.
- *  2. Identity fields (`providers`, `knownEmails`) are unioned onto the survivor
- *     and the loser's display email is folded into the survivor's match-set.
+ *  2. Identity fields (`providers`, `knownEmails`) are unioned onto the survivor.
+ *     Display emails are NOT folded into `knownEmails` (#808): that verified
+ *     match-set has one writer, the login path.
  *  3. Scalar fields fill ONLY the survivor's gaps (survivor wins deterministically).
  *  4. The loser document is deleted — all in one atomic Sanity transaction so
  *     nothing dangles.
@@ -223,8 +224,9 @@ function stringList(
  * Compute the identity union + scalar reconciliation to apply to the survivor.
  *
  * - `providers`: deduplicated union.
- * - `knownEmails`: normalized, deduplicated union of both match-sets PLUS both
- *   display emails (so the loser's address becomes a future match key).
+ * - `knownEmails`: normalized, deduplicated union of the two accounts' existing
+ *   match-sets ONLY. Display emails are NOT folded in (#808) — that would let an
+ *   unverified organizer-written `email` become a verified match key.
  * - `email` (display): keep the survivor's unless empty, then fall back to the
  *   loser's. The survivor's `slug` is intentionally never touched.
  * - Scalars: keep the survivor's; fill from the loser only where the survivor's
@@ -246,13 +248,25 @@ export function computeSurvivorFieldMerge(
     set.providers = providersAfter
   }
 
-  // knownEmails — normalized union incl. both display emails.
+  // knownEmails — normalized union of ONLY the two accounts' existing verified
+  // match-sets.
+  //
+  // SECURITY (#808): the display `email` is DELIBERATELY excluded from this
+  // union. `knownEmails` is the verified login match-set (`findSpeakersByEmails`
+  // in `./sanity.ts` treats it as verified-owned), whereas the display `email`
+  // has an UNVERIFIED writer: `speaker.admin.create` stamps an organizer-typed
+  // address before anyone signs in. Folding display emails in here let an
+  // organizer create a throwaway with an attacker-chosen `email`, merge it into
+  // a victim they hold, and land that address in the victim's VERIFIED set — a
+  // cross-tenant account-takeover primitive. The verified set has exactly one
+  // legitimate writer, the login path (`linkProviderToSpeaker` /
+  // `getOrCreateSpeaker`), which already unions every genuinely verified address
+  // into `knownEmails` at sign-in — so unioning the two existing sets here loses
+  // no real verified email.
   const knownBefore = uniqueEmails(survivor.knownEmails ?? [])
   const knownAfter = uniqueEmails([
     ...(survivor.knownEmails ?? []),
     ...(loser.knownEmails ?? []),
-    survivor.email,
-    loser.email,
   ])
   if (knownAfter.length !== knownBefore.length) {
     set.knownEmails = knownAfter

--- a/src/lib/speaker/merge.ts
+++ b/src/lib/speaker/merge.ts
@@ -258,11 +258,18 @@ export function computeSurvivorFieldMerge(
   // address before anyone signs in. Folding display emails in here let an
   // organizer create a throwaway with an attacker-chosen `email`, merge it into
   // a victim they hold, and land that address in the victim's VERIFIED set — a
-  // cross-tenant account-takeover primitive. The verified set has exactly one
-  // legitimate writer, the login path (`linkProviderToSpeaker` /
-  // `getOrCreateSpeaker`), which already unions every genuinely verified address
-  // into `knownEmails` at sign-in — so unioning the two existing sets here loses
-  // no real verified email.
+  // cross-tenant account-takeover primitive. The verified set's only legitimate
+  // writers are the login paths (`linkProviderToSpeaker` / `getOrCreateSpeaker` /
+  // `getOrCreateSpeakerForVerifiedEmail`). Any address dropped by narrowing this
+  // union was therefore not provably verified AT THE MERGE BOUNDARY: the
+  // provider-id fast path does not refresh `knownEmails` on a returning login,
+  // and self-service `updateProfileEmail` writes the display `email` only, so a
+  // legitimate loser can hold a verified display address that never reached
+  // `knownEmails`. Dropping it costs at worst a recoverable dedup miss (the
+  // loser's `providers[]` still merge, so no login is orphaned) — the opposite
+  // asymmetry (admitting an unverified address into the verified set) is the
+  // account-takeover, so failing closed here is the correct trade. Making the
+  // fast path refresh `knownEmails` would erase even that dedup miss (follow-up).
   const knownBefore = uniqueEmails(survivor.knownEmails ?? [])
   const knownAfter = uniqueEmails([
     ...(survivor.knownEmails ?? []),


### PR DESCRIPTION
## Summary

Closes the cross-tenant identity issue in `speaker.admin.merge` tracked in #808.

`computeSurvivorFieldMerge` (`src/lib/speaker/merge.ts`) folded both speakers' display `email` values into the survivor's `knownEmails` — the verified login match-set that `findSpeakersByEmails` treats as verified-owned. Because the display `email` has an unverified writer, that promotion let an unverified address reach the verified set through a merge. This narrows the union so an unverified address can no longer be laundered into `knownEmails`.

## Fix (#808 option B)

Union **only** the two accounts' existing `knownEmails` sets; drop the `survivor.email` / `loser.email` promotion. This is option B from the issue (stop the unverified→verified promotion at its source), **not** option A (tightening the survivor arm to `requireExclusive`) — merge is inherently a cross-tenant de-duplication operation, so requiring exclusive standing on the survivor would break its legitimate purpose.

**Losslessness verified.** The login path (`linkProviderToSpeaker` / `getOrCreateSpeaker` / `getOrCreateSpeakerForVerifiedEmail`) already unions every genuinely verified address into `knownEmails` at sign-in (create seeds `knownEmails` from `computeVerifiedEmails`; link unions the verified incoming set; the GitHub/LinkedIn primary is included in that verified set). So dropping the display-email promotion loses no real verified email. The display `email` field itself is unchanged by this PR.

The residual display-email match-key question (whether display `email` should be a login match key at all) is out of scope here and tracked in #807.

## Tests

- A merge that would previously have promoted a display email into `knownEmails` no longer does.
- No regression: two real duplicates still union their genuine verified `knownEmails`.

Reverting the fix makes the guard test fail while the no-regression test stays green; restoring makes both green.

## Verification

- `pnpm test`: 477 files, 6877 tests pass
- `pnpm typecheck`: clean
- `npx prettier --check .`: clean
- `npx eslint .`: 0 errors (216 pre-existing tenancy warnings, none in the changed files)
