### PR TITLE
fix(tenancy): scope ticketing and Slack credentials to the owning organization

### DIFF
--- a/__tests__/lib/slack/client.test.ts
+++ b/__tests__/lib/slack/client.test.ts
@@ -10,6 +10,12 @@ let savedNodeEnv: string | undefined
 let savedBotToken: string | undefined
 let savedFetch: typeof global.fetch
 
+/**
+ * NOTE: `SLACK_BOT_TOKEN` is set here only to prove the transport IGNORES it.
+ * `postSlackMessage` has no env fallback — the token must be injected by
+ * `resolveConferenceSlackToken` at the caller's boundary (see
+ * `src/lib/slack/token.test.ts` for the isolation rules that resolver enforces).
+ */
 function setEnv(opts: { nodeEnv: string; botToken?: string }) {
   ;(process.env as Record<string, string | undefined>).NODE_ENV = opts.nodeEnv
   if (opts.botToken !== undefined) {
@@ -93,6 +99,7 @@ describe('Slack client', () => {
       await postSlackMessage(testMessage, {
         channel: '#test',
         forceSlack: true,
+        botToken: 'xoxb-test',
       })
 
       expect(mockFetch).toHaveBeenCalledWith(
@@ -112,7 +119,10 @@ describe('Slack client', () => {
       } as Response)
 
       const { postSlackMessage } = await import('@/lib/slack/client')
-      await postSlackMessage(testMessage, { channel: '#sales' })
+      await postSlackMessage(testMessage, {
+        channel: '#sales',
+        botToken: 'xoxb-test-token',
+      })
 
       expect(mockFetch).toHaveBeenCalledWith(
         'https://slack.com/api/chat.postMessage',
@@ -140,7 +150,10 @@ describe('Slack client', () => {
 
       const { postSlackMessage } = await import('@/lib/slack/client')
       await expect(
-        postSlackMessage(testMessage, { channel: '#bad' }),
+        postSlackMessage(testMessage, {
+          channel: '#bad',
+          botToken: 'xoxb-test',
+        }),
       ).rejects.toThrow('Slack API error: channel_not_found')
     })
 
@@ -155,20 +168,47 @@ describe('Slack client', () => {
 
       const { postSlackMessage } = await import('@/lib/slack/client')
       await expect(
-        postSlackMessage(testMessage, { channel: '#test' }),
+        postSlackMessage(testMessage, {
+          channel: '#test',
+          botToken: 'xoxb-test',
+        }),
       ).rejects.toThrow('Slack API HTTP 401: Unauthorized')
     })
   })
 
   describe('missing configuration', () => {
-    it('should warn when no bot token', async () => {
+    it('should warn and NOT send when no bot token is injected', async () => {
       setEnv({ nodeEnv: 'production' })
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      global.fetch = mockFetch
 
       const { postSlackMessage } = await import('@/lib/slack/client')
       await postSlackMessage(testMessage, { channel: '#test' })
 
-      expect(warnSpy).toHaveBeenCalledWith('SLACK_BOT_TOKEN is not configured')
+      expect(warnSpy).toHaveBeenCalledWith(
+        'No Slack bot token resolved for this organization, skipping notification',
+      )
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    /**
+     * THE ISOLATION PIN. The transport used to end
+     * `injectedToken ?? process.env.SLACK_BOT_TOKEN`, so any caller that
+     * resolved no token silently posted with the PLATFORM's bot into a
+     * tenant-editable channel name. Restoring that fallback flips this case.
+     */
+    it('IGNORES process.env.SLACK_BOT_TOKEN when no token is injected', async () => {
+      setEnv({ nodeEnv: 'production', botToken: 'xoxb-platform-bot' })
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      global.fetch = mockFetch
+
+      const { postSlackMessage } = await import('@/lib/slack/client')
+      await postSlackMessage(testMessage, { channel: '#tenant-typed-channel' })
+
+      expect(mockFetch).not.toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalledWith(
+        'No Slack bot token resolved for this organization, skipping notification',
+      )
     })
 
     it('should warn when no channel specified', async () => {
@@ -176,7 +216,7 @@ describe('Slack client', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const { postSlackMessage } = await import('@/lib/slack/client')
-      await postSlackMessage(testMessage)
+      await postSlackMessage(testMessage, { botToken: 'xoxb-test' })
 
       expect(warnSpy).toHaveBeenCalledWith(
         'No Slack channel specified, skipping notification',

--- a/__tests__/lib/slack/weeklyUpdate.test.ts
+++ b/__tests__/lib/slack/weeklyUpdate.test.ts
@@ -14,6 +14,34 @@ import type {
 import type { TicketAnalysisResult } from '@/lib/tickets/types'
 import { createMockConference } from '../../testdata/conference'
 
+/**
+ * The weekly-update cron is a REAL Slack sender, so it now resolves its bot
+ * token through `resolveConferenceSlackToken` — meaning the conference must be
+ * owned by an org the `slack-mirror` gate allows. These tests run as the
+ * PLATFORM org (production's Cloud Native Days), which is exactly the case that
+ * must keep working. `src/lib/slack/token.test.ts` covers the denial side.
+ */
+const PLATFORM_ORG_ID = 'org-platform'
+
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationById: vi.fn(async (id: string) => ({
+    _id: id,
+    name: 'Platform Org',
+    slug: 'platform-org',
+  })),
+  getOrganizationRefForCurrentConference: vi.fn(),
+}))
+
+/** A conference OWNED by the platform org — the weekly update's real shape. */
+function platformConference(
+  overrides: Parameters<typeof createMockConference>[0] = {},
+) {
+  return createMockConference({
+    organization: { _ref: PLATFORM_ORG_ID, _type: 'reference' },
+    ...overrides,
+  })
+}
+
 const mockFetch = vi.fn() as MockedFunction<typeof global.fetch>
 
 let savedNodeEnv: string | undefined
@@ -22,6 +50,7 @@ let savedFetch: typeof global.fetch
 
 function setEnv(nodeEnv: string, botToken?: string) {
   ;(process.env as Record<string, string | undefined>).NODE_ENV = nodeEnv
+  process.env.PLATFORM_ORG_ID = PLATFORM_ORG_ID
   if (botToken !== undefined) {
     process.env.SLACK_BOT_TOKEN = botToken
   } else {
@@ -31,6 +60,7 @@ function setEnv(nodeEnv: string, botToken?: string) {
 
 function restoreEnv() {
   ;(process.env as Record<string, string | undefined>).NODE_ENV = savedNodeEnv
+  delete process.env.PLATFORM_ORG_ID
   if (savedBotToken !== undefined) {
     process.env.SLACK_BOT_TOKEN = savedBotToken
   } else {
@@ -42,7 +72,7 @@ function createBaseUpdateData(
   overrides: Partial<WeeklyUpdateData> = {},
 ): WeeklyUpdateData {
   return {
-    conference: createMockConference({
+    conference: platformConference({
       salesNotificationChannel: '#sales',
     }),
     ticketsByCategory: { Regular: 50 },
@@ -145,7 +175,37 @@ describe('weeklyUpdate', () => {
         await import('@/lib/slack/weeklyUpdate')
       await sendWeeklyUpdateToSlack(createBaseUpdateData())
 
-      expect(warnSpy).toHaveBeenCalledWith('SLACK_BOT_TOKEN is not configured')
+      expect(warnSpy).toHaveBeenCalledWith(
+        'No Slack bot token resolved for this organization, skipping notification',
+      )
+    })
+
+    /**
+     * The cron sends for EVERY conference with a channel configured, across every
+     * tenant. It injects whatever `resolveConferenceSlackToken` returns, so a
+     * conference owned by a non-platform org sends nothing — no per-call guard
+     * needed in the cron itself.
+     */
+    it('sends NOTHING for a conference owned by a non-platform org', async () => {
+      setEnv('production', 'xoxb-platform-bot')
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      global.fetch = mockFetch
+
+      const { sendWeeklyUpdateToSlack } =
+        await import('@/lib/slack/weeklyUpdate')
+      await sendWeeklyUpdateToSlack(
+        createBaseUpdateData({
+          conference: createMockConference({
+            salesNotificationChannel: '#their-channel',
+            organization: { _ref: 'org-second-tenant', _type: 'reference' },
+          }),
+        }),
+      )
+
+      expect(mockFetch).not.toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalledWith(
+        'No Slack bot token resolved for this organization, skipping notification',
+      )
     })
 
     it('should send message via bot token in production', async () => {
@@ -160,7 +220,7 @@ describe('weeklyUpdate', () => {
         await import('@/lib/slack/weeklyUpdate')
       await sendWeeklyUpdateToSlack(
         createBaseUpdateData({
-          conference: createMockConference({
+          conference: platformConference({
             salesNotificationChannel: '#sales-updates',
           }),
         }),
@@ -199,7 +259,7 @@ describe('weeklyUpdate', () => {
       await expect(
         sendWeeklyUpdateToSlack(
           createBaseUpdateData({
-            conference: createMockConference({
+            conference: platformConference({
               salesNotificationChannel: '#test',
             }),
           }),
@@ -218,7 +278,7 @@ describe('weeklyUpdate', () => {
       const { sendWeeklyUpdateToSlack } =
         await import('@/lib/slack/weeklyUpdate')
       const data = createBaseUpdateData({
-        conference: createMockConference({
+        conference: platformConference({
           salesNotificationChannel: '#conference-sales',
         }),
       })

--- a/docs/TENANT_SECRETS.md
+++ b/docs/TENANT_SECRETS.md
@@ -114,17 +114,30 @@ family, stores)`) for tests and alternate compositions.
 
 ## Wired consumers
 
-| Family    | Boundary                                                                     | Status                                                                                                                                                                                               |
-| --------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ticketing | `resolveTicketingProvider` (`src/lib/tickets/provider/index.ts`)             | **Wired (Checkin + Tito).** Branches on `conference.ticketingProvider`; Checkin falls back to `platformCheckinCredentials()`, Tito to `platformTitoCredentials()` (per-org via the JSON store only). |
-| email     | `resolveEmailSender(orgId)` (`src/lib/email/config.ts`)                      | **Wired (seam).** Lazily-constructed per-credentials client factory + cached default.                                                                                                                |
-| slack     | `resolveConferenceSlackToken(conference)` → `postSlackMessage({ botToken })` | **Wired.** Notify paths, weekly-update cron, and the status probe inject the org token.                                                                                                              |
-| push      | `resolveTenantSecrets(orgId, 'push')`                                        | **Seam only.** Env-only; VAPID config is process-global (see the TODO in `push/vapid.ts`).                                                                                                           |
-| badge     | `resolveTenantSecrets(orgId, 'badge')`                                       | **Seam only.** Env-only; signing keys thread through pure config (TODO in `badge/config.ts`).                                                                                                        |
+| Family    | Boundary                                                                     | Status                                                                                                                                                                                                                                                          |
+| --------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ticketing | `resolveTicketingCredentials` (`src/lib/tickets/provider/index.ts`)          | **Wired (Checkin + Tito).** Per-org secret wins; the platform env is handed out **only to the platform org** (`PLATFORM_ORG_ID`). Any other org resolves to `null` ⇒ the conference reports unconfigured.                                                       |
+| email     | `resolveEmailSender(orgId)` (`src/lib/email/config.ts`)                      | **Wired (seam).** Lazily-constructed per-credentials client factory + cached default.                                                                                                                                                                           |
+| slack     | `resolveConferenceSlackToken(conference)` → `postSlackMessage({ botToken })` | **Wired + gated.** The ONLY token source — `postSlackMessage` has no env fallback. A per-org token always wins; the platform `SLACK_BOT_TOKEN` requires the `slack-mirror` entitlement (`src/lib/features/slack.ts`), which defaults to the platform org alone. |
+| push      | `resolveTenantSecrets(orgId, 'push')`                                        | **Seam only.** Env-only; VAPID config is process-global (see the TODO in `push/vapid.ts`).                                                                                                                                                                      |
+| badge     | `resolveTenantSecrets(orgId, 'badge')`                                       | **Seam only.** Env-only; signing keys thread through pure config (TODO in `badge/config.ts`).                                                                                                                                                                   |
 
-Direct `platformCheckinCredentials()` callers that operate **outside** an org
-context (the Checkin webhook, the public event lookup, cross-tenant admin ticket
-pages) intentionally keep using the platform env default.
+The one remaining direct `platformCheckinCredentials()` consumer is the inbound
+`/api/webhooks/checkin/ticket-sold` route, which verifies a signature **before**
+any tenant is known and so has no org to key on. Every org-aware surface —
+including the `tickets` tRPC router and the admin ticket sub-pages — resolves
+through `resolveTicketingCredentials`.
+
+### Why the platform env is gated, not shared
+
+Both env credentials are single upstream ACCOUNTS, and both are addressed by
+TENANT-EDITABLE identifiers: a conference's `checkinEventId` / `titoEventSlug`,
+and Slack's `cfpNotificationChannel` / `salesNotificationChannel`. Sharing the
+account therefore lets a tenant's own document fields address the platform's
+account, and no Sanity-side guard can see a provider id or a channel name.
+Withholding the credential is the isolation. A tenant that legitimately needs the
+integration gets its OWN secret provisioned, which addresses its own account and
+needs no gate.
 
 ## What the later #617 wave adds
 

--- a/src/app/(admin)/admin/tickets/companies/page.tsx
+++ b/src/app/(admin)/admin/tickets/companies/page.tsx
@@ -1,7 +1,7 @@
 import { groupTicketsByOrder } from '@/lib/tickets/api'
 import {
   getTicketingProvider,
-  platformCheckinCredentials,
+  resolveTicketingCredentials,
 } from '@/lib/tickets/provider'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import type { EventTicket, GroupedOrder } from '@/lib/tickets/types'
@@ -16,15 +16,20 @@ import Link from 'next/link'
 import { EmptyState } from '@/components/EmptyState'
 import { CompanyBreakdownTable } from './CompanyBreakdownTable'
 
+/**
+ * Credentials come from the per-org seam, keyed on the conference's owning
+ * organization — never straight off the platform env. A tenant the seam has no
+ * credentials for renders the same empty state as an unbound conference.
+ */
 async function getTicketData(
+  orgId: string | undefined,
   customerId: number,
   eventId: number,
 ): Promise<EventTicket[]> {
+  const credentials = await resolveTicketingCredentials(orgId, 'checkin')
+  if (!credentials) return []
   try {
-    const provider = getTicketingProvider(
-      'checkin',
-      platformCheckinCredentials(),
-    )
+    const provider = getTicketingProvider('checkin', credentials)
     return await provider.fetchEventTickets({ customerId, eventId })
   } catch (error) {
     throw new Error(
@@ -256,6 +261,7 @@ export default async function CompaniesAdminPage() {
 
   try {
     allTickets = await getTicketData(
+      conference.organization?._ref,
       conference.checkinCustomerId,
       conference.checkinEventId,
     )

--- a/src/app/(admin)/admin/tickets/orders/page.tsx
+++ b/src/app/(admin)/admin/tickets/orders/page.tsx
@@ -1,7 +1,7 @@
 import { groupTicketsByOrder } from '@/lib/tickets/api'
 import {
   getTicketingProvider,
-  platformCheckinCredentials,
+  resolveTicketingCredentials,
 } from '@/lib/tickets/provider'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import type { EventTicket } from '@/lib/tickets/types'
@@ -17,15 +17,20 @@ import {
 import Link from 'next/link'
 import { EmptyState } from '@/components/EmptyState'
 
+/**
+ * Credentials come from the per-org seam, keyed on the conference's owning
+ * organization — never straight off the platform env. A tenant the seam has no
+ * credentials for renders the same empty state as an unbound conference.
+ */
 async function getTicketData(
+  orgId: string | undefined,
   customerId: number,
   eventId: number,
 ): Promise<EventTicket[]> {
+  const credentials = await resolveTicketingCredentials(orgId, 'checkin')
+  if (!credentials) return []
   try {
-    const provider = getTicketingProvider(
-      'checkin',
-      platformCheckinCredentials(),
-    )
+    const provider = getTicketingProvider('checkin', credentials)
     return await provider.fetchEventTickets({ customerId, eventId })
   } catch (error) {
     throw new Error(`Unable to fetch tickets: ${(error as Error).message}`)
@@ -63,6 +68,7 @@ export default async function OrdersAdminPage() {
 
   try {
     allTickets = await getTicketData(
+      conference.organization?._ref,
       conference.checkinCustomerId,
       conference.checkinEventId,
     )

--- a/src/app/(admin)/admin/tickets/types/page.tsx
+++ b/src/app/(admin)/admin/tickets/types/page.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/lib/tickets/public'
 import {
   getTicketingProvider,
-  platformCheckinCredentials,
+  resolveTicketingCredentials,
 } from '@/lib/tickets/provider'
 import { ErrorDisplay, AdminPageHeader } from '@/components/admin'
 import { TicketIcon } from '@heroicons/react/24/outline'
@@ -70,14 +70,19 @@ export default async function TicketTypesAdminPage() {
   let error: string | null = null
 
   try {
-    const provider = getTicketingProvider(
+    // Credentials come from the per-org seam, keyed on the conference's owning
+    // organization — never straight off the platform env.
+    const credentials = await resolveTicketingCredentials(
+      conference.organization?._ref,
       'checkin',
-      platformCheckinCredentials(),
     )
-    const data = await provider.fetchPublicTicketTypes(
-      conference.checkinEventId,
-    )
-    tickets = data.tickets.sort((a, b) => a.position - b.position)
+    if (credentials) {
+      const provider = getTicketingProvider('checkin', credentials)
+      const data = await provider.fetchPublicTicketTypes(
+        conference.checkinEventId,
+      )
+      tickets = data.tickets.sort((a, b) => a.position - b.position)
+    }
   } catch (err) {
     error = (err as Error).message
   }

--- a/src/components/admin/system-status/SelfCheckPanel.tsx
+++ b/src/components/admin/system-status/SelfCheckPanel.tsx
@@ -24,10 +24,16 @@ export function SelfCheckPanel() {
     setSlackState(null)
     try {
       const res = await slack.mutateAsync()
+      // `notEnabled` is not a fault to fix — this organization has no Slack
+      // integration — so it reads MUTED, never amber. `slack-mirror` is an
+      // internal-readiness feature, so there is deliberately no upsell here.
       setSlackState(
         res.ok
           ? { tone: 'success', text: `Posted to ${res.channel}` }
-          : { tone: 'warn', text: res.error ?? 'Slack probe failed' },
+          : {
+              tone: 'notEnabled' in res && res.notEnabled ? 'muted' : 'warn',
+              text: res.error ?? 'Slack probe failed',
+            },
       )
     } catch (err) {
       setSlackState({ tone: 'warn', text: messageFromError(err) })

--- a/src/lib/features/registry.ts
+++ b/src/lib/features/registry.ts
@@ -31,12 +31,13 @@ import {
  *   revokes a feature the plan would grant. An override whose `expiresAt` is
  *   in the past is ignored entirely.
  *
- * The set is intentionally SMALL and truthful. `graphql-api`,
- * `dedicated-email` and `slack-mirror` are still foundation-only (not enforced
- * anywhere). `workshops` IS enforced — see `./workshops.ts` for the single
- * resolver every workshop surface and the ticket-sold email go through.
- * Enforcement is wired per-feature via that pattern or the `requireFeature`
- * tRPC middleware.
+ * The set is intentionally SMALL and truthful. `graphql-api` and
+ * `dedicated-email` are still foundation-only (not enforced anywhere).
+ * `workshops` and `slack-mirror` ARE enforced — see `./workshops.ts` and
+ * `./slack.ts` for the single resolver each of their surfaces goes through
+ * (`slack-mirror` gates the PLATFORM's shared Slack bot token, consumed at the
+ * one chokepoint `resolveConferenceSlackToken`). Enforcement is wired
+ * per-feature via that pattern or the `requireFeature` tRPC middleware.
  */
 
 export const FEATURE_IDS = [

--- a/src/lib/features/slack.test.ts
+++ b/src/lib/features/slack.test.ts
@@ -1,0 +1,224 @@
+/**
+ * @vitest-environment node
+ *
+ * The `slack-mirror` feature gate — the ONE resolver deciding whether an
+ * organization may send with the PLATFORM's Slack bot token.
+ *
+ * Same two boundaries as the workshops gate it mirrors:
+ *
+ *  - `@/lib/organization/sanity` — the CACHED org document, carrying `plan` and
+ *    `featureOverrides`; the real entitlement resolution runs on top of it.
+ *  - The platform-org identity is `isPlatformOrganization`, a pure id comparison
+ *    against `PLATFORM_ORG_ID`. No Sanity read is involved, so the
+ *    `@/lib/sanity/client` mock is a TRIPWIRE: a reintroduced slug (or any
+ *    other) lookup would call `h.fetch` and trip the no-fetch guards.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Organization } from '@/lib/organization/types'
+
+const getOrganizationById = vi.fn()
+const getOrganizationRefForCurrentConference = vi.fn()
+
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationById: (...args: unknown[]) => getOrganizationById(...args),
+  getOrganizationRefForCurrentConference: () =>
+    getOrganizationRefForCurrentConference(),
+}))
+
+// TRIPWIRE only — the platform-org check must read NO Sanity.
+const h = vi.hoisted(() => ({
+  fetch: vi.fn<(query: string, params?: unknown) => Promise<unknown>>(),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: h.fetch },
+}))
+
+import {
+  isSlackMirrorEnabledForOrg,
+  isSlackMirrorEnabledForConference,
+  isSlackMirrorEnabledForCurrentOrg,
+} from './slack'
+
+/** The configured platform org's document id — deliberately distinct from the
+ * default tenant `org-A`, so ordinary-tenant cases are never accidentally
+ * platform. */
+const PLATFORM_ORG_ID = 'org-platform'
+
+function org(overrides: Partial<Organization> = {}): Organization {
+  return {
+    _id: 'org-A',
+    name: 'Tenant A',
+    slug: 'tenant-a',
+    ...overrides,
+  }
+}
+
+const PAST = '2020-01-01T00:00:00.000Z'
+const FUTURE = '2999-01-01T00:00:00.000Z'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubEnv('PLATFORM_ORG_ID', PLATFORM_ORG_ID)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('isSlackMirrorEnabledForOrg — fail closed', () => {
+  it('is DISABLED and reads nothing when the org cannot be resolved', async () => {
+    await expect(isSlackMirrorEnabledForOrg(null)).resolves.toBe(false)
+    await expect(isSlackMirrorEnabledForOrg(undefined)).resolves.toBe(false)
+    await expect(isSlackMirrorEnabledForOrg('')).resolves.toBe(false)
+    expect(getOrganizationById).not.toHaveBeenCalled()
+  })
+
+  it('is DISABLED for an unknown organization document', async () => {
+    getOrganizationById.mockResolvedValue(null)
+    await expect(isSlackMirrorEnabledForOrg('org-missing')).resolves.toBe(false)
+  })
+
+  it('is DISABLED — not thrown — when the organization read REJECTS', async () => {
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {})
+    getOrganizationById.mockRejectedValue(new Error('sanity unavailable'))
+
+    await expect(isSlackMirrorEnabledForOrg('org-A')).resolves.toBe(false)
+    expect(logged).toHaveBeenCalled()
+    logged.mockRestore()
+  })
+
+  it('is DISABLED for an ordinary tenant on every plan', async () => {
+    for (const plan of ['community', 'pro', 'enterprise'] as const) {
+      getOrganizationById.mockResolvedValue(org({ plan }))
+      await expect(isSlackMirrorEnabledForOrg('org-A')).resolves.toBe(false)
+    }
+  })
+})
+
+describe('isSlackMirrorEnabledForOrg — overrides', () => {
+  it('is ENABLED by an explicit grant, regardless of plan', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        plan: 'community',
+        featureOverrides: [{ feature: 'slack-mirror', enabled: true }],
+      }),
+    )
+    await expect(isSlackMirrorEnabledForOrg('org-A')).resolves.toBe(true)
+  })
+
+  it('ignores an EXPIRED grant', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        featureOverrides: [
+          { feature: 'slack-mirror', enabled: true, expiresAt: PAST },
+        ],
+      }),
+    )
+    await expect(isSlackMirrorEnabledForOrg('org-A')).resolves.toBe(false)
+  })
+
+  it('honours a grant that has not expired yet', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        featureOverrides: [
+          { feature: 'slack-mirror', enabled: true, expiresAt: FUTURE },
+        ],
+      }),
+    )
+    await expect(isSlackMirrorEnabledForOrg('org-A')).resolves.toBe(true)
+  })
+
+  it('ignores an override for a different feature', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({ featureOverrides: [{ feature: 'workshops', enabled: true }] }),
+    )
+    await expect(isSlackMirrorEnabledForOrg('org-A')).resolves.toBe(false)
+  })
+})
+
+describe('isSlackMirrorEnabledForOrg — the platform org keeps working', () => {
+  it('is ENABLED for the org whose id is PLATFORM_ORG_ID, with no override', async () => {
+    getOrganizationById.mockResolvedValue(org({ _id: PLATFORM_ORG_ID }))
+    await expect(isSlackMirrorEnabledForOrg(PLATFORM_ORG_ID)).resolves.toBe(
+      true,
+    )
+    expect(h.fetch).not.toHaveBeenCalled()
+  })
+
+  it('is DISABLED for that same org when the contract is unset', async () => {
+    vi.stubEnv('PLATFORM_ORG_ID', '')
+    getOrganizationById.mockResolvedValue(org({ _id: PLATFORM_ORG_ID }))
+    await expect(isSlackMirrorEnabledForOrg(PLATFORM_ORG_ID)).resolves.toBe(
+      false,
+    )
+  })
+
+  it('lets an explicit DENY override revoke it from the platform org', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        _id: PLATFORM_ORG_ID,
+        featureOverrides: [{ feature: 'slack-mirror', enabled: false }],
+      }),
+    )
+    await expect(isSlackMirrorEnabledForOrg(PLATFORM_ORG_ID)).resolves.toBe(
+      false,
+    )
+  })
+
+  it('ignores an EXPIRED deny override on the platform org', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        _id: PLATFORM_ORG_ID,
+        featureOverrides: [
+          { feature: 'slack-mirror', enabled: false, expiresAt: PAST },
+        ],
+      }),
+    )
+    await expect(isSlackMirrorEnabledForOrg(PLATFORM_ORG_ID)).resolves.toBe(
+      true,
+    )
+  })
+
+  it('DENIES an org whose cached slug looks like the platform but whose id is not PLATFORM_ORG_ID', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({ _id: 'org-A', slug: 'platform-org' }),
+    )
+    await expect(isSlackMirrorEnabledForOrg('org-A')).resolves.toBe(false)
+    expect(h.fetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('isSlackMirrorEnabledForConference', () => {
+  it('keys on the conference OWNER, not the request host', async () => {
+    getOrganizationById.mockResolvedValue(org({ _id: PLATFORM_ORG_ID }))
+    await expect(
+      isSlackMirrorEnabledForConference({
+        organization: { _ref: PLATFORM_ORG_ID, _type: 'reference' },
+      }),
+    ).resolves.toBe(true)
+    expect(getOrganizationById).toHaveBeenCalledWith(PLATFORM_ORG_ID)
+  })
+
+  it('is DISABLED for a conference with no organization (fail closed)', async () => {
+    await expect(isSlackMirrorEnabledForConference({})).resolves.toBe(false)
+    await expect(isSlackMirrorEnabledForConference(null)).resolves.toBe(false)
+    expect(getOrganizationById).not.toHaveBeenCalled()
+  })
+})
+
+describe('isSlackMirrorEnabledForCurrentOrg', () => {
+  it('resolves the org from the request domain', async () => {
+    getOrganizationRefForCurrentConference.mockResolvedValue('org-A')
+    getOrganizationById.mockResolvedValue(
+      org({ featureOverrides: [{ feature: 'slack-mirror', enabled: true }] }),
+    )
+    await expect(isSlackMirrorEnabledForCurrentOrg()).resolves.toBe(true)
+  })
+
+  it('is DISABLED when the request domain resolves to no org', async () => {
+    getOrganizationRefForCurrentConference.mockResolvedValue(null)
+    await expect(isSlackMirrorEnabledForCurrentOrg()).resolves.toBe(false)
+    expect(getOrganizationById).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/features/slack.ts
+++ b/src/lib/features/slack.ts
@@ -1,0 +1,135 @@
+import 'server-only'
+import { getOrganizationById } from '@/lib/organization/sanity'
+import { resolveCurrentOrgId } from '@/lib/authz/organizer'
+import { computeEntitlements, hasActiveOverride } from './entitlements'
+import { isPlatformOrganization } from './platform'
+
+/**
+ * THE single gate for the `slack-mirror` feature — enforcement for the registry
+ * id that has existed since the entitlements work but gated nothing.
+ *
+ * WHY IT IS GATED. `SLACK_BOT_TOKEN` is ONE bot installed in ONE Slack
+ * workspace: the platform org's. The channel each message goes to, however, is
+ * TENANT-EDITABLE — `cfpNotificationChannel` and `salesNotificationChannel` are
+ * plain string fields on the conference document, editable from any tenant's own
+ * admin settings page. So a shared token plus a tenant-typed channel name means
+ * one tenant's CFP submissions, sponsor contracts and weekly revenue updates are
+ * posted into the platform's workspace, addressed by a string that tenant chose.
+ * There is no cross-check that the channel belongs to the tenant, because there
+ * cannot be: it is the platform's workspace, and every channel in it is the
+ * platform's. Withholding the token is the only isolation available.
+ *
+ * A tenant that legitimately wants Slack gets its OWN bot token provisioned into
+ * the per-org secret store, which this gate does not stand in front of (see
+ * `resolveConferenceSlackToken`) — that token addresses the tenant's own
+ * workspace, so no isolation question arises.
+ *
+ * RESOLUTION ORDER — fail-CLOSED at every step, identical in shape to
+ * `./workshops.ts` (read that first; the ordering there is deliberate):
+ *
+ *  1. No resolvable org (unknown domain, missing org document, or a REJECTED
+ *     org read) → DISABLED. An unresolvable tenant must never degrade into
+ *     "send it anyway".
+ *  2. An ACTIVE `featureOverrides` entry for `slack-mirror` wins, in BOTH
+ *     directions — `enabled: true` grants it, `enabled: false` revokes it even
+ *     from the platform org (rule 3). NOTE: a grant hands out the PLATFORM's bot
+ *     token, so it should be reserved for orgs operated on the platform's own
+ *     workspace; provisioning a per-org token is the right answer for everyone
+ *     else and needs no override at all.
+ *  3. The org whose id is `PLATFORM_ORG_ID` keeps Slack by default. The bot and
+ *     the workspace belong to the platform deployment, so the platform org is
+ *     the one tenant the shared token is actually FOR — this is what keeps
+ *     today's behaviour byte-identical for it without a data migration.
+ *  4. Anything else → DISABLED, i.e. `resolveConferenceSlackToken` returns
+ *     `undefined` and `postSlackMessage` takes its existing no-op-warn path.
+ *
+ * ONE READ ONLY: `plan` and `featureOverrides` come from `getOrganizationById`
+ * (cached, tagged `organizationTag(orgId)`, so an override flip takes effect by
+ * invalidation); rule 3's identity comes from `isPlatformOrganization`, a pure id
+ * comparison against `PLATFORM_ORG_ID` with no read and no staleness window.
+ * Override expiry is evaluated per call against a fresh `now`.
+ *
+ * DEV BEHAVIOUR: `PLATFORM_ORG_ID` is set on production and preview but NOT in
+ * local development, so this returns false for everything locally and no Slack
+ * token resolves. That is the intended posture — `postSlackMessage` already
+ * short-circuits to a console log when `NODE_ENV === 'development'`, so a
+ * developer never had a working send to lose. There is deliberately NO
+ * development-only fallback: one would have to live in the same code path that
+ * runs in production, and a gate with a bypass branch is not a gate.
+ */
+
+/** The registry id this module gates. */
+const SLACK_MIRROR_FEATURE = 'slack-mirror' as const
+
+/**
+ * Whether the organization may use the PLATFORM's Slack bot token. See the
+ * module doc for the exact resolution order; a nullish org id is DISABLED (fail
+ * closed).
+ */
+export async function isSlackMirrorEnabledForOrg(
+  orgId: string | null | undefined,
+): Promise<boolean> {
+  if (!orgId) return false
+
+  // A REJECTED read (transient Sanity failure) must resolve to DISABLED like any
+  // other unresolvable org — never propagate, or one flaky read would turn a
+  // best-effort notification into a thrown error inside the mutation that
+  // triggered it.
+  let org
+  try {
+    org = await getOrganizationById(orgId)
+  } catch (error) {
+    console.error(
+      `[slack] organization read failed for ${orgId}; treating Slack mirroring as DISABLED`,
+      error,
+    )
+    return false
+  }
+  if (!org) return false
+
+  const now = new Date()
+  if (
+    computeEntitlements(org.plan, org.featureOverrides, now).has(
+      SLACK_MIRROR_FEATURE,
+    )
+  ) {
+    return true
+  }
+
+  // Not entitled by plan/override. An ACTIVE override at this point can only be
+  // an explicit `enabled: false`, which must beat the platform default below.
+  if (hasActiveOverride(org.featureOverrides, SLACK_MIRROR_FEATURE, now)) {
+    return false
+  }
+
+  // ID comparison against the ONE resolver, never `org.slug` off the cached read
+  // above — see `./platform`. This is a grant, and this deployment has an org
+  // that is both the platform org and a tenant, so a revocation must take effect
+  // NOW rather than whenever the cached document happens to expire.
+  return isPlatformOrganization(orgId)
+}
+
+/** The minimum conference shape this gate reads — its owning tenant. */
+interface ConferenceTenant {
+  organization?: { _ref?: string; _type?: 'reference' } | null
+}
+
+/**
+ * Whether Slack mirroring is enabled for the tenant that OWNS this conference.
+ * Use this wherever a conference is already in hand (every Slack sender) so the
+ * decision keys on the conference's real owner rather than on whatever host the
+ * request happens to carry.
+ */
+export async function isSlackMirrorEnabledForConference(
+  conference: ConferenceTenant | null | undefined,
+): Promise<boolean> {
+  return isSlackMirrorEnabledForOrg(conference?.organization?._ref)
+}
+
+/**
+ * Whether Slack mirroring is enabled for the CURRENT request's domain-resolved
+ * org. For surfaces with no conference in hand; an unresolvable org is DISABLED.
+ */
+export async function isSlackMirrorEnabledForCurrentOrg(): Promise<boolean> {
+  return isSlackMirrorEnabledForOrg(await resolveCurrentOrgId())
+}

--- a/src/lib/signing/sanity.ts
+++ b/src/lib/signing/sanity.ts
@@ -32,6 +32,12 @@ export interface SigningContractData {
     domains?: string[]
     socialLinks?: string[]
     salesNotificationChannel?: string
+    /**
+     * The owning tenant. Required, not decorative: `resolveConferenceSlackToken`
+     * keys the Slack bot token on it, and a projection that drops it resolves NO
+     * token and silently stops the contract-signed Slack post.
+     */
+    organization?: { _ref?: string } | null
     /** Tenant brand theme — the contract-signed email is branded from it. */
     theme?: ConferenceTheme | null
   }
@@ -57,7 +63,7 @@ const SIGNING_CONTRACT_QUERY = `*[_type == "sponsorForConference" && signatureId
   },
   "sponsor": sponsor->{ name },
   "tier": tier->{ title },
-  "conference": conference->{ _id, title, startDate, city, organizer, sponsorEmail, domains, socialLinks, salesNotificationChannel, theme },
+  "conference": conference->{ _id, title, startDate, city, organizer, sponsorEmail, domains, socialLinks, salesNotificationChannel, organization, theme },
   contactPersons[]{ name, email, isPrimary },
   contractValue,
   contractCurrency

--- a/src/lib/slack/client.ts
+++ b/src/lib/slack/client.ts
@@ -46,13 +46,25 @@ export interface PostSlackMessageOptions {
   channel?: string
   forceSlack?: boolean
   /**
-   * Bot token resolved at the caller's boundary (CaaS #617). When omitted, falls
-   * back to the platform env `SLACK_BOT_TOKEN` — today's behavior. A per-org
-   * token is resolved by `resolveConferenceSlackToken` where a conference/org is
-   * in scope and injected here.
+   * Bot token resolved at the caller's boundary by
+   * `resolveConferenceSlackToken`. REQUIRED in practice: there is no env
+   * fallback, so an omitted or `undefined` token no-op-warns instead of sending.
    */
   botToken?: string
 }
+
+/**
+ * The transport is CREDENTIAL-FREE by construction: it reads no env of its own,
+ * so a caller that resolves no token cannot send. This is what makes
+ * `resolveConferenceSlackToken` the single chokepoint every sender inherits —
+ * the `notify.ts` helpers, the weekly-update cron and the admin status probe are
+ * covered without any of them repeating the check.
+ *
+ * It used to end `?? process.env.SLACK_BOT_TOKEN`, so an omitted or
+ * unresolved-to-`undefined` token silently posted with the PLATFORM's bot into a
+ * tenant-editable channel name. Do NOT reintroduce a default here; add the token
+ * to the resolver instead.
+ */
 
 interface SlackApiResponse {
   ok: boolean
@@ -63,7 +75,7 @@ export async function postSlackMessage(
   message: SlackMessage,
   options: PostSlackMessageOptions = {},
 ): Promise<void> {
-  const { channel, forceSlack = false, botToken: injectedToken } = options
+  const { channel, forceSlack = false, botToken } = options
 
   if (process.env.NODE_ENV === 'development' && !forceSlack) {
     console.log('Slack notification (development mode):')
@@ -71,10 +83,10 @@ export async function postSlackMessage(
     return
   }
 
-  const botToken = injectedToken ?? process.env.SLACK_BOT_TOKEN
-
   if (!botToken) {
-    console.warn('SLACK_BOT_TOKEN is not configured')
+    console.warn(
+      'No Slack bot token resolved for this organization, skipping notification',
+    )
     return
   }
 

--- a/src/lib/slack/senderProjections.test.ts
+++ b/src/lib/slack/senderProjections.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @vitest-environment node
+ *
+ * `organization` IS A LOAD-BEARING PROJECTION FIELD for every Slack sender.
+ *
+ * `resolveConferenceSlackToken` keys the bot token on `conference.organization`
+ * and fails closed without it, and `postSlackMessage` has no env fallback to
+ * paper over the gap. So a conference read whose projection is an EXPLICIT field
+ * list — not a `{...}` spread — silently stops that surface's Slack posts with
+ * no type error and no runtime error: the send just no-op-warns.
+ *
+ * Two such reads feed the sponsor CONTRACT-SIGNED notification, one per signing
+ * path. These cases pin `organization` into both. Most other senders read
+ * through `getConferenceForCurrentDomain` / `conference->{ ... }`, which spread
+ * the whole document and cannot lose the field.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const fetchMock = vi.fn()
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: (...args: unknown[]) => fetchMock(...args) },
+  clientWrite: { fetch: vi.fn(), patch: vi.fn(), create: vi.fn() },
+  clientRead: { fetch: (...args: unknown[]) => fetchMock(...args) },
+}))
+
+import { getSigningContract } from '@/lib/signing/sanity'
+import { getSponsorForConference } from '@/lib/sponsor-crm/sanity'
+
+/** The `conference->{ … }` sub-projection of a GROQ query, as written. */
+function conferenceProjection(query: string): string {
+  const start = query.indexOf('conference->{')
+  expect(start).toBeGreaterThan(-1)
+  return query.slice(start, query.indexOf('}', start))
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  fetchMock.mockResolvedValue(null)
+})
+
+describe('conference projections feeding Slack senders carry `organization`', () => {
+  it('SIGNING_CONTRACT_QUERY projects it (public signing → contract-signed post)', async () => {
+    await getSigningContract('token-1')
+    const query = fetchMock.mock.calls[0][0] as string
+    expect(conferenceProjection(query)).toContain('organization')
+  })
+
+  it('SPONSOR_FOR_CONFERENCE_FIELDS projects it (admin signature-status → contract-signed post)', async () => {
+    await getSponsorForConference('sfc-1')
+    const query = fetchMock.mock.calls[0][0] as string
+    expect(conferenceProjection(query)).toContain('organization')
+  })
+})

--- a/src/lib/slack/token.test.ts
+++ b/src/lib/slack/token.test.ts
@@ -1,0 +1,206 @@
+/**
+ * @vitest-environment node
+ *
+ * CROSS-TENANT ISOLATION for the Slack bot token.
+ *
+ * `resolveConferenceSlackToken` is the ONLY source of a token —
+ * `postSlackMessage` has no env fallback — so what this file proves about the
+ * resolver holds for every Slack sender in the app (`notify.ts`,
+ * `weeklyUpdate.ts`, the weekly-update cron, the admin status probe).
+ *
+ * THE INVARIANTS:
+ *  1. A NON-PLATFORM org with no per-org secret gets NO token, even with
+ *     `SLACK_BOT_TOKEN` set — the platform's bot must not post that tenant's
+ *     content into the platform workspace under a tenant-typed channel name.
+ *  2. The PLATFORM org (CNDN in production) still gets the env token. The hard
+ *     constraint on this change is that it loses nothing.
+ *  3. An UNRESOLVABLE org (no `organization` ref, unknown document, failed read)
+ *     gets NO token — fail closed.
+ *  4. A per-org token is the tenant's OWN credential and flows regardless of the
+ *     gate; provisioning it IS the grant.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const getOrganizationById = vi.fn()
+
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationById: (...args: unknown[]) => getOrganizationById(...args),
+  getOrganizationRefForCurrentConference: vi.fn(),
+}))
+
+import { resolveConferenceSlackToken } from './token'
+
+const PLATFORM_ORG_ID = 'org-platform'
+const TENANT_ORG_ID = 'org-tenant'
+const PLATFORM_TOKEN = 'xoxb-platform-bot'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubEnv('PLATFORM_ORG_ID', PLATFORM_ORG_ID)
+  vi.stubEnv('SLACK_BOT_TOKEN', PLATFORM_TOKEN)
+  getOrganizationById.mockResolvedValue({
+    _id: TENANT_ORG_ID,
+    name: 'Tenant',
+    slug: 'tenant',
+    plan: 'enterprise',
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('resolveConferenceSlackToken — a second tenant gets nothing', () => {
+  it('gives a NON-platform org NO token even though SLACK_BOT_TOKEN is set', async () => {
+    await expect(
+      resolveConferenceSlackToken({
+        organization: { _ref: TENANT_ORG_ID },
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('gives a non-platform org nothing on ANY plan (this is not a plan feature)', async () => {
+    for (const plan of ['community', 'pro', 'enterprise'] as const) {
+      getOrganizationById.mockResolvedValue({
+        _id: TENANT_ORG_ID,
+        name: 'Tenant',
+        slug: 'tenant',
+        plan,
+      })
+      await expect(
+        resolveConferenceSlackToken({
+          organization: { _ref: TENANT_ORG_ID },
+        }),
+      ).resolves.toBeUndefined()
+    }
+  })
+
+  it('does not leak the platform token to a tenant whose SLUG looks like the platform', async () => {
+    getOrganizationById.mockResolvedValue({
+      _id: TENANT_ORG_ID,
+      name: 'Impostor',
+      slug: 'platform-org',
+      plan: 'enterprise',
+    })
+    await expect(
+      resolveConferenceSlackToken({
+        organization: { _ref: TENANT_ORG_ID },
+      }),
+    ).resolves.toBeUndefined()
+  })
+})
+
+describe('resolveConferenceSlackToken — the platform org keeps everything', () => {
+  it('gives the platform org the env token', async () => {
+    getOrganizationById.mockResolvedValue({
+      _id: PLATFORM_ORG_ID,
+      name: 'Cloud Native Days',
+      slug: 'cloud-native-days',
+    })
+    await expect(
+      resolveConferenceSlackToken({
+        organization: { _ref: PLATFORM_ORG_ID },
+      }),
+    ).resolves.toBe(PLATFORM_TOKEN)
+  })
+
+  it('still resolves nothing when the platform env token itself is unset', async () => {
+    vi.stubEnv('SLACK_BOT_TOKEN', '')
+    getOrganizationById.mockResolvedValue({
+      _id: PLATFORM_ORG_ID,
+      name: 'Cloud Native Days',
+      slug: 'cloud-native-days',
+    })
+    await expect(
+      resolveConferenceSlackToken({
+        organization: { _ref: PLATFORM_ORG_ID },
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('honours an explicit override granting a pilot org the platform token', async () => {
+    getOrganizationById.mockResolvedValue({
+      _id: TENANT_ORG_ID,
+      name: 'Pilot',
+      slug: 'pilot',
+      featureOverrides: [{ feature: 'slack-mirror', enabled: true }],
+    })
+    await expect(
+      resolveConferenceSlackToken({
+        organization: { _ref: TENANT_ORG_ID },
+      }),
+    ).resolves.toBe(PLATFORM_TOKEN)
+  })
+})
+
+describe('resolveConferenceSlackToken — fails CLOSED', () => {
+  it('resolves nothing for a conference with no organization ref', async () => {
+    await expect(resolveConferenceSlackToken({})).resolves.toBeUndefined()
+    await expect(
+      resolveConferenceSlackToken({ organization: null }),
+    ).resolves.toBeUndefined()
+    await expect(
+      resolveConferenceSlackToken({ organization: {} }),
+    ).resolves.toBeUndefined()
+    expect(getOrganizationById).not.toHaveBeenCalled()
+  })
+
+  it('resolves nothing for an unknown organization document', async () => {
+    getOrganizationById.mockResolvedValue(null)
+    await expect(
+      resolveConferenceSlackToken({ organization: { _ref: 'org-ghost' } }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('resolves nothing — and does not throw — when the org read REJECTS', async () => {
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {})
+    getOrganizationById.mockRejectedValue(new Error('sanity unavailable'))
+    await expect(
+      resolveConferenceSlackToken({ organization: { _ref: TENANT_ORG_ID } }),
+    ).resolves.toBeUndefined()
+    expect(logged).toHaveBeenCalled()
+    logged.mockRestore()
+  })
+
+  it('resolves nothing for ANY org when PLATFORM_ORG_ID is unset (local dev)', async () => {
+    vi.stubEnv('PLATFORM_ORG_ID', '')
+    for (const orgId of [PLATFORM_ORG_ID, TENANT_ORG_ID]) {
+      getOrganizationById.mockResolvedValue({
+        _id: orgId,
+        name: 'Any',
+        slug: 'any',
+      })
+      await expect(
+        resolveConferenceSlackToken({ organization: { _ref: orgId } }),
+      ).resolves.toBeUndefined()
+    }
+  })
+})
+
+describe("resolveConferenceSlackToken — a tenant's OWN token is not gated", () => {
+  it("returns the per-org token for a non-platform org, and never the platform's", async () => {
+    vi.stubEnv(
+      'TENANT_SECRETS_JSON',
+      JSON.stringify({
+        [TENANT_ORG_ID]: { slack: { botToken: 'xoxb-tenant-own' } },
+      }),
+    )
+    await expect(
+      resolveConferenceSlackToken({ organization: { _ref: TENANT_ORG_ID } }),
+    ).resolves.toBe('xoxb-tenant-own')
+    // Its own credential decides it — no entitlement read is needed at all.
+    expect(getOrganizationById).not.toHaveBeenCalled()
+  })
+
+  it('prefers a per-org token over the env token for the platform org too', async () => {
+    vi.stubEnv(
+      'TENANT_SECRETS_JSON',
+      JSON.stringify({
+        [PLATFORM_ORG_ID]: { slack: { botToken: 'xoxb-platform-own' } },
+      }),
+    )
+    await expect(
+      resolveConferenceSlackToken({ organization: { _ref: PLATFORM_ORG_ID } }),
+    ).resolves.toBe('xoxb-platform-own')
+  })
+})

--- a/src/lib/slack/token.ts
+++ b/src/lib/slack/token.ts
@@ -1,5 +1,6 @@
 import 'server-only'
-import { resolveTenantSecrets } from '@/lib/secrets/store'
+import { perOrgSecretsStore, envSecretsStore } from '@/lib/secrets/store'
+import { isSlackMirrorEnabledForOrg } from '@/lib/features/slack'
 
 /** Only the conference field the Slack token resolver needs. */
 type ConferenceSlackBinding = {
@@ -7,20 +8,42 @@ type ConferenceSlackBinding = {
 }
 
 /**
- * Resolve the Slack bot token for a conference's owning organization (CaaS
- * #617). A per-org Slack secret wins; otherwise the platform env
- * `SLACK_BOT_TOKEN` flows through {@link resolveTenantSecrets}'s default chain —
- * so behavior is UNCHANGED until a tenant is provisioned with its own token.
+ * THE only source of a Slack bot token. `postSlackMessage` has no env fallback
+ * of its own, so a send happens iff this returns a token.
  *
- * Returns `undefined` when neither is configured, which lets `postSlackMessage`
- * fall back to `process.env.SLACK_BOT_TOKEN` and no-op-warn exactly as today.
+ * ORDER:
+ *  1. The org's OWN token from the per-org secret store, if provisioned. That
+ *     addresses the tenant's own workspace, so no isolation question arises and
+ *     no feature gate stands in front of it — provisioning the secret IS the
+ *     grant.
+ *  2. Otherwise the platform env token, but ONLY when the `slack-mirror` gate
+ *     passes for the owning org (`@/lib/features/slack`): by default that is the
+ *     platform org alone, plus any org given an explicit override.
+ *  3. Otherwise `undefined` — `postSlackMessage` warns and no-ops, which is the
+ *     path an unconfigured deployment has always taken.
+ *
+ * WHY THE GATE. `SLACK_BOT_TOKEN` is one bot in the platform's workspace, while
+ * the destination channel is a tenant-editable conference field, so a shared
+ * token posts arbitrary tenants' content into the platform's workspace under a
+ * name the tenant chose. See the module doc in `@/lib/features/slack` for the
+ * full argument and the dev-behaviour decision.
+ *
+ * FAILS CLOSED on a conference with no `organization` ref — which also means a
+ * caller must pass a conference projection that INCLUDES `organization`, not a
+ * narrow one. Grep for `resolveConferenceSlackToken` before adding a sender.
  */
 export async function resolveConferenceSlackToken(
   conference: ConferenceSlackBinding,
 ): Promise<string | undefined> {
-  const creds = await resolveTenantSecrets(
-    conference.organization?._ref,
-    'slack',
-  )
-  return creds?.botToken
+  const orgId = conference.organization?._ref
+
+  const perOrg = await perOrgSecretsStore.get(orgId, 'slack')
+  if (perOrg?.botToken) return perOrg.botToken
+
+  if (!(await isSlackMirrorEnabledForOrg(orgId))) return undefined
+
+  // `EnvSecretsStore` is org-BLIND (it returns the platform env for any org id),
+  // so it is only ever read on the far side of the gate above.
+  const platform = await envSecretsStore.get(orgId, 'slack')
+  return platform?.botToken
 }

--- a/src/lib/sponsor-crm/sanity.ts
+++ b/src/lib/sponsor-crm/sanity.ts
@@ -47,7 +47,8 @@ const SPONSOR_FOR_CONFERENCE_FIELDS = `
     domains,
     socialLinks,
     logoBright,
-    theme
+    theme,
+    organization
   },
   tier->{
     _id,

--- a/src/lib/tickets/provider/index.ts
+++ b/src/lib/tickets/provider/index.ts
@@ -1,6 +1,7 @@
 import { CheckinProvider } from './checkin'
 import { TitoProvider } from './tito'
 import { resolveTenantSecrets, perOrgSecretsStore } from '@/lib/secrets/store'
+import { isPlatformOrganization } from '@/lib/features/platform'
 import type {
   EventRef,
   TicketingProvider,
@@ -53,11 +54,12 @@ export function getTicketingProvider(
 /**
  * Platform-default credentials, assembled from environment variables.
  *
- * The env-backed default-tenant credential source. Still the direct source for
- * consumers that operate outside an org context (webhooks, cross-tenant admin
- * reads). The org-aware request boundary resolves through
- * {@link resolveTicketingProvider}, which layers a per-org secret store
- * (CaaS #617) IN FRONT of this via `resolveTenantSecrets`.
+ * These are the PLATFORM ORG's credentials, not a universal default. Org-aware
+ * callers MUST go through {@link resolveTicketingCredentials} /
+ * {@link resolveTicketingProvider}, which hand these out only when the org IS
+ * the platform org. The one legitimate direct consumer is the inbound
+ * `/api/webhooks/checkin/ticket-sold` route, which verifies a signature BEFORE
+ * any tenant is known and so has no org to key on.
  */
 export function platformCheckinCredentials(): TicketingProviderCredentials {
   return {
@@ -73,17 +75,69 @@ export function platformCheckinCredentials(): TicketingProviderCredentials {
  * a single API token (`TITO_API_KEY`) and signs webhooks with the endpoint
  * security token (`TITO_WEBHOOK_SECRET`).
  *
- * NOTE on the resolver: the env-backed `ticketing` family in
- * {@link EnvSecretsStore} is Checkin-shaped (it reads `CHECKIN_*`), so the Tito
- * branch of {@link resolveTicketingProvider} does NOT use that env store as its
- * fallback — it resolves per-org Tito secrets through the provider-agnostic
- * JSON store and falls back to THIS function.
+ * NOTE on the resolver: the env-backed `ticketing` family in `EnvSecretsStore`
+ * is Checkin-shaped (it reads `CHECKIN_*`) AND org-blind, so
+ * {@link resolveTicketingCredentials} does not use that store at all — it reads
+ * per-org secrets from the provider-agnostic JSON store and layers the
+ * platform-org-only env fallback (this function for Tito) on top itself.
  */
 export function platformTitoCredentials(): TicketingProviderCredentials {
   return {
     apiKey: process.env.TITO_API_KEY,
     webhookSecret: process.env.TITO_WEBHOOK_SECRET,
   }
+}
+
+/**
+ * THE single place ticketing credentials are chosen for an organization.
+ *
+ * ORDER:
+ *  1. A per-org secret (`TENANT_SECRETS_JSON` → the org's own provider account)
+ *     always wins. That is the tenant's OWN credential; nothing is shared.
+ *  2. Otherwise the platform env credentials, but ONLY for the platform org
+ *     (`PLATFORM_ORG_ID`). This deployment's platform org is also a tenant, so
+ *     it must keep the env account it has always used — every existing surface
+ *     stays byte-identical for it.
+ *  3. Otherwise `null`. A tenant without its own provider secret gets NO
+ *     credentials rather than the platform's.
+ *
+ * WHY (cross-tenant isolation). The env credentials are one Checkin/Tito
+ * ACCOUNT. A conference's `checkinEventId` / `titoEventSlug` is a provider-side
+ * id that no Sanity document guard can see, so handing that account to an
+ * arbitrary tenant makes their own binding fields address the platform's
+ * account. `ticketingBindingIsClaimed` (`src/server/routers/conference.ts`)
+ * already refuses a binding another conference document has claimed, but an
+ * event that exists in the platform account and is bound to NO conference
+ * document is invisible to that check — it needs a provider round-trip to
+ * detect. Withholding the credential closes that residue at the source: with no
+ * account to address, an unclaimed event id resolves to nothing.
+ *
+ * FAILS CLOSED on a nullish `orgId` — an unresolvable tenant gets nothing.
+ *
+ * DEV NOTE: `PLATFORM_ORG_ID` is set on production and preview but NOT in local
+ * development, so locally this returns `null` and ticketing surfaces render
+ * their existing unconfigured empty states. That is deliberate: a developer
+ * pointing a local checkout at the real Checkin account is the same
+ * cross-account hazard this function exists to remove. Set `PLATFORM_ORG_ID`
+ * (and the provider env vars) locally to exercise the real integration.
+ */
+export async function resolveTicketingCredentials(
+  orgId: string | null | undefined,
+  providerType: TicketingProviderType,
+): Promise<TicketingProviderCredentials | null> {
+  // The env-backed `ticketing` family in `EnvSecretsStore` is Checkin-shaped AND
+  // org-blind (it returns the platform env for ANY org id), so the chain here is
+  // the per-org store ONLY; the platform env is layered back on below, gated.
+  const perOrg = await resolveTenantSecrets(orgId, 'ticketing', [
+    perOrgSecretsStore,
+  ])
+  if (perOrg) return perOrg
+
+  if (!(await isPlatformOrganization(orgId))) return null
+
+  return providerType === 'tito'
+    ? platformTitoCredentials()
+    : platformCheckinCredentials()
 }
 
 /**
@@ -161,13 +215,13 @@ export function hasTicketingBinding(
  * unconfigured behaves IDENTICALLY to before (callers short-circuit to their
  * existing empty/soft-fail path).
  *
- * CREDENTIALS (CaaS #617): resolved through `resolveTenantSecrets(orgId,
- * 'ticketing')` — a per-org secret store hit wins, otherwise the platform env
- * default (`platformCheckinCredentials`), preserved as the terminal fallback so
- * behavior is UNCHANGED for every tenant until a per-org secret is provisioned.
- * Like today, this does NOT pre-check API credentials; when those are absent the
- * provider's operations throw at call time and are caught by each consumer's
- * existing error path.
+ * CREDENTIALS: resolved through {@link resolveTicketingCredentials} — a per-org
+ * secret wins, the platform env applies to the PLATFORM ORG ONLY, and anything
+ * else resolves to `null`. A `null` resolution returns the SAME unconfigured
+ * result as a missing binding, so callers short-circuit to the empty states they
+ * already render; nothing new has to be handled. Like today, this does NOT
+ * pre-check that the resolved credentials work; when the values are absent the
+ * provider's operations throw at call time into each consumer's error path.
  */
 export async function resolveTicketingProvider(
   conference: ConferenceTicketingBinding,
@@ -179,13 +233,12 @@ export async function resolveTicketingProvider(
     if (!conference.titoAccountSlug || !conference.titoEventSlug) {
       return { configured: false, provider: null, eventRef: null }
     }
-    // The env-backed `ticketing` family is Checkin-shaped, so the Tito branch
-    // resolves per-org secrets through the provider-agnostic JSON store ONLY,
-    // then falls back to the platform Tito env creds. A per-org Tito ticketing
-    // secret is an opaque `{ apiKey, webhookSecret? }` record.
-    const credentials =
-      (await resolveTenantSecrets(orgId, 'ticketing', [perOrgSecretsStore])) ??
-      platformTitoCredentials()
+    // A per-org Tito ticketing secret is an opaque `{ apiKey, webhookSecret? }`
+    // record; the platform Tito env applies to the platform org only.
+    const credentials = await resolveTicketingCredentials(orgId, 'tito')
+    if (!credentials) {
+      return { configured: false, provider: null, eventRef: null }
+    }
 
     const eventRef: TitoEventRef = {
       provider: 'tito',
@@ -204,9 +257,10 @@ export async function resolveTicketingProvider(
     return { configured: false, provider: null, eventRef: null }
   }
 
-  const credentials =
-    (await resolveTenantSecrets(orgId, 'ticketing')) ??
-    platformCheckinCredentials()
+  const credentials = await resolveTicketingCredentials(orgId, 'checkin')
+  if (!credentials) {
+    return { configured: false, provider: null, eventRef: null }
+  }
 
   const eventRef: CheckinEventRef = {
     customerId: conference.checkinCustomerId,

--- a/src/lib/tickets/provider/provider.test.ts
+++ b/src/lib/tickets/provider/provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createHmac } from 'node:crypto'
 import {
   getTicketingProvider,
@@ -16,6 +16,13 @@ const CREDS = {
   apiSecret: 'test-secret',
   webhookSecret: 'test-webhook-secret',
 }
+
+/**
+ * The platform org's document id. The platform env credentials are handed out to
+ * THIS org and no other, so every resolver case that expects env creds to flow
+ * must own its conference through it. See the isolation describe block below.
+ */
+const PLATFORM_ORG = 'org-platform'
 
 /**
  * A fetch stub that answers the Checkin GraphQL endpoint based on the query
@@ -68,6 +75,10 @@ function stubCheckinFetch(
     }
   })
 }
+
+beforeEach(() => {
+  vi.stubEnv('PLATFORM_ORG_ID', PLATFORM_ORG)
+})
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -139,6 +150,7 @@ describe('resolveTicketingProvider', () => {
     const resolved = await resolveTicketingProvider({
       checkinCustomerId: 42,
       checkinEventId: 7,
+      organization: { _ref: PLATFORM_ORG },
     })
     expect(resolved.configured).toBe(true)
     if (resolved.configured) {
@@ -147,12 +159,13 @@ describe('resolveTicketingProvider', () => {
     }
   })
 
-  it('uses the platform env credentials when no per-org secret is present', async () => {
+  it('uses the platform env credentials for the PLATFORM ORG when it has no per-org secret', async () => {
     vi.stubEnv('CHECKIN_API_KEY', 'env-key')
     vi.stubEnv('CHECKIN_API_SECRET', 'env-secret')
     const resolved = await resolveTicketingProvider({
       checkinCustomerId: 42,
       checkinEventId: 7,
+      organization: { _ref: PLATFORM_ORG },
     })
     expect(resolved.configured).toBe(true)
     if (resolved.configured) {
@@ -216,6 +229,7 @@ describe('resolveTicketingProvider', () => {
       // No `ticketingProvider` field at all — the legacy shape.
       checkinCustomerId: 42,
       checkinEventId: 7,
+      organization: { _ref: PLATFORM_ORG },
     })
     expect(resolved.configured).toBe(true)
     if (resolved.configured) {
@@ -232,6 +246,7 @@ describe('resolveTicketingProvider', () => {
       ticketingProvider: 'tito',
       titoAccountSlug: 'acme',
       titoEventSlug: '2026',
+      organization: { _ref: PLATFORM_ORG },
     })
     expect(resolved.configured).toBe(true)
     if (resolved.configured) {
@@ -281,6 +296,106 @@ describe('resolveTicketingProvider', () => {
         }),
       )
     }
+  })
+
+  /**
+   * CROSS-TENANT ISOLATION for ticketing credentials.
+   *
+   * The platform env is ONE Checkin/Tito account. A conference's
+   * `checkinEventId` / `titoEventSlug` is a provider-side id no Sanity guard can
+   * see, so handing that account to an arbitrary tenant makes their own binding
+   * fields address the platform's account. `ticketingBindingIsClaimed` already
+   * refuses a binding another conference DOCUMENT claims; an event that exists in
+   * the platform account but is bound to no document is invisible to it. These
+   * cases pin the source-level fix: no account, nothing to address.
+   */
+  describe('the platform env account is the PLATFORM ORG only', () => {
+    beforeEach(() => {
+      vi.stubEnv('CHECKIN_API_KEY', 'env-key')
+      vi.stubEnv('CHECKIN_API_SECRET', 'env-secret')
+      vi.stubEnv('TITO_API_KEY', 'env-tito-token')
+    })
+
+    it('gives a NON-platform tenant NO credentials, so the conference resolves UNCONFIGURED', async () => {
+      expect(
+        await resolveTicketingProvider({
+          checkinCustomerId: 42,
+          checkinEventId: 7,
+          organization: { _ref: 'org-second-tenant' },
+        }),
+      ).toEqual({ configured: false, provider: null, eventRef: null })
+    })
+
+    it('does the same on the Tito branch', async () => {
+      expect(
+        await resolveTicketingProvider({
+          ticketingProvider: 'tito',
+          titoAccountSlug: 'acme',
+          titoEventSlug: '2026',
+          organization: { _ref: 'org-second-tenant' },
+        }),
+      ).toEqual({ configured: false, provider: null, eventRef: null })
+    })
+
+    it('FAILS CLOSED on a conference with no owning organization', async () => {
+      expect(
+        await resolveTicketingProvider({
+          checkinCustomerId: 42,
+          checkinEventId: 7,
+        }),
+      ).toEqual({ configured: false, provider: null, eventRef: null })
+      expect(
+        await resolveTicketingProvider({
+          checkinCustomerId: 42,
+          checkinEventId: 7,
+          organization: null,
+        }),
+      ).toEqual({ configured: false, provider: null, eventRef: null })
+    })
+
+    it('FAILS CLOSED for every org when PLATFORM_ORG_ID is unset (local dev)', async () => {
+      vi.stubEnv('PLATFORM_ORG_ID', '')
+      expect(
+        await resolveTicketingProvider({
+          checkinCustomerId: 42,
+          checkinEventId: 7,
+          organization: { _ref: PLATFORM_ORG },
+        }),
+      ).toEqual({ configured: false, provider: null, eventRef: null })
+    })
+
+    it('KEEPS the platform org fully credentialed (the hard constraint)', async () => {
+      const resolved = await resolveTicketingProvider({
+        checkinCustomerId: 42,
+        checkinEventId: 7,
+        organization: { _ref: PLATFORM_ORG },
+      })
+      expect(resolved.configured).toBe(true)
+      if (resolved.configured) {
+        expect(resolved.provider.isConfigured()).toBe(true)
+        expect(resolved.eventRef).toEqual({ customerId: 42, eventId: 7 })
+      }
+    })
+
+    it('still serves a non-platform tenant that has its OWN provisioned secret', async () => {
+      vi.stubEnv(
+        'TENANT_SECRETS_JSON',
+        JSON.stringify({
+          'org-second-tenant': {
+            ticketing: { apiKey: 'own-key', apiSecret: 'own-secret' },
+          },
+        }),
+      )
+      const resolved = await resolveTicketingProvider({
+        checkinCustomerId: 42,
+        checkinEventId: 7,
+        organization: { _ref: 'org-second-tenant' },
+      })
+      expect(resolved.configured).toBe(true)
+      if (resolved.configured) {
+        expect(resolved.provider.isConfigured()).toBe(true)
+      }
+    })
   })
 
   it('returns unconfigured when a tito conference is missing its slugs', async () => {

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -240,7 +240,13 @@ async function sendContractSignedSlackNotification(
     tier?: { title?: string }
     contractValue?: number
     contractCurrency?: string
-    conference?: { _id?: string; domains?: string[] }
+    // `organization` is load-bearing: `resolveConferenceSlackToken` keys the bot
+    // token on it, and dropping it resolves NO token and silently kills this post.
+    conference?: {
+      _id?: string
+      domains?: string[]
+      organization?: { _ref?: string } | null
+    }
   },
 ) {
   try {

--- a/src/server/routers/status.probes.test.ts
+++ b/src/server/routers/status.probes.test.ts
@@ -14,6 +14,18 @@ vi.mock('@/lib/slack/client', () => ({
     text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
 }))
 
+/**
+ * The token resolver is mocked at ITS boundary — the isolation rules it enforces
+ * are proven in `src/lib/slack/token.test.ts`. What matters here is that the
+ * probe consults it FIRST and reports `notEnabled` when it yields nothing,
+ * instead of attempting a send and blaming the channel configuration.
+ */
+const resolveSlackTokenMock = vi.fn()
+vi.mock('@/lib/slack/token', () => ({
+  resolveConferenceSlackToken: (...args: unknown[]) =>
+    resolveSlackTokenMock(...args),
+}))
+
 const createOrReplaceMock = vi.fn()
 const deleteMock = vi.fn()
 vi.mock('@/lib/sanity/client', () => ({
@@ -68,6 +80,7 @@ const CONFERENCE = {
 beforeEach(() => {
   vi.clearAllMocks()
   getConferenceMock.mockResolvedValue({ conference: CONFERENCE, error: null })
+  resolveSlackTokenMock.mockResolvedValue('xoxb-resolved')
 })
 
 describe('status.admin probes — auth gate', () => {
@@ -87,8 +100,42 @@ describe('status.admin.probeSlack', () => {
     expect(res).toEqual({ ok: true, channel: '#updates' })
     expect(postSlackMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({ text: expect.stringContaining('Admin') }),
-      expect.objectContaining({ channel: '#updates', forceSlack: true }),
+      expect.objectContaining({
+        channel: '#updates',
+        forceSlack: true,
+        botToken: 'xoxb-resolved',
+      }),
     )
+  })
+
+  /**
+   * `slack-mirror` is `readiness: 'internal'`, so an org without it is told
+   * plainly that Slack is not enabled — no upsell, and no send attempt whose
+   * silent no-op used to be reported back as `ok: true, Posted to #channel`.
+   */
+  it('reports notEnabled — without sending — when no token resolves', async () => {
+    resolveSlackTokenMock.mockResolvedValue(undefined)
+    const res = await makeCaller({
+      speakerId: 'slack-notenabled',
+    }).admin.probeSlack()
+    expect(res).toEqual({
+      ok: false,
+      notEnabled: true,
+      error: 'Slack is not enabled for this organization.',
+    })
+    expect(postSlackMessageMock).not.toHaveBeenCalled()
+  })
+
+  it('checks entitlement BEFORE the channel, so a non-entitled org is not sent to fix a channel', async () => {
+    resolveSlackTokenMock.mockResolvedValue(undefined)
+    getConferenceMock.mockResolvedValue({
+      conference: { ...CONFERENCE, salesNotificationChannel: undefined },
+      error: null,
+    })
+    const res = await makeCaller({
+      speakerId: 'slack-order',
+    }).admin.probeSlack()
+    expect(res).toMatchObject({ notEnabled: true })
   })
 
   it('returns an error when no channel is configured', async () => {

--- a/src/server/routers/status.ts
+++ b/src/server/routers/status.ts
@@ -90,9 +90,28 @@ export const statusRouter = router({
     }),
 
     // Post a test message to the same Slack channel the weekly update uses.
+    //
+    // TOKEN FIRST, CHANNEL SECOND. Whether Slack is available to this
+    // organization at all is resolved BEFORE anything about the conference's
+    // configuration is reported, so an org without Slack is told it is not
+    // enabled rather than being sent to fix a channel field that would change
+    // nothing. `slack-mirror` is `readiness: 'internal'`, so `notEnabled` is a
+    // neutral statement of fact with no upsell — there is nothing to buy.
+    //
+    // It also removes a lie: `postSlackMessage` no-op-warns when no token
+    // resolves, so the old order returned `ok: true` ("Posted to #channel") for
+    // a send that never happened.
     probeSlack: adminProcedure.mutation(async ({ ctx }) => {
       requireCooldown(ctx.speaker._id, 'slack')
       const conference = await requireConference()
+      const botToken = await resolveConferenceSlackToken(conference)
+      if (!botToken) {
+        return {
+          ok: false as const,
+          notEnabled: true as const,
+          error: 'Slack is not enabled for this organization.',
+        }
+      }
       const channel = conference.salesNotificationChannel
       if (!channel) {
         return {
@@ -107,7 +126,6 @@ export const statusRouter = router({
         blocks: [{ type: 'section', text: { type: 'mrkdwn', text: body } }],
       }
       try {
-        const botToken = await resolveConferenceSlackToken(conference)
         await postSlackMessage(message, { channel, forceSlack: true, botToken })
         return { ok: true as const, channel }
       } catch (err) {

--- a/src/server/routers/tickets.tenancy.test.ts
+++ b/src/server/routers/tickets.tenancy.test.ts
@@ -69,12 +69,12 @@ const OUR_EVENT = 4242
 /** Another tenant's event on the same shared Checkin account. */
 const THEIR_EVENT = 4243
 
-function ctx(): Context {
+function ctx(orgId: string = ORG_A): Context {
   const speaker = {
     _id: 'sp-admin',
     name: 'Admin',
     isOrganizer: true,
-    organizerOrgIds: [ORG_A],
+    organizerOrgIds: [orgId],
   }
   const user = { email: 'a@example.com', name: 'Admin', picture: '' }
   return {
@@ -94,7 +94,8 @@ function ctx(): Context {
   } as unknown as Context
 }
 
-const tickets = () => t.createCallerFactory(ticketsRouter)(ctx())
+const tickets = (orgId?: string) =>
+  t.createCallerFactory(ticketsRouter)(ctx(orgId))
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -276,9 +277,13 @@ describe('the router credentials per-organization, never off the platform env', 
         discountCode: 'FREE',
       }),
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    // BAD_REQUEST, not NOT_FOUND: credentials resolve BEFORE the order-ownership
+    // enumeration (which needs a provider to run at all), so an uncredentialed
+    // org is refused a step earlier. It discloses nothing about another tenant —
+    // it is a statement about the caller's own organization.
     await expect(
       tickets().admin.getPaymentDetails({ orderId: 500 }),
-    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
 
     expect(h.listDiscounts).not.toHaveBeenCalled()
     expect(h.createDiscount).not.toHaveBeenCalled()
@@ -305,5 +310,73 @@ describe('the router credentials per-organization, never off the platform env', 
     ).rejects.toMatchObject({ code: 'FORBIDDEN' })
     expect(h.resolveCredentials).not.toHaveBeenCalled()
     expect(h.listDiscounts).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * ACCOUNT-SCOPED CACHE KEYS.
+ *
+ * Checkin `customerId` / `eventId` are numeric ids unique only WITHIN one
+ * Checkin account, so two orgs holding their OWN accounts can legitimately carry
+ * the same pair. The order-id memo is a process-global `Map`, so a key built
+ * from those ids alone would serve the first org's cached order set to the
+ * second — cross-tenant data leakage through the cache rather than through the
+ * credential, defeating the credential seam one layer up.
+ *
+ * The two orgs below share `customerId: 7` / `eventId: 4242` deliberately. That
+ * is the whole point: identical provider ids, different accounts.
+ */
+describe('the order-id memo is scoped to the ACCOUNT, not just the numeric ids', () => {
+  const ORG_B = 'org-B'
+
+  /** Same numeric binding as ORG_A's conference — different owner. */
+  function asOrgB() {
+    h.getConference.mockResolvedValue({
+      conference: {
+        _id: 'conf-B',
+        organization: { _ref: ORG_B },
+        checkinEventId: OUR_EVENT,
+        checkinCustomerId: 7,
+      },
+      domain: 'localhost',
+      error: null,
+    })
+    // A DIFFERENT Checkin account, whose event 4242 holds a different order set.
+    h.resolveCredentials.mockResolvedValue({
+      apiKey: 'B-key',
+      apiSecret: 'B-s',
+    })
+    h.fetchEventTickets.mockResolvedValue([{ id: 9, order_id: 900 }])
+  }
+
+  it('does NOT serve org A’s cached order set to org B', async () => {
+    // Warm the memo as org A: its account's event 4242 holds order 500.
+    await tickets(ORG_A).admin.getPaymentDetails({ orderId: 500 })
+    expect(h.fetchEventTickets).toHaveBeenCalledTimes(1)
+
+    asOrgB()
+
+    // Order 500 exists in A's account, NOT in B's. A shared key would admit it.
+    await expect(
+      tickets(ORG_B).admin.getPaymentDetails({ orderId: 500 }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+
+    // B must have enumerated its OWN account rather than reading A's entry.
+    expect(h.fetchEventTickets).toHaveBeenCalledTimes(2)
+    expect(h.resolveCredentials).toHaveBeenLastCalledWith(ORG_B, 'checkin')
+  })
+
+  it('lets org B read its OWN order with the same numeric ids', async () => {
+    await tickets(ORG_A).admin.getPaymentDetails({ orderId: 500 })
+
+    asOrgB()
+    await tickets(ORG_B).admin.getPaymentDetails({ orderId: 900 })
+    expect(h.fetchOrderPaymentDetails).toHaveBeenLastCalledWith(900)
+  })
+
+  it('still memoizes WITHIN one account (the rate limiter survives the fix)', async () => {
+    await tickets(ORG_A).admin.getPaymentDetails({ orderId: 500 })
+    await tickets(ORG_A).admin.getPaymentDetails({ orderId: 500 })
+    expect(h.fetchEventTickets).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/server/routers/tickets.tenancy.test.ts
+++ b/src/server/routers/tickets.tenancy.test.ts
@@ -3,8 +3,9 @@
  *
  * TENANCY FOR PROVIDER IDS (#731 F5).
  *
- * `checkin()` is constructed from ONE process-wide `CHECKIN_API_KEY` /
- * `CHECKIN_API_SECRET` pair shared by every tenant. Four `tickets.admin.*`
+ * `checkin()` used to be constructed from ONE process-wide `CHECKIN_API_KEY` /
+ * `CHECKIN_API_SECRET` pair shared by every tenant (it now resolves per-org
+ * through `resolveTicketingCredentials`). Four `tickets.admin.*`
  * procedures took the Checkin `eventId` / `orderId` straight from client input
  * and never compared it with the request's own conference, so an organizer of
  * tenant A could mint 100%-off codes on tenant B's paid sale (the router
@@ -29,6 +30,7 @@ vi.mock('next/cache', () => ({
 
 const h = vi.hoisted(() => ({
   getConference: vi.fn(),
+  resolveCredentials: vi.fn(),
   listDiscounts: vi.fn(),
   createDiscount: vi.fn(),
   deleteDiscount: vi.fn(),
@@ -44,7 +46,7 @@ vi.mock('@/lib/sanity/client', () => ({
   clientReadUncached: { fetch: vi.fn() },
 }))
 vi.mock('@/lib/tickets/provider', () => ({
-  platformCheckinCredentials: () => ({ apiKey: 'k', apiSecret: 's' }),
+  resolveTicketingCredentials: h.resolveCredentials,
   getTicketingProvider: () => ({
     listDiscounts: h.listDiscounts,
     createDiscount: h.createDiscount,
@@ -99,6 +101,7 @@ beforeEach(() => {
   // The order-id memo (#731 N1) is module state; a case must never inherit the
   // previous one's enumeration.
   __resetOrderIdCache()
+  h.resolveCredentials.mockResolvedValue({ apiKey: 'k', apiSecret: 's' })
   h.getConference.mockResolvedValue({
     conference: {
       _id: CONF_A,
@@ -235,5 +238,72 @@ describe('tickets payment details are bound to this conference’s orders (#731 
     await tickets().admin.getPaymentDetails({ orderId: 500 })
     expect(h.fetchOrderPaymentDetails).toHaveBeenCalledWith(500)
     expect(h.fetchEventTickets).toHaveBeenCalledTimes(2)
+  })
+})
+
+/**
+ * CROSS-TENANT CREDENTIAL ISOLATION for this router.
+ *
+ * Distinct from the id-ownership guards above: those stop a tenant addressing
+ * another tenant's event WITH the account it holds; these stop it holding the
+ * platform's account at all. The router used to build its client straight from
+ * `platformCheckinCredentials()`, bypassing the per-org seam every other
+ * ticketing surface goes through.
+ */
+describe('the router credentials per-organization, never off the platform env', () => {
+  it('resolves credentials for the request conference’s OWNING org', async () => {
+    await tickets().admin.getDiscountCodes({ eventId: OUR_EVENT })
+    expect(h.resolveCredentials).toHaveBeenCalledWith(ORG_A, 'checkin')
+  })
+
+  it('REFUSES every provider call when the seam has no credentials for the org', async () => {
+    h.resolveCredentials.mockResolvedValue(null)
+
+    await expect(
+      tickets().admin.getDiscountCodes({ eventId: OUR_EVENT }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    await expect(
+      tickets().admin.createDiscountCode({
+        eventId: OUR_EVENT,
+        discountCode: 'FREE',
+        numberOfTickets: 1,
+        sponsorName: 'Acme',
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    await expect(
+      tickets().admin.deleteDiscountCode({
+        eventId: OUR_EVENT,
+        discountCode: 'FREE',
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    await expect(
+      tickets().admin.getPaymentDetails({ orderId: 500 }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+
+    expect(h.listDiscounts).not.toHaveBeenCalled()
+    expect(h.createDiscount).not.toHaveBeenCalled()
+    expect(h.deleteDiscount).not.toHaveBeenCalled()
+    expect(h.fetchOrderPaymentDetails).not.toHaveBeenCalled()
+    expect(h.fetchEventTickets).not.toHaveBeenCalled()
+  })
+
+  it('FAILS CLOSED for a conference with no owning organization', async () => {
+    h.getConference.mockResolvedValue({
+      conference: {
+        _id: CONF_A,
+        checkinEventId: OUR_EVENT,
+        checkinCustomerId: 7,
+      },
+      domain: 'localhost',
+      error: null,
+    })
+    // The org-scoped `adminProcedure` waist refuses first — it cannot match the
+    // caller's `organizerOrgIds` against an unresolvable owner. So no credential
+    // is even requested, let alone the platform's.
+    await expect(
+      tickets().admin.getDiscountCodes({ eventId: OUR_EVENT }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expect(h.resolveCredentials).not.toHaveBeenCalled()
+    expect(h.listDiscounts).not.toHaveBeenCalled()
   })
 })

--- a/src/server/routers/tickets.ts
+++ b/src/server/routers/tickets.ts
@@ -24,6 +24,25 @@ import {
 import type { DiscountUsageStats } from '@/lib/discounts/types'
 
 /**
+ * This request's ticketing context: a Checkin client, plus the ORGANIZATION
+ * whose account that client is authenticated against.
+ *
+ * `orgId` is not decoration. Checkin `customerId` / `eventId` are numeric ids
+ * scoped to ONE account, so they are only unique WITHIN an account — two orgs
+ * with their own Checkin accounts can legitimately hold the same pair. Anything
+ * keyed on those ids alone (a cache, a memo, a lock) therefore needs the account
+ * as part of its key or it will serve one org's data to another. `orgId` is the
+ * discriminator to use: it identifies the account 1:1 through
+ * `resolveTicketingCredentials`, and unlike the API key it is not a secret, so
+ * it is safe in a cache key that may reach a log or a key dump.
+ */
+interface RequestTicketing {
+  /** The owning organization — the ACCOUNT discriminator for any cache key. */
+  orgId: string
+  provider: TicketingProvider
+}
+
+/**
  * The Checkin client for THIS request's conference, credentialed through the
  * per-org seam (`resolveTicketingCredentials`) rather than straight off the
  * platform env.
@@ -40,10 +59,16 @@ import type { DiscountUsageStats } from '@/lib/discounts/types'
  * Checkin customer/event ids. A Tito-bound conference has no `checkinEventId`
  * and is already refused by `requireCheckinEventId`.
  *
- * FAILS CLOSED: an unresolvable conference, or an org the seam has no
- * credentials for, throws BAD_REQUEST.
+ * COST: `getConferenceForCurrentDomain` is a `'use cache'` read and
+ * `resolveTicketingCredentials` is pure env, so calling this twice in one
+ * request costs no extra Sanity round-trip. Procedures that need it more than
+ * once still hoist it to one local — one resolution per request reads better and
+ * keeps `orgId` in scope for the cache key.
+ *
+ * FAILS CLOSED: an unresolvable conference, a conference with no owning
+ * organization, or an org the seam has no credentials for throws BAD_REQUEST.
  */
-async function checkin(): Promise<TicketingProvider> {
+async function checkin(): Promise<RequestTicketing> {
   const { conference, error } = await getConferenceForCurrentDomain()
   if (error || !conference?._id) {
     throw new TRPCError({
@@ -51,17 +76,22 @@ async function checkin(): Promise<TicketingProvider> {
       message: 'Conference checkin configuration not found',
     })
   }
-  const credentials = await resolveTicketingCredentials(
-    conference.organization?._ref,
-    'checkin',
-  )
+  const orgId = conference.organization?._ref
+  if (!orgId) {
+    // No owner means no account to resolve and no discriminator to key on.
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Conference checkin configuration not found',
+    })
+  }
+  const credentials = await resolveTicketingCredentials(orgId, 'checkin')
   if (!credentials) {
     throw new TRPCError({
       code: 'BAD_REQUEST',
       message: 'Ticketing is not configured for this organization',
     })
   }
-  return getTicketingProvider('checkin', credentials)
+  return { orgId, provider: getTicketingProvider('checkin', credentials) }
 }
 
 /**
@@ -107,10 +137,23 @@ async function requireCheckinEventId(clientEventId?: number): Promise<number> {
  * endpoint and throttle ticketing for all of them. That amplification is new in
  * this PR, because the guard is.
  *
- * The memo keys on the event and holds the in-flight PROMISE, so concurrent
- * callers share one enumeration and a burst of misses costs one round-trip
- * rather than one each. Rejections are evicted immediately: a failed read must
- * not be cached into a refusal, and the caller fails closed on it anyway.
+ * The memo holds the in-flight PROMISE, so concurrent callers share one
+ * enumeration and a burst of misses costs one round-trip rather than one each.
+ * Rejections are evicted immediately: a failed read must not be cached into a
+ * refusal, and the caller fails closed on it anyway.
+ *
+ * THE KEY IS ACCOUNT-SCOPED (`orgId:customerId:eventId`). Checkin
+ * `customerId`/`eventId` are numeric ids unique only WITHIN one Checkin account,
+ * so two orgs holding their own accounts can legitimately carry the same pair.
+ * Keyed on the ids alone, the second org would be served the first org's cached
+ * order-id set — the same cross-tenant read this router's credential seam
+ * closes, defeated one layer up in a process-global `Map`. Unreachable while the
+ * platform org is the only credentialed tenant, but reachable the moment a
+ * second org is provisioned, which is the state this work builds toward.
+ *
+ * `orgId` — NOT the API key — is the discriminator: it maps 1:1 to the account
+ * through `resolveTicketingCredentials` and is not a secret, so it is safe in a
+ * key that can surface in a log or a heap dump.
  *
  * The TTL is deliberately short. It is a rate limiter, not a data cache — an
  * order created within the window is refused until it expires, which is a modal
@@ -123,16 +166,17 @@ const orderIdsCache = new Map<
 >()
 
 function orderIdsForEvent(
+  ticketing: RequestTicketing,
   customerId: number,
   eventId: number,
 ): Promise<Set<number>> {
-  const key = `${customerId}:${eventId}`
+  const key = `${ticketing.orgId}:${customerId}:${eventId}`
   const now = Date.now()
   const cached = orderIdsCache.get(key)
   if (cached && cached.expiresAt > now) return cached.orderIds
 
-  const orderIds = checkin()
-    .then((provider) => provider.fetchEventTickets({ customerId, eventId }))
+  const orderIds = ticketing.provider
+    .fetchEventTickets({ customerId, eventId })
     .then((tickets) => new Set(tickets.map((ticket) => ticket.order_id)))
   orderIds.catch(() => orderIdsCache.delete(key))
   orderIdsCache.set(key, { expiresAt: now + ORDER_IDS_TTL_MS, orderIds })
@@ -152,7 +196,10 @@ export function __resetOrderIdCache() {
  * The same posture for an `orderId`: prove the order is one of THIS
  * conference's event's orders before reading its payment/customer details.
  */
-async function requireOrderInCurrentEvent(orderId: number): Promise<void> {
+async function requireOrderInCurrentEvent(
+  ticketing: RequestTicketing,
+  orderId: number,
+): Promise<void> {
   const { conference, error } = await getConferenceForCurrentDomain()
   if (error || !conference?.checkinEventId || !conference?.checkinCustomerId) {
     throw new TRPCError({
@@ -163,6 +210,7 @@ async function requireOrderInCurrentEvent(orderId: number): Promise<void> {
   let orderIds: Set<number>
   try {
     orderIds = await orderIdsForEvent(
+      ticketing,
       conference.checkinCustomerId,
       conference.checkinEventId,
     )
@@ -369,7 +417,8 @@ export const ticketsRouter = router({
         }
 
         const eventId = conference.checkinEventId
-        const eventData = await (await checkin()).listDiscounts(eventId)
+        const { provider } = await checkin()
+        const eventData = await provider.listDiscounts(eventId)
 
         return {
           success: true,
@@ -396,7 +445,8 @@ export const ticketsRouter = router({
           // OWNERSHIP (#730): the event id comes from THIS conference, never
           // from the payload. Discount codes are redeemable strings.
           const eventId = await requireCheckinEventId(input.eventId)
-          const eventData = await (await checkin()).listDiscounts(eventId)
+          const { provider } = await checkin()
+          const eventData = await provider.listDiscounts(eventId)
           return {
             success: true,
             discounts: eventData.discounts,
@@ -432,16 +482,16 @@ export const ticketsRouter = router({
         const customerId = conference.checkinCustomerId
         const eventId = conference.checkinEventId
 
-        const eventData = await (await checkin()).listDiscounts(eventId)
+        // ONE resolution for both provider calls below.
+        const { provider } = await checkin()
+        const eventData = await provider.listDiscounts(eventId)
         const discounts = eventData.discounts
 
         let usageStats: DiscountUsageStats = {}
         let totalTickets = 0
 
         try {
-          const tickets = await (
-            await checkin()
-          ).fetchEventTickets({
+          const tickets = await provider.fetchEventTickets({
             customerId,
             eventId,
           })
@@ -504,7 +554,9 @@ export const ticketsRouter = router({
           // an unvalidated `eventId` minted 100%-off codes on ANOTHER tenant's
           // paid ticket sale against the shared platform credential.
           const eventId = await requireCheckinEventId(input.eventId)
-          const eventData = await (await checkin()).listDiscounts(eventId)
+          // ONE resolution for the existence check and the create below.
+          const { provider } = await checkin()
+          const eventData = await provider.listDiscounts(eventId)
           const codeExists = eventData.discounts.some(
             (discount) => discount.triggerValue === discountCode,
           )
@@ -516,9 +568,7 @@ export const ticketsRouter = router({
             })
           }
 
-          const result = await (
-            await checkin()
-          ).createDiscount({
+          const result = await provider.createDiscount({
             eventId,
             discountCode,
             numberOfTickets,
@@ -557,9 +607,11 @@ export const ticketsRouter = router({
           // OWNERSHIP (#730): unvalidated, this deleted another tenant's live
           // sponsor/partner discount codes.
           const eventId = await requireCheckinEventId(input.eventId)
-          const success = await (
-            await checkin()
-          ).deleteDiscount(eventId, input.discountCode)
+          const { provider } = await checkin()
+          const success = await provider.deleteDiscount(
+            eventId,
+            input.discountCode,
+          )
 
           if (!success) {
             throw new TRPCError({
@@ -595,10 +647,13 @@ export const ticketsRouter = router({
           // OWNERSHIP (#730): `orderId` is a small enumerable integer against a
           // credential shared by every tenant — unvalidated, this read another
           // tenant's customer's payment and order details.
-          await requireOrderInCurrentEvent(orderId)
-          const paymentDetails = await (
-            await checkin()
-          ).fetchOrderPaymentDetails(orderId)
+          // ONE resolution: the ownership enumeration and the read that
+          // follows MUST run against the SAME account, or the guard proves
+          // nothing about the order it just admitted.
+          const ticketing = await checkin()
+          await requireOrderInCurrentEvent(ticketing, orderId)
+          const paymentDetails =
+            await ticketing.provider.fetchOrderPaymentDetails(orderId)
           return {
             success: true,
             paymentDetails,

--- a/src/server/routers/tickets.ts
+++ b/src/server/routers/tickets.ts
@@ -18,23 +18,61 @@ import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { calculateDiscountUsage } from '@/lib/discounts'
 import {
   getTicketingProvider,
-  platformCheckinCredentials,
+  resolveTicketingCredentials,
+  type TicketingProvider,
 } from '@/lib/tickets/provider'
 import type { DiscountUsageStats } from '@/lib/discounts/types'
 
-/** Platform-credentialed ticketing provider for this request. */
-function checkin() {
-  return getTicketingProvider('checkin', platformCheckinCredentials())
+/**
+ * The Checkin client for THIS request's conference, credentialed through the
+ * per-org seam (`resolveTicketingCredentials`) rather than straight off the
+ * platform env.
+ *
+ * WHY IT MOVED. This router used to build ONE process-wide client from
+ * `platformCheckinCredentials()`, which bypassed the org-keyed credential
+ * resolution every other ticketing surface goes through — so a tenant with its
+ * own provisioned Checkin account was served the platform's account here, and a
+ * tenant with no account at all was served it too. Resolution is now keyed on
+ * the request conference's owning organization, and a tenant the seam declines
+ * to credential is REFUSED instead of borrowing the platform's.
+ *
+ * The provider is pinned to `'checkin'` on purpose: every procedure below speaks
+ * Checkin customer/event ids. A Tito-bound conference has no `checkinEventId`
+ * and is already refused by `requireCheckinEventId`.
+ *
+ * FAILS CLOSED: an unresolvable conference, or an org the seam has no
+ * credentials for, throws BAD_REQUEST.
+ */
+async function checkin(): Promise<TicketingProvider> {
+  const { conference, error } = await getConferenceForCurrentDomain()
+  if (error || !conference?._id) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Conference checkin configuration not found',
+    })
+  }
+  const credentials = await resolveTicketingCredentials(
+    conference.organization?._ref,
+    'checkin',
+  )
+  if (!credentials) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Ticketing is not configured for this organization',
+    })
+  }
+  return getTicketingProvider('checkin', credentials)
 }
 
 /**
- * TENANCY FOR PROVIDER IDS (#730). `checkin()` is built from ONE process-wide
- * credential pair shared by every tenant, so a Checkin `eventId` taken from
- * client input addressed any customer's event — minting 100%-off codes on, or
- * deleting codes from, another tenant's paid ticket sale. These are provider
- * ids, not Sanity ids, so the document guards cannot see them: the event id is
- * therefore DERIVED from the request's own conference, and a client-supplied one
- * is accepted only when it matches.
+ * TENANCY FOR PROVIDER IDS (#730). Even with per-org credentials, a Checkin
+ * `eventId` taken from client input addressed any event the resolved account can
+ * reach — minting 100%-off codes on, or deleting codes from, another tenant's
+ * paid ticket sale whenever two tenants share an account (as every tenant did
+ * before the credential seam above). These are provider ids, not Sanity ids, so
+ * the document guards cannot see them: the event id is therefore DERIVED from
+ * the request's own conference, and a client-supplied one is accepted only when
+ * it matches.
  *
  * FAILS CLOSED: an unresolvable conference or a conference with no
  * `checkinEventId` refuses.
@@ -65,10 +103,9 @@ async function requireCheckinEventId(clientEventId?: number): Promise<number> {
  * `fetchEventTickets` is `fetchEventTicketsRaw` PLUS a `while (hasMore)`
  * pagination loop at 1000 orders per batch, so an uncached ownership check costs
  * 1 + ⌈orders/1000⌉ upstream GraphQL calls returning the entire attendee list.
- * `platformCheckinCredentials()` is ONE account shared by every tenant, so any
- * authenticated organizer of ANY tenant could loop the payment-details endpoint
- * and throttle ticketing for everyone. That amplification is new in this PR,
- * because the guard is.
+ * Every organizer sharing one provider account could loop the payment-details
+ * endpoint and throttle ticketing for all of them. That amplification is new in
+ * this PR, because the guard is.
  *
  * The memo keys on the event and holds the in-flight PROMISE, so concurrent
  * callers share one enumeration and a burst of misses costs one round-trip
@@ -95,7 +132,7 @@ function orderIdsForEvent(
   if (cached && cached.expiresAt > now) return cached.orderIds
 
   const orderIds = checkin()
-    .fetchEventTickets({ customerId, eventId })
+    .then((provider) => provider.fetchEventTickets({ customerId, eventId }))
     .then((tickets) => new Set(tickets.map((ticket) => ticket.order_id)))
   orderIds.catch(() => orderIdsCache.delete(key))
   orderIdsCache.set(key, { expiresAt: now + ORDER_IDS_TTL_MS, orderIds })
@@ -332,7 +369,7 @@ export const ticketsRouter = router({
         }
 
         const eventId = conference.checkinEventId
-        const eventData = await checkin().listDiscounts(eventId)
+        const eventData = await (await checkin()).listDiscounts(eventId)
 
         return {
           success: true,
@@ -359,7 +396,7 @@ export const ticketsRouter = router({
           // OWNERSHIP (#730): the event id comes from THIS conference, never
           // from the payload. Discount codes are redeemable strings.
           const eventId = await requireCheckinEventId(input.eventId)
-          const eventData = await checkin().listDiscounts(eventId)
+          const eventData = await (await checkin()).listDiscounts(eventId)
           return {
             success: true,
             discounts: eventData.discounts,
@@ -395,14 +432,16 @@ export const ticketsRouter = router({
         const customerId = conference.checkinCustomerId
         const eventId = conference.checkinEventId
 
-        const eventData = await checkin().listDiscounts(eventId)
+        const eventData = await (await checkin()).listDiscounts(eventId)
         const discounts = eventData.discounts
 
         let usageStats: DiscountUsageStats = {}
         let totalTickets = 0
 
         try {
-          const tickets = await checkin().fetchEventTickets({
+          const tickets = await (
+            await checkin()
+          ).fetchEventTickets({
             customerId,
             eventId,
           })
@@ -465,7 +504,7 @@ export const ticketsRouter = router({
           // an unvalidated `eventId` minted 100%-off codes on ANOTHER tenant's
           // paid ticket sale against the shared platform credential.
           const eventId = await requireCheckinEventId(input.eventId)
-          const eventData = await checkin().listDiscounts(eventId)
+          const eventData = await (await checkin()).listDiscounts(eventId)
           const codeExists = eventData.discounts.some(
             (discount) => discount.triggerValue === discountCode,
           )
@@ -477,7 +516,9 @@ export const ticketsRouter = router({
             })
           }
 
-          const result = await checkin().createDiscount({
+          const result = await (
+            await checkin()
+          ).createDiscount({
             eventId,
             discountCode,
             numberOfTickets,
@@ -516,10 +557,9 @@ export const ticketsRouter = router({
           // OWNERSHIP (#730): unvalidated, this deleted another tenant's live
           // sponsor/partner discount codes.
           const eventId = await requireCheckinEventId(input.eventId)
-          const success = await checkin().deleteDiscount(
-            eventId,
-            input.discountCode,
-          )
+          const success = await (
+            await checkin()
+          ).deleteDiscount(eventId, input.discountCode)
 
           if (!success) {
             throw new TRPCError({
@@ -556,8 +596,9 @@ export const ticketsRouter = router({
           // credential shared by every tenant — unvalidated, this read another
           // tenant's customer's payment and order details.
           await requireOrderInCurrentEvent(orderId)
-          const paymentDetails =
-            await checkin().fetchOrderPaymentDetails(orderId)
+          const paymentDetails = await (
+            await checkin()
+          ).fetchOrderPaymentDetails(orderId)
           return {
             success: true,
             paymentDetails,


### PR DESCRIPTION
Closes two credential-isolation gaps ahead of onboarding a second organization. Both have the same shape: the platform environment holds **one** upstream account, that account was handed to **every** organization, and the thing that addresses it inside the account is a **tenant-editable** field. No Sanity-side guard can see an upstream provider id or a Slack channel name, so withholding the credential is the isolation.

Today there is exactly one organization in production, which is both the platform org and a tenant. **It keeps every capability it has** — see "What the platform org keeps" below.

## S1 — ticketing credentials

`resolveTicketingProvider` fell back to `platformCheckinCredentials()` / `platformTitoCredentials()` for any org without its own secret, and the `tickets` tRPC router plus three admin ticket sub-pages built clients from the platform env directly, bypassing the per-org seam entirely.

New `resolveTicketingCredentials(orgId, providerType)` is the single place ticketing credentials are chosen:

1. a per-org secret wins (the tenant's own account — no isolation question),
2. otherwise the platform env, **only** when the org is the platform org (`PLATFORM_ORG_ID`),
3. otherwise `null`.

`null` returns `{ configured: false, provider: null, eventRef: null }` — the shape every caller already handles, so an unentitled tenant renders the existing unconfigured empty state rather than a new error path.

This complements rather than duplicates `ticketingBindingIsClaimed` (`src/server/routers/conference.ts`), which refuses a binding another conference *document* claims. Its docstring names the residue it cannot cover — an event that exists in the platform account but is bound to no document, which needs a provider round-trip to detect. That residue closes here at the source: with no account resolved, there is nothing for a binding to address.

## S2 — Slack bot token

`postSlackMessage` ended `injectedToken ?? process.env.SLACK_BOT_TOKEN`, with no guard in front of it. `resolveConferenceSlackToken` returned `undefined` for any org without a per-org secret, so every tenant's sends rode the platform bot into `cfpNotificationChannel` / `salesNotificationChannel` — plain string fields editable from each tenant's own admin settings.

- New `src/lib/features/slack.ts` enforces the `slack-mirror` registry id, mirroring `workshops.ts` exactly: entitlement → active-override denial → platform-org default → disabled, failing closed on an unresolvable org or a rejected read.
- The `process.env.SLACK_BOT_TOKEN` fallback is **deleted** from `postSlackMessage`, making `resolveConferenceSlackToken` the only token source. That resolver returns a per-org token unconditionally (it addresses the tenant's own workspace) and the platform env token only when the gate passes. `undefined` takes the existing no-op-warn path.
- Doing it at that chokepoint covers every sender without touching them: `notify.ts` (proposal, speaker/sponsor message, volunteer, sponsor registration, contract signed), `weeklyUpdate.ts` and its cron, and the `status.ts` probe. Verified by enumerating every `postSlackMessage` call site — there are four in production code and all four inject.

### One thing the chokepoint exposed

Two conference reads use an **explicit field list** rather than a `{...}` spread and omitted `organization`: `SIGNING_CONTRACT_QUERY` and `SPONSOR_FOR_CONFERENCE_FIELDS`, both feeding the sponsor contract-signed post. Under the old env fallback that was invisible. Under the new rule it would have silently killed those two posts *for the platform org too*. Both projections now carry `organization`, with a regression test pinning it (`src/lib/slack/senderProjections.test.ts`), because the failure mode is a silent no-op with no type error.

## S3 — account-blind cache key (review follow-up)

Caught in review, same defect class one layer up. The order-id ownership memo (`#731 N1`) is a process-global `Map` keyed `customerId:eventId`. Those are numeric ids unique only **within** one Checkin account, so two orgs holding their own accounts can legitimately carry the same pair — and the second would have been served the first's cached order-id set. Cross-tenant leakage through the cache rather than through the credential, defeating the seam this PR establishes.

Not reachable today (only the platform org holds credentials), but reachable the moment a second org is provisioned, which is the state this work builds toward — so it is fixed here rather than left latent.

The key is now `orgId:customerId:eventId`. The discriminator is the owning organization, **never** the API key: a credential must not sit in a key that can surface in a log or a heap dump. `checkin()` now returns `{ orgId, provider }` so the account is in scope wherever a key is built.

I swept every other cache in the ticketing path. `getPublicTicketTypes` (`'use cache'`) keys on the serialized `ticketingBinding(conference)`, which already carries `organization`, so it is account-discriminated. No other module-level cache in the path is keyed on provider ids.

**Also (Copilot, minor):** procedures making more than one provider call now hoist to a single `checkin()`. `getConferenceForCurrentDomain` is a `'use cache'` read and `resolveTicketingCredentials` is pure env, so the duplicate cost no Sanity round-trip — but `getPaymentDetails` genuinely needed it: its ownership enumeration and the read that follows must run against the **same** account, or the guard proves nothing about the order it just admitted.

One deliberate behaviour change: `getPaymentDetails` for an uncredentialed org now refuses `BAD_REQUEST` rather than `NOT_FOUND`, because credentials resolve before the ownership check (which needs a provider to run at all). It discloses nothing about another tenant — it is a statement about the caller's own organization.

## Admin UX

The status-page Slack probe now resolves the token **first** and returns `notEnabled` when nothing resolves, rendered in the existing muted tone — `slack-mirror` is `readiness: 'internal'`, so this is a neutral statement of fact with no upsell. Ordering it before the channel check also removes a lie: `postSlackMessage` no-op-warns when no token resolves, so the old order reported `ok: true, Posted to #channel` for a send that never happened.

## Dev behaviour — decision

`PLATFORM_ORG_ID` is set on production and preview but **not** in local development, so `isPlatformOrganization()` is false for everything locally and both integrations resolve to nothing for every developer.

**That is the intended behaviour, and there is deliberately no dev fallback.**

- Slack loses nothing: `postSlackMessage` already short-circuits to a console log under `NODE_ENV === 'development'`, so no developer had a working send.
- Ticketing surfaces render their existing unconfigured empty states — the same thing a developer without `CHECKIN_API_KEY` already saw.
- A developer pointing a local checkout at the live Checkin account is the same cross-account hazard this change exists to remove, so degrading to it would be odd.
- A fallback would have to live in the code path that also runs in production. A gate with a bypass branch is not a gate.

Setting `PLATFORM_ORG_ID` locally (with the provider env vars) exercises the real integration when needed.

## What the platform org keeps

Every ticketing path was traced to its conference source; all pass either a full conference from `getConferenceForCurrentDomain` (`...` projection) or `ticketingBinding(conference)`, which preserves the ref:

`admin/actions.ts` `fetchTicketSales` · `admin/budget/page.tsx` · `admin/tickets/page.tsx` · `admin/tickets/{orders,companies,types}/page.tsx` · `events/handlers/speakerTicket.ts` · `status/summary.ts` (weekly cron) · `tickets/public.ts` (home page, tickets page, `conference` router) · `workshop/eligibility.ts` · every `tickets.admin.*` procedure.

Same for Slack: proposal/volunteer/messaging/registration/weekly-update/status-probe all read `...` or `conference->{ ... }`; the two explicit projections are fixed above.

The inbound `/api/webhooks/checkin/ticket-sold` route still uses `platformCheckinCredentials()` on purpose — it verifies a signature *before* any tenant is known, so it has no org to key on. Documented at the function.

## Tests

Sabotage-proven. Each guard was removed by exact call string (never line number), the suite re-run, and the guard restored:

| Guard removed | Failing tests |
| --- | --- |
| platform-org condition in `resolveTicketingCredentials` | 4 |
| refusal in the `tickets` router's `checkin()` | 1 |
| `?? process.env.SLACK_BOT_TOKEN` restored in `postSlackMessage` | 2 |
| `slack-mirror` gate in `resolveConferenceSlackToken` | 8 |
| `notEnabled` branch in `probeSlack` | 2 |
| `organization` dropped from `SIGNING_CONTRACT_QUERY` | 1 |
| account discriminator dropped from the order-id cache key | 2 |

Each restored to green. Four new files: `features/slack.test.ts`, `slack/token.test.ts`, `slack/senderProjections.test.ts`, plus isolation blocks in `provider.test.ts` and `tickets.tenancy.test.ts`.

## Numbers

| | baseline (`a9e687e`) | this branch |
| --- | --- | --- |
| `pnpm test` | 480 files / 6923 tests passed | **483 files / 6970 tests passed** |
| `pnpm typecheck` | clean | clean |
| `npx prettier --check .` | clean | clean |
| `npx eslint .` | 0 errors, 216 warnings | 0 errors, 216 warnings |

## Follow-up (not in this PR)

The passive system-status registry (`src/lib/system-status/checks.ts`) still reports platform env presence — `SLACK_BOT_TOKEN` fingerprint, `Checkin.no API credentials` — to any tenant organizer, regardless of entitlement. It grants no capability and leaks no cross-tenant data beyond a fingerprint, but it now reads as misleading for a non-entitled org. Making it org-aware means making the currently-synchronous `buildChecks` async, and the same argument applies to ~40 other env rows, so it belongs in its own change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scopes shared ticketing and Slack credentials to the owning organization and updates affected admin, status-probe, and sponsor-notification paths.
- Introduces platform-organization gates for ticketing and Slack environment credentials.
- Removes Slack transport fallback to the process-wide bot token.
- Routes ticket admin operations through organization-resolved credentials.
- Adds organization fields to explicit sponsor-signing projections and expands tenancy regression coverage.

<h3>Confidence Score: 4/5</h3>

The ticket order cache must be scoped to the resolved organization or provider account before merging, because separate Checkin accounts can currently reuse each other's cached ownership sets.

Per-organization credentials make ticket enumeration account-specific, but the existing shared cache still identifies results only by numeric customer and event IDs, causing incorrect payment-order authorization when those IDs collide across accounts.

**Files Needing Attention:** src/server/routers/tickets.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/tickets/provider/index.ts | Centralizes ticketing credential selection and restricts platform environment credentials to the platform organization. |
| src/server/routers/tickets.ts | Routes ticket operations through per-organization credentials, but the shared order-ID cache does not distinguish those provider accounts. |
| src/lib/features/slack.ts | Adds a fail-closed entitlement gate controlling access to the platform Slack bot. |
| src/lib/slack/token.ts | Prefers tenant-owned Slack secrets and exposes the platform token only after the new gate passes. |
| src/lib/slack/client.ts | Removes the implicit process-wide token fallback so unresolved credentials result in a no-op. |
| src/server/routers/status.ts | Resolves Slack credentials before probing and accurately reports organizations for which Slack is not enabled. |
| src/lib/signing/sanity.ts | Adds the owning organization to the signing projection needed by the Slack token resolver. |
| src/lib/sponsor-crm/sanity.ts | Preserves organization ownership in the explicit sponsor conference projection used by Slack notifications. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Request["Tenant ticket request"] --> Conference["Resolve conference owner"]
  Conference --> Credentials["Resolve per-org Checkin credentials"]
  Credentials --> Provider["Account-specific Checkin provider"]
  Provider --> Cache{"Order-ID cache<br/>customerId:eventId"}
  Cache --> Ownership["Validate requested order ID"]
  Ownership --> Payment["Fetch payment details"]
  Other["Another tenant/account with<br/>same numeric IDs"] -. "collides within TTL" .-> Cache
```

<sub>Reviews (1): Last reviewed commit: ["fix(tenancy): scope ticketing and Slack ..."](https://github.com/cloudnativebergen/website/commit/2ef9f3370f243ba8bd66598422b634fdeb6d3799) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50408989)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Platform Tenancy: Scoping, Domain Verification, and Provisioning](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/platform-tenancy.md)
- Knowledge Base — [Ticketing and contract e-signature](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/ticketing-signing.md)
- Knowledge Base — [Conference Core: Editions, Settings & AI Agent Config](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/conference-core.md)
</details>

<!-- /greptile_comment -->
