### PR TITLE
fix(brand): use konf.app's real lockup on the platform landing page

### DIFF
--- a/src/components/PlatformLanding.tsx
+++ b/src/components/PlatformLanding.tsx
@@ -1,4 +1,3 @@
-import { BrandWordmark } from '@/components/BrandWordmark'
 import { PLATFORM_NAME } from '@/lib/branding/platform'
 
 export interface PlatformLandingProps {
@@ -28,14 +27,44 @@ export function PlatformLanding({ signupUrl }: PlatformLandingProps) {
         className="pointer-events-none absolute inset-0 bg-linear-to-b from-brand-sky-mist/60 via-transparent to-transparent dark:from-blue-950/40"
       />
       <div className="relative flex w-full max-w-lg flex-col items-center text-center">
-        {/* This screen is the PLATFORM's own, not any tenant's — so it carries
-            the platform wordmark. It used to render the Cloud Native Days mark
-            under an aria-label that already said "Konf". */}
-        <BrandWordmark
-          name={PLATFORM_NAME}
-          variant="monochrome"
-          className="h-16 w-auto text-brand-cloud-blue dark:text-white"
-        />
+        {/* This screen is the PLATFORM's own, not any tenant's, so it carries
+            the platform's lockup — reproduced from konf.app's, which is the
+            authority (RunKonf/landingpage `index.html`, `.brand-lockup`).
+
+            The lockup is a badge MARK plus the word as LIVE TEXT, not a single
+            piece of vector art: the mark is stroked ember on both grounds while
+            the word takes the ground's foreground, and the trailing dot is
+            ember in both. Geometry, stroke widths and the `#e8823c` ember are
+            copied verbatim from konf.app; the font stack mirrors its
+            `--display`. Redrawing the word as paths (what this used to do)
+            produced a lockup that was subtly not the brand's — no dot, wrong
+            letterforms. */}
+        <div className="flex items-center gap-3">
+          <svg
+            viewBox="0 0 100 100"
+            aria-hidden="true"
+            className="h-14 w-14 flex-none"
+            fill="none"
+            stroke="#e8823c"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <rect x="28" y="20" width="44" height="60" rx="9" strokeWidth="7" />
+            <line x1="44" y1="31" x2="56" y2="31" strokeWidth="6" />
+            <line x1="42" y1="44" x2="42" y2="70" strokeWidth="7" />
+            <path d="M58 44 L45 57 L58 70" strokeWidth="7" />
+          </svg>
+          <span
+            className="text-5xl leading-none font-semibold tracking-[0.01em] text-brand-slate-gray dark:text-[#e9f0f4]"
+            style={{
+              fontFamily:
+                "Futura, 'Avenir Next', 'Century Gothic', system-ui, sans-serif",
+            }}
+          >
+            {PLATFORM_NAME.toLowerCase()}
+            <span className="text-[#e8823c]">.</span>
+          </span>
+        </div>
 
         <h1 className="font-jetbrains mt-10 text-3xl font-bold tracking-tighter text-brand-slate-gray sm:text-4xl dark:text-white">
           No conference here yet


### PR DESCRIPTION
The unknown-host screen (`https://foo.konf.run/`, and every host that resolves to no conference) rendered `BrandWordmark` — a wordmark generated from the platform name string. So the one page that is unambiguously Konf's own did not carry Konf's logo.

## What the lockup actually is

Reproduced from its authority, konf.app (`RunKonf/landingpage` → `index.html`, `.brand-lockup`):

- **badge mark** — SVG, stroke `#e8823c` (ember), `fill: none`, round caps and joins. Geometry and stroke widths copied verbatim.
- **wordmark** — LIVE TEXT in the `--display` stack (Futura / Avenir Next / Century Gothic), weight 600, letter-spacing `0.01em`, taking the ground's foreground colour…
- **…closing with an ember dot.**

## Note for the next person

An earlier attempt at this redrew the whole lockup as vector paths, reasoning that art renders identically everywhere with no font dependency. The reasoning is sound in general and was wrong here: the result had subtly wrong letterforms and **omitted the dot entirely**, which is the distinctive part of the mark. Copying the brand beats re-deriving it.

The mark stays ember on both grounds while only the word changes colour, which is why it is composed rather than shipped as one tinted asset.

## Gates

- `pnpm test` — 480 files / 6,923 tests pass
- `pnpm typecheck` — clean
- `npx eslint` / `prettier --check` on the changed file — clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the generated platform wordmark on the unknown-host landing page with Konf’s authoritative badge-and-live-text lockup.
- Adds the ember badge as inline SVG geometry.
- Renders the lowercase platform name in the display font stack with the distinctive ember dot.
- Preserves light- and dark-ground foreground colors for the live wordmark.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The fixed `Konf` text, decorative hidden badge, and compact responsive lockup preserve accessible content and fit the landing page’s existing layout.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/PlatformLanding.tsx | Replaces the generic BrandWordmark with a static Konf badge and live-text lockup without introducing a concrete runtime, accessibility, or responsive-layout defect. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(brand): use konf.app&#39;s real lockup o..."](https://github.com/cloudnativebergen/website/commit/2b5e38d7e1043d143efad2137afbce719f00f125) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50405222)</sub>

<!-- /greptile_comment -->