### PR TITLE
fix(security): drop NEXTAUTH_URL from contract-signing base-URL fallback (#687)

### DIFF
--- a/src/docs/SponsorSystem.stories.tsx
+++ b/src/docs/SponsorSystem.stories.tsx
@@ -645,8 +645,8 @@ Self-service portal
                   Optional; defaults to self-hosted
                 </li>
                 <li>
-                  <code className="text-xs">NEXTAUTH_URL</code> — Base URL used
-                  to build signing links
+                  <code className="text-xs">NEXT_PUBLIC_BASE_URL</code> — Base
+                  URL used to build signing links
                 </li>
                 <li>
                   <code className="text-xs">CRON_SECRET</code> — Cron job auth

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -506,8 +506,7 @@ function warnOnFixedAuthOrigin(env: NodeJS.ProcessEnv = process.env): void {
       'next-auth rewrites EVERY request origin to that host, which breaks ' +
       'sign-in on every conference domain except that one. Remove the ' +
       'variable(s); use AUTH_REDIRECT_PROXY_URL for a central OAuth origin, and ' +
-      'NEXT_PUBLIC_BASE_URL for the self-hosted contract-signing base URL that ' +
-      'also reads NEXTAUTH_URL.',
+      'NEXT_PUBLIC_BASE_URL for the self-hosted contract-signing base URL.',
   )
 }
 

--- a/src/lib/contract-signing/self-hosted.test.ts
+++ b/src/lib/contract-signing/self-hosted.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+// The provider imports the Sanity client at module load; sendForSigning itself
+// never touches it, so a stub keeps these tests off the network.
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: vi.fn() },
+  clientWrite: { patch: vi.fn() },
+}))
+
+import { SelfHostedSigningProvider } from './self-hosted'
+
+const provider = new SelfHostedSigningProvider()
+
+const send = (baseUrl?: string) =>
+  provider.sendForSigning({
+    pdf: Buffer.from('pdf'),
+    filename: 'agreement.pdf',
+    signerEmail: 'sponsor@example.com',
+    agreementName: 'Sponsorship Agreement',
+    baseUrl,
+  })
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('SelfHostedSigningProvider.sendForSigning — base URL resolution', () => {
+  it('builds the signing link on the tenant origin passed as baseUrl', async () => {
+    const { signingUrl } = await send('https://tenant.example')
+    expect(signingUrl).toMatch(
+      /^https:\/\/tenant\.example\/sponsor\/contract\/sign\/[0-9a-f-]+$/,
+    )
+  })
+
+  it('falls back to NEXT_PUBLIC_BASE_URL when no baseUrl is passed', async () => {
+    vi.stubEnv('NEXT_PUBLIC_BASE_URL', 'https://platform.example')
+    const { signingUrl } = await send()
+    expect(new URL(signingUrl!).origin).toBe('https://platform.example')
+  })
+
+  // The #687 trap: next-auth's reqWithEnvURL rewrites EVERY request origin to
+  // NEXTAUTH_URL, so an operator setting it to "fix" signing links would
+  // silently break auth on every other tenant domain. The signing module must
+  // NOT read it — setting it must not change the resolved signing URL.
+  it('IGNORES NEXTAUTH_URL — it does not influence the signing origin (#687)', async () => {
+    vi.stubEnv('NEXTAUTH_URL', 'https://auth-pinned.example')
+    vi.stubEnv('NEXT_PUBLIC_BASE_URL', 'https://platform.example')
+    const { signingUrl } = await send()
+    // Before the fix, NEXTAUTH_URL sat ahead of NEXT_PUBLIC_BASE_URL in the
+    // fallback chain and this origin would be 'https://auth-pinned.example'.
+    expect(new URL(signingUrl!).origin).toBe('https://platform.example')
+    expect(signingUrl).not.toContain('auth-pinned.example')
+  })
+
+  it('IGNORES NEXTAUTH_URL even when it is the only origin env var set (#687)', async () => {
+    vi.stubEnv('NEXTAUTH_URL', 'https://auth-pinned.example')
+    await expect(send()).rejects.toThrow(/Missing base URL/)
+  })
+
+  it('does not name NEXTAUTH_URL in the missing-base-URL error', async () => {
+    await expect(send()).rejects.toThrow(/NEXT_PUBLIC_BASE_URL/)
+    await expect(send()).rejects.not.toThrow(/NEXTAUTH_URL/)
+  })
+})

--- a/src/lib/contract-signing/self-hosted.test.ts
+++ b/src/lib/contract-signing/self-hosted.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 // The provider imports the Sanity client at module load; sendForSigning itself
 // never touches it, so a stub keeps these tests off the network.
@@ -11,6 +11,18 @@ import { SelfHostedSigningProvider } from './self-hosted'
 
 const provider = new SelfHostedSigningProvider()
 
+// Every env var the resolution chain reads (or must be proven to IGNORE). Each
+// case starts from a known-empty slate and stubs only what it means to test, so
+// an ambient VERCEL_URL / NEXT_PUBLIC_* in CI or a dev shell can never resolve
+// an origin behind the test's back and turn a correct fix into a false failure.
+const ORIGIN_ENV = [
+  'NEXTAUTH_URL',
+  'AUTH_URL',
+  'NEXT_PUBLIC_BASE_URL',
+  'NEXT_PUBLIC_URL',
+  'VERCEL_URL',
+] as const
+
 const send = (baseUrl?: string) =>
   provider.sendForSigning({
     pdf: Buffer.from('pdf'),
@@ -19,6 +31,10 @@ const send = (baseUrl?: string) =>
     agreementName: 'Sponsorship Agreement',
     baseUrl,
   })
+
+beforeEach(() => {
+  for (const name of ORIGIN_ENV) vi.stubEnv(name, '')
+})
 
 afterEach(() => {
   vi.unstubAllEnvs()
@@ -57,7 +73,8 @@ describe('SelfHostedSigningProvider.sendForSigning — base URL resolution', () 
     await expect(send()).rejects.toThrow(/Missing base URL/)
   })
 
-  it('does not name NEXTAUTH_URL in the missing-base-URL error', async () => {
+  it('throws when no origin resolves, and does not name NEXTAUTH_URL', async () => {
+    // All ORIGIN_ENV cleared by beforeEach and no baseUrl passed.
     await expect(send()).rejects.toThrow(/NEXT_PUBLIC_BASE_URL/)
     await expect(send()).rejects.not.toThrow(/NEXTAUTH_URL/)
   })

--- a/src/lib/contract-signing/self-hosted.ts
+++ b/src/lib/contract-signing/self-hosted.ts
@@ -39,15 +39,26 @@ export class SelfHostedSigningProvider implements ContractSigningProvider {
   }): Promise<SendForSigningResult> {
     const token = randomUUID()
 
+    // The signing URL points a SPONSOR at `/sponsor/contract/sign/<token>` on
+    // the tenant conference's OWN domain, so callers pass a tenant-scoped
+    // `baseUrl` (derived via `conferenceBaseUrl()`). The env fallbacks below are
+    // a platform-level last resort for the misconfigured case where a
+    // conference has no domain.
+    //
+    // Deliberately NOT reading `NEXTAUTH_URL` / `AUTH_URL`: next-auth's
+    // `reqWithEnvURL` rewrites EVERY request's origin onto whichever host those
+    // are set to, so an operator setting one to fix signing links would
+    // silently pin all tenants to one host and break sign-in on every other
+    // conference domain. `NEXT_PUBLIC_BASE_URL` is the platform base URL and
+    // carries no such side effect (#687).
     const rawBaseUrl =
       params.baseUrl ||
-      process.env.NEXTAUTH_URL ||
       process.env.NEXT_PUBLIC_BASE_URL ||
       process.env.NEXT_PUBLIC_URL ||
       (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined)
     if (!rawBaseUrl) {
       throw new Error(
-        'Missing base URL for self-hosted signing. Set NEXTAUTH_URL or pass baseUrl.',
+        'Missing base URL for self-hosted signing. Pass baseUrl (tenant origin) or set NEXT_PUBLIC_BASE_URL.',
       )
     }
 

--- a/src/lib/contract-signing/self-hosted.ts
+++ b/src/lib/contract-signing/self-hosted.ts
@@ -58,7 +58,7 @@ export class SelfHostedSigningProvider implements ContractSigningProvider {
       (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined)
     if (!rawBaseUrl) {
       throw new Error(
-        'Missing base URL for self-hosted signing. Pass baseUrl (tenant origin) or set NEXT_PUBLIC_BASE_URL.',
+        'Missing base URL for self-hosted signing. Pass baseUrl (the tenant origin) or set one of NEXT_PUBLIC_BASE_URL, NEXT_PUBLIC_URL, VERCEL_URL.',
       )
     }
 

--- a/src/lib/system-status/checks.test.ts
+++ b/src/lib/system-status/checks.test.ts
@@ -152,8 +152,8 @@ describe('collectStaticChecks — fixed auth origin (#682)', () => {
     // being pinned to is the whole point of the check.
     expect(check.value).toContain('https://one-host.example')
     expect(check.detail).toMatch(/breaks on every conference domain except/i)
-    // Remediation must not tell an operator to blindly delete a var another
-    // subsystem still reads (self-hosted contract-signing base URL).
+    // Remediation must point operators at the side-effect-free replacement for
+    // the self-hosted contract-signing base URL (NEXT_PUBLIC_BASE_URL, #687).
     expect(check.detail).toMatch(/NEXT_PUBLIC_BASE_URL/)
   })
 

--- a/src/lib/system-status/checks.ts
+++ b/src/lib/system-status/checks.ts
@@ -462,7 +462,7 @@ function buildChecks(conference: ConferenceForSystemChecks): SystemCheck[] {
         : 'not set (correct)',
     detail:
       fixedOrigins.length > 0
-        ? 'next-auth rewrites EVERY request origin to this host — sign-in breaks on every conference domain except this one (harmless ONLY on a strictly single-domain deployment). Remove the variable(s); use AUTH_REDIRECT_PROXY_URL for a central OAuth origin, and NEXT_PUBLIC_BASE_URL for the self-hosted contract-signing base URL that also reads NEXTAUTH_URL.'
+        ? 'next-auth rewrites EVERY request origin to this host — sign-in breaks on every conference domain except this one (harmless ONLY on a strictly single-domain deployment). Remove the variable(s); use AUTH_REDIRECT_PROXY_URL for a central OAuth origin, and NEXT_PUBLIC_BASE_URL for the self-hosted contract-signing base URL.'
         : 'Request origin comes from the actual host, so every conference domain signs in on itself',
   })
   //


### PR DESCRIPTION
Closes #687.

## Problem
`src/lib/contract-signing/self-hosted.ts` read `NEXTAUTH_URL` as its first base-URL fallback. On this multi-tenant platform that is a trap: next-auth's `reqWithEnvURL` rewrites **every** request's origin onto whatever `NEXTAUTH_URL` is set to. An operator setting it to fix contract-signing links would silently pin all tenants to one host and break sign-in (mis-scoped cookies) on every *other* conference domain. The failure is silent — OAuth completes, the browser rejects the cookie, users loop back to sign-in with no error.

## What the module builds — and why the replacement is correct
`sendForSigning` builds a signing link at `/sponsor/contract/sign/<token>` that a **sponsor** clicks, so it must live on the **tenant conference's own domain** (tenant-scoped). Both callers already pass a tenant-scoped `baseUrl` (via `conferenceBaseUrl()` in `src/server/routers/sponsor.ts`, and `https://<conference.domains[0]>` in `src/lib/sponsor-crm/contract-send.ts`). The provider's env chain is only a platform-level last resort for the misconfigured no-domain case — so removing `NEXTAUTH_URL` and keeping `NEXT_PUBLIC_BASE_URL` (the platform base URL, which carries no request-rewrite side effect) is the correct fix.

## Changes
- **`self-hosted.ts`**: remove `process.env.NEXTAUTH_URL` from the fallback chain (now `baseUrl` → `NEXT_PUBLIC_BASE_URL` → `NEXT_PUBLIC_URL` → `VERCEL_URL`); update the error message to stop naming `NEXTAUTH_URL`; add a comment explaining the hazard.
- **`auth.ts` + `system-status/checks.ts`**: refresh the `auth.fixedOrigin` remediation text, which still told operators the signing module "also reads NEXTAUTH_URL". These files still *read* the vars only to flag them (the #686/#682 guard) — that reporting is intended and unchanged.
- **`SponsorSystem.stories.tsx`**: doc listed `NEXTAUTH_URL` as the signing base URL → now `NEXT_PUBLIC_BASE_URL`.
- **`self-hosted.test.ts`** (new): pins that the signing origin follows the passed tenant `baseUrl` / `NEXT_PUBLIC_BASE_URL`, and — the sabotage-proven part — that setting `NEXTAUTH_URL` no longer changes the signing origin.

## Acceptance
No module resolves a base URL from `NEXTAUTH_URL`/`AUTH_URL` after this change; the only remaining reads are the `auth.fixedOrigin` reporter (explicitly allowed) plus comments and tests.

## Sabotage check
Re-adding `process.env.NEXTAUTH_URL ||` to the fallback chain fails 2 of the 5 new tests (the `IGNORES NEXTAUTH_URL` cases); removing it, all 5 pass.

## Numbers (branch)
- `pnpm test`: 479 files, 6915 tests passed
- `pnpm typecheck`: clean
- `npx prettier --check .`: all files formatted
- `npx eslint .`: 0 errors, 216 warnings (all pre-existing `tenancy/no-unscoped-groq` in unrelated routers; none in changed files)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents self-hosted contract-signing links from resolving through `NEXTAUTH_URL`, avoiding fixed-origin behavior that can break authentication across tenant domains.

- Preserves tenant-provided base URLs as the preferred signing-link origin and uses platform URL variables only as fallbacks.
- Updates authentication warnings, system-status remediation, and sponsor documentation to recommend `NEXT_PUBLIC_BASE_URL`.
- Adds regression coverage proving `NEXTAUTH_URL` cannot influence signing-link resolution.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and consistently removes the unsafe fixed-auth-origin dependency from contract signing.

Tenant-scoped caller URLs remain preferred, supported platform fallbacks remain available, diagnostics point operators to the replacement variable, and regression tests cover the removed NEXTAUTH_URL behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/contract-signing/self-hosted.ts | Removes the unsafe NEXTAUTH_URL fallback while retaining tenant-first and platform-level URL resolution with actionable failure guidance. |
| src/lib/contract-signing/self-hosted.test.ts | Adds focused regression tests for tenant origins, supported platform fallback, ignored NEXTAUTH_URL, and missing-base diagnostics. |
| src/lib/auth.ts | Corrects fixed-auth-origin remediation so it no longer claims contract signing reads NEXTAUTH_URL. |
| src/lib/system-status/checks.ts | Aligns system-status remediation with the revised signing URL contract. |
| src/lib/system-status/checks.test.ts | Updates the remediation assertion to require the supported side-effect-free platform URL variable. |
| src/docs/SponsorSystem.stories.tsx | Documents NEXT_PUBLIC_BASE_URL as the contract-signing fallback instead of NEXTAUTH_URL. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Caller["Contract-signing caller"] --> Tenant{"Tenant baseUrl supplied?"}
  Tenant -->|Yes| TenantOrigin["Use tenant conference origin"]
  Tenant -->|No| Platform["Resolve NEXT_PUBLIC_BASE_URL → NEXT_PUBLIC_URL → VERCEL_URL"]
  Platform --> Available{"Platform origin available?"}
  Available -->|Yes| SigningLink["Build /sponsor/contract/sign/token"]
  Available -->|No| Error["Throw Missing base URL"]
  FixedAuth["NEXTAUTH_URL / AUTH_URL"] -. deliberately ignored .-> Platform
```

<sub>Reviews (1): Last reviewed commit: ["fix(security): drop NEXTAUTH\_URL from co..."](https://github.com/cloudnativebergen/website/commit/5bf53d44c59b7fbd042d556d413ccffa5c77fcea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50364067)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Authentication and Access Control](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/auth-access.md)
- Knowledge Base — [Conference Core: Editions, Settings & AI Agent Config](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/conference-core.md)
- Knowledge Base — [Ticketing and contract e-signature](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/ticketing-signing.md)
</details>

<!-- /greptile_comment -->