### PR TITLE
feat(admin): find duplicate speakers, not just merge them (#267)

### DIFF
--- a/scripts/report-duplicate-speakers.ts
+++ b/scripts/report-duplicate-speakers.ts
@@ -1,21 +1,25 @@
 /**
- * Duplicate-speaker detection REPORT (Phase 4, Part B).
+ * Duplicate-speaker detection REPORT.
  *
  * ============================ READ-ONLY ============================
  * This script makes NO writes. It only reads speaker documents and
  * their inbound references and prints/serializes a report. It never
  * merges, patches, or deletes anything. Merging is a deliberate,
- * human-reviewed action performed later via the Phase 3 admin tool.
+ * human-reviewed action performed via the admin merge tool.
  * ==================================================================
  *
- * It flags likely-duplicate speaker accounts by:
- *   1. overlapping normalized email (`email` / `knownEmails` intersection), and
- *   2. identical normalized name.
+ * CROSS-TENANT BY DESIGN, and that is the difference from the in-app surface.
+ * `speaker.admin.duplicateCandidates` is scoped to one organization because an
+ * organizer may only see and merge their own people. This script is an operator
+ * tool run with a dataset credential: it scans EVERY speaker document so the
+ * platform owner can see the whole picture. Both share one detector
+ * (`src/lib/speaker/duplicates.ts`) so the two can never disagree about what a
+ * duplicate is.
  *
  * For every candidate it enumerates inbound references
- * (`*[references($id)]{_id,_type}`) so an organizer can see the blast radius
- * (talks, invitations, schedules, galleries, …) each account carries before
- * deciding which record to keep.
+ * (`*[references($id)]{_id,_type}`) so a human can see the blast radius (talks,
+ * invitations, schedules, galleries, …) each account carries before deciding
+ * which record to keep.
  *
  * Usage:
  *   tsx scripts/report-duplicate-speakers.ts [--json <path>]
@@ -27,18 +31,22 @@
 import { writeFileSync } from 'node:fs'
 import { clientReadUncached } from '@/lib/sanity/client'
 import {
-  clusterDuplicateSpeakers,
+  findDuplicateSpeakerCandidates,
   speakerEmailSet,
+  SIGNAL_LABEL,
   type DuplicateSpeakerInput,
 } from '@/lib/speaker/duplicates'
 
 interface SpeakerRecord extends DuplicateSpeakerInput {
   _id: string
   name?: string | null
+  slug?: string | null
   email?: string | null
   knownEmails?: string[] | null
   providers?: string[] | null
   _createdAt?: string | null
+  talkCount?: number
+  confirmedTalkCount?: number
 }
 
 interface InboundReference {
@@ -78,27 +86,32 @@ async function reportDuplicateSpeakers(): Promise<void> {
   console.log('Duplicate-speaker detection report (READ-ONLY — no writes)\n')
 
   const speakers = await clientReadUncached.fetch<SpeakerRecord[]>(
+    // groq-global: operator tool, run with a dataset credential to see EVERY
+    // tenant's speakers. The in-app surface is org-scoped; see the header.
     `*[_type == "speaker"]{
       _id,
       name,
       email,
       knownEmails,
       providers,
-      _createdAt
+      _createdAt,
+      "slug": slug.current,
+      "talkCount": count(*[_type == "talk" && references(^._id)]),
+      "confirmedTalkCount": count(*[_type == "talk" && references(^._id) && status == "confirmed"])
     } | order(_createdAt asc)`,
   )
 
   console.log(`Loaded ${speakers.length} speaker document(s).`)
 
-  const clusters = clusterDuplicateSpeakers(speakers)
+  const groups = findDuplicateSpeakerCandidates(speakers)
 
-  if (clusters.length === 0) {
+  if (groups.length === 0) {
     console.log('\n✅ No likely-duplicate speakers found.')
     if (jsonPath) {
       writeFileSync(
         jsonPath,
         JSON.stringify(
-          { generatedAt: new Date().toISOString(), clusters: [] },
+          { generatedAt: new Date().toISOString(), groups: [] },
           null,
           2,
         ),
@@ -108,52 +121,60 @@ async function reportDuplicateSpeakers(): Promise<void> {
     return
   }
 
-  const flaggedCount = clusters.reduce(
-    (sum, cluster) => sum + cluster.members.length,
-    0,
+  const flaggedIds = new Set(
+    groups.flatMap((group) => group.members.map((member) => member._id)),
   )
+  const certainCount = groups.filter(
+    (group) => group.confidence === 'certain',
+  ).length
   console.log(
-    `\n⚠ Found ${clusters.length} likely-duplicate cluster(s) covering ${flaggedCount} speaker(s).\n`,
+    `\n⚠ Found ${groups.length} duplicate candidate group(s) (${certainCount} certain) covering ${flaggedIds.size} speaker(s).\n`,
   )
 
   // Enumerate inbound references per member (blast radius). Read-only.
   const referencesById = new Map<string, InboundReference[]>()
-  for (const cluster of clusters) {
-    for (const member of cluster.members) {
-      if (referencesById.has(member._id)) continue
-      const refs = await clientReadUncached.fetch<InboundReference[]>(
-        `*[references($id) && _id != $id]{ _id, _type }`,
-        { id: member._id },
-      )
-      referencesById.set(member._id, refs ?? [])
-    }
+  for (const id of flaggedIds) {
+    const refs = await clientReadUncached.fetch<InboundReference[]>(
+      `*[references($id) && _id != $id]{ _id, _type }`,
+      { id },
+    )
+    referencesById.set(id, refs ?? [])
   }
 
-  const jsonClusters = clusters.map((cluster, clusterIndex) => {
-    const reasonLabel = cluster.reasons.join(' + ') || 'unknown'
+  const jsonGroups = groups.map((group, groupIndex) => {
+    const corroboration =
+      group.corroboratingSignals.length > 0
+        ? ` (also: ${group.corroboratingSignals
+            .map((signal) => SIGNAL_LABEL[signal])
+            .join(', ')})`
+        : ''
     console.log(
-      `── Cluster ${clusterIndex + 1} (${cluster.members.length} accounts, matched by: ${reasonLabel}) ─────────`,
+      `── Group ${groupIndex + 1} [${group.confidence.toUpperCase()}] ${SIGNAL_LABEL[group.signal]}: ${group.value} — ${group.members.length} accounts${corroboration} ─────────`,
     )
-    if (cluster.sharedEmails.length > 0) {
-      console.log(`   shared email(s): ${cluster.sharedEmails.join(', ')}`)
-    }
-    if (cluster.sharedNames.length > 0) {
-      console.log(`   shared name(s):  ${cluster.sharedNames.join(', ')}`)
-    }
 
-    const members = cluster.members.map((member) => {
+    const members = group.members.map((member) => {
       const refs = referencesById.get(member._id) ?? []
       const summary = summarizeReferences(refs)
       const emails = speakerEmailSet(member)
       const providers = (member.providers ?? []).filter(Boolean)
+      const survivorMark =
+        member._id === group.suggestedSurvivorId
+          ? `  ← suggested survivor (${group.survivorReason})`
+          : ''
 
-      console.log(`\n   • ${member.name ?? '(no name)'}  [${member._id}]`)
+      console.log(
+        `\n   • ${member.name ?? '(no name)'}  [${member._id}]${survivorMark}`,
+      )
       console.log(`       created:   ${member._createdAt ?? 'unknown'}`)
+      console.log(`       slug:      ${member.slug ?? 'none'}`)
       console.log(
         `       emails:    ${emails.length > 0 ? emails.join(', ') : 'none'}`,
       )
       console.log(
         `       providers: ${providers.length > 0 ? providers.join(', ') : 'none'}`,
+      )
+      console.log(
+        `       talks:     ${member.talkCount ?? 0} (${member.confirmedTalkCount ?? 0} confirmed)`,
       )
       console.log(
         `       inbound refs: ${summary.total} (${formatByType(summary.byType)})`,
@@ -162,9 +183,13 @@ async function reportDuplicateSpeakers(): Promise<void> {
       return {
         _id: member._id,
         name: member.name ?? null,
+        slug: member.slug ?? null,
         emails,
         providers,
         _createdAt: member._createdAt ?? null,
+        talkCount: member.talkCount ?? 0,
+        confirmedTalkCount: member.confirmedTalkCount ?? 0,
+        isSuggestedSurvivor: member._id === group.suggestedSurvivorId,
         inboundReferences: {
           total: summary.total,
           byType: summary.byType,
@@ -176,15 +201,19 @@ async function reportDuplicateSpeakers(): Promise<void> {
     console.log('')
 
     return {
-      reasons: cluster.reasons,
-      sharedEmails: cluster.sharedEmails,
-      sharedNames: cluster.sharedNames,
+      id: group.id,
+      signal: group.signal,
+      confidence: group.confidence,
+      value: group.value,
+      corroboratingSignals: group.corroboratingSignals,
+      suggestedSurvivorId: group.suggestedSurvivorId,
+      survivorReason: group.survivorReason,
       members,
     }
   })
 
   console.log(
-    'Review these clusters and merge duplicates via the Phase 3 admin tool.',
+    'Review these groups and merge duplicates via the admin speakers page.',
   )
   console.log('This script made NO changes.')
 
@@ -195,9 +224,9 @@ async function reportDuplicateSpeakers(): Promise<void> {
         {
           generatedAt: new Date().toISOString(),
           totalSpeakers: speakers.length,
-          clusterCount: clusters.length,
-          flaggedSpeakers: flaggedCount,
-          clusters: jsonClusters,
+          groupCount: groups.length,
+          flaggedSpeakers: flaggedIds.size,
+          groups: jsonGroups,
         },
         null,
         2,

--- a/scripts/report-duplicate-speakers.ts
+++ b/scripts/report-duplicate-speakers.ts
@@ -131,14 +131,20 @@ async function reportDuplicateSpeakers(): Promise<void> {
     `\n⚠ Found ${groups.length} duplicate candidate group(s) (${certainCount} certain) covering ${flaggedIds.size} speaker(s).\n`,
   )
 
-  // Enumerate inbound references per member (blast radius). Read-only.
+  // Enumerate inbound references per member (blast radius). Read-only, and in
+  // ONE round trip: this is a global scan, so the flagged set grows with the
+  // dataset rather than staying the ~25 documents one tenant sees.
   const referencesById = new Map<string, InboundReference[]>()
-  for (const id of flaggedIds) {
-    const refs = await clientReadUncached.fetch<InboundReference[]>(
-      `*[references($id) && _id != $id]{ _id, _type }`,
-      { id },
-    )
-    referencesById.set(id, refs ?? [])
+  const referenceRows = await clientReadUncached.fetch<
+    { _id: string; refs: InboundReference[] | null }[]
+  >(
+    // groq-global: operator tool; see the header. The root filter is a bounded
+    // id list produced by the scan above, not a listing.
+    `*[_id in $ids]{ _id, "refs": *[references(^._id) && _id != ^._id]{ _id, _type } }`,
+    { ids: Array.from(flaggedIds) },
+  )
+  for (const row of referenceRows ?? []) {
+    referencesById.set(row._id, row.refs ?? [])
   }
 
   const jsonGroups = groups.map((group, groupIndex) => {

--- a/src/components/admin/DuplicateSpeakersPanel.stories.tsx
+++ b/src/components/admin/DuplicateSpeakersPanel.stories.tsx
@@ -1,0 +1,203 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { fn } from 'storybook/test'
+import { DuplicateSpeakersPanel } from './DuplicateSpeakersPanel'
+import {
+  findDuplicateSpeakerCandidates,
+  type DuplicateCandidateSpeaker,
+  type MergeBlockReason,
+} from '@/lib/speaker/duplicates'
+
+/**
+ * The duplicate-candidates panel on `/admin/speakers` (#267).
+ *
+ * The stories run the REAL detector over fixture documents, so the ranking,
+ * survivor suggestion and grouping shown here are the ones production computes —
+ * only the tenant-scoped fetch and the merge-eligibility probe are stubbed.
+ *
+ * The lead fixture is the August 2026 incident itself: two documents for one
+ * person sharing `ganesh-vasudevan`, the confirmed talk on the LinkedIn document
+ * and the GitHub document (the one he actually signs in with) holding nothing.
+ */
+const meta = {
+  title: 'Systems/Speakers/Admin/DuplicateSpeakersPanel',
+  component: DuplicateSpeakersPanel,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof DuplicateSpeakersPanel>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+interface Fixture {
+  _id: string
+  name: string
+  slug: string
+  email?: string
+  knownEmails?: string[]
+  providers?: string[]
+  _createdAt: string
+  talkCount: number
+  confirmedTalkCount: number
+  mergeBlockedReason?: MergeBlockReason | null
+}
+
+/** Run the real detector, then stamp the (server-computed) merge eligibility. */
+function build(fixtures: Fixture[]) {
+  const blocks = new Map(
+    fixtures.map((fixture) => [
+      fixture._id,
+      fixture.mergeBlockedReason ?? null,
+    ]),
+  )
+  return findDuplicateSpeakerCandidates<DuplicateCandidateSpeaker>(
+    fixtures.map((fixture) => ({
+      ...fixture,
+      mergeBlockedReason: blocks.get(fixture._id) ?? null,
+    })),
+  )
+}
+
+const INCIDENT: Fixture[] = [
+  {
+    _id: '1e80d498-4878-4341-9352-00142ce180ec',
+    name: 'Ganesh Vasudevan',
+    slug: 'ganesh-vasudevan',
+    email: 'ganesh.vasudev@gmail.com',
+    providers: ['linkedin:2mtSWuh1kA'],
+    _createdAt: '2026-05-05T09:12:00Z',
+    talkCount: 2,
+    confirmedTalkCount: 1,
+  },
+  {
+    _id: '241e8419-208a-48c2-8e1b-7080597752d8',
+    name: 'Ganesh Vasudevan',
+    slug: 'ganesh-vasudevan',
+    email: 'ganesh.vasudevan@ericsson.com',
+    providers: ['github:23187057'],
+    _createdAt: '2026-06-15T14:40:00Z',
+    talkCount: 0,
+    confirmedTalkCount: 0,
+  },
+]
+
+const TEST_ACCOUNTS: Fixture[] = ['1', '2', '3', '4'].map((n) => ({
+  _id: `test-user-${n}`,
+  name: 'Test User',
+  slug: 'test-user',
+  email: `test+${n}@example.com`,
+  providers: n === '1' ? ['github:1'] : [],
+  _createdAt: `2025-0${n}-01T08:00:00Z`,
+  talkCount: 0,
+  confirmedTalkCount: 0,
+}))
+
+const NAMESAKES: Fixture[] = [
+  {
+    _id: 'anna-1',
+    name: 'Anna Hansen',
+    slug: 'anna-hansen',
+    email: 'anna@bergen.example',
+    _createdAt: '2025-11-02T10:00:00Z',
+    talkCount: 1,
+    confirmedTalkCount: 1,
+  },
+  {
+    _id: 'anna-2',
+    name: 'anna hansen',
+    slug: 'anna-hansen-2',
+    email: 'a.hansen@oslo.example',
+    _createdAt: '2026-02-14T10:00:00Z',
+    talkCount: 1,
+    confirmedTalkCount: 0,
+  },
+]
+
+const SHARED_WITH_OTHER_ORG: Fixture[] = [
+  {
+    _id: 'kristoffer-1',
+    name: 'Kristoffer Dalby',
+    slug: 'kristoffer-dalby',
+    email: 'kristoffer@example.com',
+    providers: ['github:77'],
+    _createdAt: '2024-04-01T10:00:00Z',
+    talkCount: 3,
+    confirmedTalkCount: 2,
+    mergeBlockedReason: 'other-organization',
+  },
+  {
+    _id: 'kristoffer-2',
+    name: 'Kristoffer Dalby',
+    slug: 'kristoffer-dalby',
+    email: 'kd@work.example',
+    providers: ['linkedin:88'],
+    _createdAt: '2026-01-20T10:00:00Z',
+    talkCount: 0,
+    confirmedTalkCount: 0,
+    mergeBlockedReason: 'other-organization',
+  },
+]
+
+/**
+ * The production shape of the surface: a certain slug collision (the incident),
+ * a four-way test-data collision that is NOT a person to merge, a pair another
+ * organization also holds, and a same-name guess.
+ */
+export const Default: Story = {
+  args: {
+    groups: build([
+      ...INCIDENT,
+      ...TEST_ACCOUNTS,
+      ...SHARED_WITH_OTHER_ORG,
+      ...NAMESAKES,
+    ]),
+    scannedCount: 348,
+    onMergePair: fn(),
+  },
+}
+
+/** The incident on its own — the row an organizer has to read correctly. */
+export const SlugCollision: Story = {
+  args: {
+    groups: build(INCIDENT),
+    scannedCount: 348,
+    onMergePair: fn(),
+  },
+}
+
+/**
+ * A candidate pair neither organization holds alone. `speaker.admin.merge`
+ * would refuse it, so no button is offered — only the reason.
+ */
+export const CrossTenantAndUnmergeable: Story = {
+  args: {
+    groups: build(SHARED_WITH_OTHER_ORG),
+    scannedCount: 348,
+    onMergePair: fn(),
+  },
+}
+
+/** Only a shared name: a guess, and rendered as one. */
+export const WeakSignalOnly: Story = {
+  args: {
+    groups: build(NAMESAKES),
+    scannedCount: 348,
+    onMergePair: fn(),
+  },
+}
+
+export const Empty: Story = {
+  args: { groups: [], scannedCount: 348, onMergePair: fn() },
+}
+
+export const Loading: Story = {
+  args: { groups: [], scannedCount: 0, isLoading: true, onMergePair: fn() },
+}
+
+export const Failed: Story = {
+  args: {
+    groups: [],
+    scannedCount: 0,
+    errorMessage: 'Could not resolve organization from domain',
+    onMergePair: fn(),
+  },
+}

--- a/src/components/admin/DuplicateSpeakersPanel.tsx
+++ b/src/components/admin/DuplicateSpeakersPanel.tsx
@@ -12,6 +12,10 @@ import { CheckBadgeIcon } from '@heroicons/react/24/solid'
 import { StatusBadge, type BadgeColor } from '@/components/StatusBadge'
 import { formatDateSafe } from '@/lib/time'
 import {
+  NEVER_SIGNED_IN_LABEL,
+  providerDisplayNames,
+} from '@/lib/speaker/providers'
+import {
   SIGNAL_LABEL,
   type DuplicateCandidateGroup,
   type DuplicateCandidateSpeaker,
@@ -84,18 +88,6 @@ const BLOCK_REASON: Record<MergeBlockReason, string> = {
     'Could not verify that this organization holds this speaker alone. Reload and try again.',
 }
 
-const PROVIDER_LABEL: Record<string, string> = {
-  github: 'GitHub',
-  linkedin: 'LinkedIn',
-  'email-link': 'Email link',
-}
-
-/** `github:23187057` → `GitHub`. Unknown providers keep their raw prefix. */
-function providerLabel(provider: string): string {
-  const prefix = provider.split(':')[0] ?? provider
-  return PROVIDER_LABEL[prefix] ?? prefix
-}
-
 function MemberCard({
   member,
   group,
@@ -106,9 +98,9 @@ function MemberCard({
   onMergePair: DuplicateSpeakersPanelProps['onMergePair']
 }) {
   const isSurvivor = member._id === group.suggestedSurvivorId
-  const providers = (member.providers ?? []).filter(
-    (provider): provider is string => Boolean(provider),
-  )
+  // Shared with the merge picker's option labels so the same person reads the
+  // same way in both places (`@/lib/speaker/providers`).
+  const providerNames = providerDisplayNames(member.providers)
   const talkCount = member.talkCount ?? 0
   const confirmedTalkCount = member.confirmedTalkCount ?? 0
 
@@ -168,19 +160,23 @@ function MemberCard({
           <dt className="w-20 shrink-0 text-gray-500 dark:text-gray-400">
             Logins
           </dt>
-          <dd className="flex min-w-0 flex-wrap gap-1">
-            {providers.length === 0 ? (
-              <span className="text-gray-400 italic dark:text-gray-500">
-                no linked account
+          <dd className="flex min-w-0 flex-wrap items-center gap-1">
+            {providerNames.length === 0 ? (
+              // NOT a blank: an empty `providers[]` means this document was
+              // created by an organizer and nobody has ever claimed it. Folding
+              // a never-claimed placeholder into a real account is a different,
+              // safer operation than folding two real accounts together, so it
+              // is called out rather than left to look like missing data.
+              <span className="rounded bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+                {NEVER_SIGNED_IN_LABEL}
               </span>
             ) : (
-              providers.map((provider) => (
+              providerNames.map((name) => (
                 <span
-                  key={provider}
-                  title={provider}
+                  key={name}
                   className="rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-300"
                 >
-                  {providerLabel(provider)}
+                  {name}
                 </span>
               ))
             )}

--- a/src/components/admin/DuplicateSpeakersPanel.tsx
+++ b/src/components/admin/DuplicateSpeakersPanel.tsx
@@ -1,0 +1,424 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  ExclamationTriangleIcon,
+  LockClosedIcon,
+  UsersIcon,
+} from '@heroicons/react/24/outline'
+import { CheckBadgeIcon } from '@heroicons/react/24/solid'
+import { StatusBadge, type BadgeColor } from '@/components/StatusBadge'
+import { formatDateSafe } from '@/lib/time'
+import {
+  SIGNAL_LABEL,
+  type DuplicateCandidateGroup,
+  type DuplicateCandidateSpeaker,
+  type DuplicateConfidence,
+  type MergeBlockReason,
+  type SurvivorReason,
+} from '@/lib/speaker/duplicates'
+
+/**
+ * DUPLICATE-SPEAKER CANDIDATES (#267) — the "find" half of the merge tool.
+ *
+ * Presentational only: the page owns the tRPC query, so this renders in
+ * Storybook from fixtures and the states below are all reachable there.
+ *
+ * THREE THINGS THIS SURFACE IS RESPONSIBLE FOR NOT GETTING WRONG:
+ *
+ *  1. A CERTAIN group and a GUESS must not look the same. A shared slug is a
+ *     defect in the dataset; a shared name may be two real people. The tier is
+ *     rendered as a coloured chip AND spelled out in the group's caption.
+ *  2. The organizer must be able to pick the survivor from what is on screen.
+ *     The incident (#267) turned on confirmed talks — merging by "newest" or
+ *     "oldest" would have detached a confirmed talk from a live conference — so
+ *     talk counts, providers, email and creation date are on every row, and the
+ *     document holding confirmed talks is marked "Keep this one".
+ *  3. It must never offer a merge that will be refused. A speaker another
+ *     organization also holds cannot be deleted by us, so those rows show the
+ *     reason instead of a button.
+ */
+
+interface DuplicateSpeakersPanelProps {
+  groups: DuplicateCandidateGroup<DuplicateCandidateSpeaker>[]
+  /** How many speaker documents in this organization were examined. */
+  scannedCount: number
+  isLoading?: boolean
+  errorMessage?: string | null
+  /** Hands the pair to the existing `SpeakerMergeModal`, pre-selected. */
+  onMergePair: (pair: { survivorId: string; loserId: string }) => void
+}
+
+const CONFIDENCE_BADGE: Record<
+  DuplicateConfidence,
+  { label: string; color: BadgeColor }
+> = {
+  certain: { label: 'Certain', color: 'red' },
+  likely: { label: 'Likely', color: 'yellow' },
+  possible: { label: 'Possible', color: 'gray' },
+}
+
+const CONFIDENCE_CAPTION: Record<DuplicateConfidence, string> = {
+  certain:
+    'These documents share one public profile URL. Whoever they belong to, that is a defect — only one of them is reachable at that address.',
+  likely:
+    'These documents share a login identity key. Very likely the same person, but confirm before merging.',
+  possible:
+    'These documents only share a name. Two different people can share a name — check the talks and emails first.',
+}
+
+const SURVIVOR_CAPTION: Record<SurvivorReason, string> = {
+  'confirmed-talks': 'holds the confirmed talk(s)',
+  talks: 'holds the most talks',
+  oldest: 'oldest account — no talks to separate them',
+}
+
+const BLOCK_REASON: Record<MergeBlockReason, string> = {
+  'other-organization':
+    'Another organization also has this speaker — only an organization that holds them alone may remove them.',
+  'foreign-references':
+    'Another organization’s documents still reference this speaker, so it cannot be deleted from here.',
+  unknown:
+    'Could not verify that this organization holds this speaker alone. Reload and try again.',
+}
+
+const PROVIDER_LABEL: Record<string, string> = {
+  github: 'GitHub',
+  linkedin: 'LinkedIn',
+  'email-link': 'Email link',
+}
+
+/** `github:23187057` → `GitHub`. Unknown providers keep their raw prefix. */
+function providerLabel(provider: string): string {
+  const prefix = provider.split(':')[0] ?? provider
+  return PROVIDER_LABEL[prefix] ?? prefix
+}
+
+function MemberCard({
+  member,
+  group,
+  onMergePair,
+}: {
+  member: DuplicateCandidateSpeaker
+  group: DuplicateCandidateGroup<DuplicateCandidateSpeaker>
+  onMergePair: DuplicateSpeakersPanelProps['onMergePair']
+}) {
+  const isSurvivor = member._id === group.suggestedSurvivorId
+  const providers = (member.providers ?? []).filter(
+    (provider): provider is string => Boolean(provider),
+  )
+  const talkCount = member.talkCount ?? 0
+  const confirmedTalkCount = member.confirmedTalkCount ?? 0
+
+  return (
+    <div
+      className={`rounded-lg border p-4 ${
+        isSurvivor
+          ? 'border-green-300 bg-green-50/60 dark:border-green-800 dark:bg-green-900/10'
+          : 'border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900'
+      }`}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="font-space-grotesk truncate font-semibold text-gray-900 dark:text-white">
+            {member.name || 'Unnamed speaker'}
+          </p>
+          <p className="mt-0.5 font-mono text-xs break-all text-gray-400 dark:text-gray-500">
+            {member._id}
+          </p>
+        </div>
+        {isSurvivor && (
+          <StatusBadge
+            label="Keep this one"
+            color="green"
+            icon={CheckBadgeIcon}
+          />
+        )}
+      </div>
+
+      <dl className="mt-3 space-y-1.5 text-sm">
+        <div className="flex gap-2">
+          <dt className="w-20 shrink-0 text-gray-500 dark:text-gray-400">
+            Talks
+          </dt>
+          <dd className="min-w-0 text-gray-900 dark:text-gray-100">
+            {talkCount === 0 ? (
+              <span className="text-gray-400 italic dark:text-gray-500">
+                none in this organization
+              </span>
+            ) : (
+              <>
+                {talkCount} talk{talkCount === 1 ? '' : 's'}
+                {confirmedTalkCount > 0 ? (
+                  <span className="ml-1 font-semibold text-green-700 dark:text-green-400">
+                    · {confirmedTalkCount} confirmed
+                  </span>
+                ) : (
+                  <span className="ml-1 text-gray-400 dark:text-gray-500">
+                    · none confirmed
+                  </span>
+                )}
+              </>
+            )}
+          </dd>
+        </div>
+        <div className="flex gap-2">
+          <dt className="w-20 shrink-0 text-gray-500 dark:text-gray-400">
+            Logins
+          </dt>
+          <dd className="flex min-w-0 flex-wrap gap-1">
+            {providers.length === 0 ? (
+              <span className="text-gray-400 italic dark:text-gray-500">
+                no linked account
+              </span>
+            ) : (
+              providers.map((provider) => (
+                <span
+                  key={provider}
+                  title={provider}
+                  className="rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+                >
+                  {providerLabel(provider)}
+                </span>
+              ))
+            )}
+          </dd>
+        </div>
+        <div className="flex gap-2">
+          <dt className="w-20 shrink-0 text-gray-500 dark:text-gray-400">
+            Email
+          </dt>
+          <dd className="min-w-0 break-all text-gray-900 dark:text-gray-100">
+            {member.email || (
+              <span className="text-gray-400 italic dark:text-gray-500">
+                none
+              </span>
+            )}
+          </dd>
+        </div>
+        <div className="flex gap-2">
+          <dt className="w-20 shrink-0 text-gray-500 dark:text-gray-400">
+            Created
+          </dt>
+          <dd className="min-w-0 text-gray-900 dark:text-gray-100">
+            {member._createdAt ? formatDateSafe(member._createdAt) : 'unknown'}
+          </dd>
+        </div>
+      </dl>
+
+      <div className="mt-3">
+        {isSurvivor ? (
+          <p className="text-xs text-green-800 dark:text-green-400">
+            Suggested survivor — {SURVIVOR_CAPTION[group.survivorReason]}.
+          </p>
+        ) : member.mergeBlockedReason ? (
+          <p className="flex items-start gap-1.5 text-xs text-amber-700 dark:text-amber-400">
+            <LockClosedIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>{BLOCK_REASON[member.mergeBlockedReason]}</span>
+          </p>
+        ) : (
+          <button
+            type="button"
+            onClick={() =>
+              onMergePair({
+                survivorId: group.suggestedSurvivorId,
+                loserId: member._id,
+              })
+            }
+            className="inline-flex items-center rounded-md bg-brand-cloud-blue px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-brand-cloud-blue/90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-cloud-blue"
+          >
+            {/* Not "Merge into <name>": duplicates usually share a name, so
+                naming the survivor reads as a no-op. The direction is what
+                matters, and the modal shows both documents before anything
+                happens. */}
+            Merge into the kept document…
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function GroupCard({
+  group,
+  onMergePair,
+}: {
+  group: DuplicateCandidateGroup<DuplicateCandidateSpeaker>
+  onMergePair: DuplicateSpeakersPanelProps['onMergePair']
+}) {
+  const badge = CONFIDENCE_BADGE[group.confidence]
+  const mergeableCount = group.members.filter(
+    (member) =>
+      member._id !== group.suggestedSurvivorId && !member.mergeBlockedReason,
+  ).length
+
+  return (
+    <li className="rounded-xl border border-gray-200 p-4 dark:border-gray-700">
+      <div className="flex flex-wrap items-center gap-2">
+        <StatusBadge label={badge.label} color={badge.color} />
+        <span className="text-sm font-medium text-gray-900 dark:text-white">
+          {SIGNAL_LABEL[group.signal]}
+        </span>
+        <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs break-all text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+          {group.value}
+        </code>
+        <span className="text-sm text-gray-500 dark:text-gray-400">
+          · {group.members.length} documents
+        </span>
+        {group.corroboratingSignals.length > 0 && (
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            (also{' '}
+            {group.corroboratingSignals
+              .map((signal) => SIGNAL_LABEL[signal].toLowerCase())
+              .join(', ')}
+            )
+          </span>
+        )}
+      </div>
+
+      <p className="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+        {CONFIDENCE_CAPTION[group.confidence]}
+      </p>
+
+      {mergeableCount === 0 && group.members.length > 1 && (
+        <p className="mt-2 flex items-start gap-1.5 rounded-md bg-amber-50 p-2 text-xs text-amber-800 dark:bg-amber-900/20 dark:text-amber-300">
+          <ExclamationTriangleIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>
+            None of these documents can be merged away from here — see the
+            reasons below.
+          </span>
+        </p>
+      )}
+
+      <div className="mt-3 grid gap-3 sm:grid-cols-2">
+        {group.members.map((member) => (
+          <MemberCard
+            key={member._id}
+            member={member}
+            group={group}
+            onMergePair={onMergePair}
+          />
+        ))}
+      </div>
+    </li>
+  )
+}
+
+export function DuplicateSpeakersPanel({
+  groups,
+  scannedCount,
+  isLoading = false,
+  errorMessage = null,
+  onMergePair,
+}: DuplicateSpeakersPanelProps) {
+  const certainCount = groups.filter(
+    (group) => group.confidence === 'certain',
+  ).length
+  const flaggedCount = new Set(
+    groups.flatMap((group) => group.members.map((member) => member._id)),
+  ).size
+
+  // Open itself when there is something certain to act on — or when the scan
+  // failed, which is not something to bury behind a chevron. The organizer's own
+  // toggle always wins after that. Derived, so no effect has to chase the query.
+  const [override, setOverride] = useState<boolean | null>(null)
+  const isOpen = override ?? (certainCount > 0 || Boolean(errorMessage))
+
+  const summary = isLoading
+    ? 'Scanning speakers…'
+    : errorMessage
+      ? 'Scan failed'
+      : groups.length === 0
+        ? `No duplicate candidates among ${scannedCount} speakers`
+        : `${groups.length} candidate group${groups.length === 1 ? '' : 's'} covering ${flaggedCount} of ${scannedCount} speakers` +
+          (certainCount > 0 ? ` · ${certainCount} certain` : '')
+
+  return (
+    <section className="overflow-hidden rounded-lg bg-white shadow-sm ring-1 ring-gray-900/5 dark:bg-gray-900 dark:ring-gray-700">
+      <div className="flex items-center transition-colors has-[button[aria-expanded]:hover]:bg-gray-50 dark:has-[button[aria-expanded]:hover]:bg-gray-800">
+        <h2 className="flex min-w-0 flex-1">
+          <button
+            type="button"
+            onClick={() => setOverride(!isOpen)}
+            aria-expanded={isOpen}
+            aria-controls="duplicate-speakers-body"
+            className="flex min-w-0 flex-1 items-center justify-between gap-3 px-6 py-4 text-left"
+          >
+            <span className="flex min-w-0 items-center gap-2">
+              <UsersIcon className="h-5 w-5 shrink-0 text-gray-400 dark:text-gray-500" />
+              {/* No `truncate` here: at 393px the summary is the only place the
+                  candidate/scanned counts appear, and clipping it to "1
+                  candidate group c…" hides the number the organizer came for. */}
+              <span className="min-w-0">
+                <span className="block text-lg font-medium text-gray-900 dark:text-white">
+                  Possible duplicate speakers
+                </span>
+                <span className="block text-sm text-gray-500 dark:text-gray-400">
+                  {summary}
+                </span>
+              </span>
+            </span>
+            <span className="flex shrink-0 items-center gap-2">
+              {certainCount > 0 && (
+                <StatusBadge label={`${certainCount} certain`} color="red" />
+              )}
+              {isOpen ? (
+                <ChevronDownIcon className="h-5 w-5 text-gray-400" />
+              ) : (
+                <ChevronRightIcon className="h-5 w-5 text-gray-400" />
+              )}
+            </span>
+          </button>
+        </h2>
+      </div>
+
+      <div
+        id="duplicate-speakers-body"
+        hidden={!isOpen}
+        className="border-t border-gray-200 dark:border-gray-700"
+      >
+        {isOpen && (
+          <div className="p-6">
+            {isLoading ? (
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Scanning this organization&apos;s speakers for duplicate
+                documents…
+              </p>
+            ) : errorMessage ? (
+              <p className="text-sm text-red-600 dark:text-red-400">
+                {errorMessage}
+              </p>
+            ) : groups.length === 0 ? (
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                No speaker documents in this organization share a profile URL,
+                login account, email address or name.
+              </p>
+            ) : (
+              <>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Candidates are found by comparing profile URLs, login
+                  accounts, emails and names within this organization. They are
+                  a starting point, not a verdict — some may be test or
+                  placeholder accounts, and two people really can share a name.
+                  Check the talks before merging; merging deletes the duplicate
+                  document permanently.
+                </p>
+                <ul className="mt-4 space-y-4">
+                  {groups.map((group) => (
+                    <GroupCard
+                      key={group.id}
+                      group={group}
+                      onMergePair={onMergePair}
+                    />
+                  ))}
+                </ul>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/components/admin/SpeakerMergeModal.seed.test.tsx
+++ b/src/components/admin/SpeakerMergeModal.seed.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * SEEDING THE MERGE MODAL FROM THE DUPLICATE PANEL (#267).
+ *
+ * The panel's "Merge into the kept document" button hands a pair to this modal.
+ * Seeding it only at MOUNT was wrong in a way that broke the exact flow the
+ * feature exists to add: closing the modal clears its selection
+ * (`resetAndClose`), so opening a suggested pair, closing it without merging,
+ * and clicking the SAME pair again produced an empty modal — a click that
+ * visibly does nothing. A remount `key` derived from the pair does not fix it,
+ * because an identical key is not a remount.
+ *
+ * These drive the real component through a harness that behaves like the page:
+ * one `isOpen` flag, one seed, and buttons that mimic the panel and the
+ * "Merge Duplicates" header action.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { render, cleanup, screen, fireEvent } from '@testing-library/react'
+import { useState } from 'react'
+
+vi.mock('@/lib/trpc/client', () => ({
+  api: {
+    speaker: {
+      admin: {
+        mergePreview: {
+          useQuery: () => ({
+            data: undefined,
+            isLoading: false,
+            isError: false,
+            error: null,
+          }),
+        },
+        merge: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      },
+    },
+  },
+}))
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}))
+vi.mock('./NotificationProvider', () => ({
+  useNotification: () => ({ showNotification: vi.fn() }),
+}))
+
+import { SpeakerMergeModal, type MergeCandidate } from './SpeakerMergeModal'
+
+const SPEAKERS: MergeCandidate[] = [
+  {
+    _id: 'spk-keep',
+    name: 'Ganesh Vasudevan',
+    email: 'ganesh.vasudev@gmail.com',
+    providers: ['linkedin:2mtSWuh1kA'],
+  },
+  {
+    _id: 'spk-dupe',
+    name: 'Ganesh Vasudevan',
+    email: 'ganesh.vasudevan@ericsson.com',
+    providers: ['github:23187057'],
+  },
+  {
+    _id: 'spk-other',
+    name: 'Marcus Noble',
+    email: 'marcus@example.com',
+    providers: ['github:5'],
+  },
+  {
+    _id: 'spk-other-dupe',
+    name: 'Marcus Noble',
+    email: 'm.noble@example.com',
+    providers: [],
+  },
+]
+
+const PAIR_A = { survivorId: 'spk-keep', loserId: 'spk-dupe' }
+const PAIR_B = { survivorId: 'spk-other', loserId: 'spk-other-dupe' }
+
+/** Mimics `SpeakersPageClient`: one open flag, one seed, panel-style buttons. */
+function Harness() {
+  const [isOpen, setIsOpen] = useState(false)
+  const [seed, setSeed] = useState<{
+    survivorId: string
+    loserId: string
+  } | null>(null)
+
+  return (
+    <>
+      <button
+        onClick={() => {
+          setSeed(PAIR_A)
+          setIsOpen(true)
+        }}
+      >
+        panel pair A
+      </button>
+      <button
+        onClick={() => {
+          setSeed(PAIR_B)
+          setIsOpen(true)
+        }}
+      >
+        panel pair B
+      </button>
+      <button
+        onClick={() => {
+          setSeed(null)
+          setIsOpen(true)
+        }}
+      >
+        manual merge
+      </button>
+      <SpeakerMergeModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        speakers={SPEAKERS}
+        initialSurvivorId={seed?.survivorId}
+        initialLoserId={seed?.loserId}
+      />
+    </>
+  )
+}
+
+function selects() {
+  return {
+    survivor: screen.getByRole('combobox', {
+      name: /survivor/i,
+    }) as HTMLSelectElement,
+    duplicate: screen.getByRole('combobox', {
+      name: /duplicate/i,
+    }) as HTMLSelectElement,
+  }
+}
+
+function closeModal() {
+  fireEvent.click(screen.getByRole('button', { name: /close dialog/i }))
+}
+
+afterEach(cleanup)
+
+describe('SpeakerMergeModal — seeding from the duplicate panel', () => {
+  it('populates both sides when a pair is handed over', () => {
+    render(<Harness />)
+    fireEvent.click(screen.getByText('panel pair A'))
+
+    const { survivor, duplicate } = selects()
+    expect(survivor.value).toBe('spk-keep')
+    expect(duplicate.value).toBe('spk-dupe')
+  })
+
+  it('re-seeds the SAME pair after closing without merging', () => {
+    // The regression: close clears the selection, so a second click on the same
+    // suggestion used to open an empty modal.
+    render(<Harness />)
+    fireEvent.click(screen.getByText('panel pair A'))
+    closeModal()
+    fireEvent.click(screen.getByText('panel pair A'))
+
+    const { survivor, duplicate } = selects()
+    expect(survivor.value).toBe('spk-keep')
+    expect(duplicate.value).toBe('spk-dupe')
+  })
+
+  it('seeds a DIFFERENT pair after a close, with no stale selection', () => {
+    render(<Harness />)
+    fireEvent.click(screen.getByText('panel pair A'))
+    closeModal()
+    fireEvent.click(screen.getByText('panel pair B'))
+
+    const { survivor, duplicate } = selects()
+    expect(survivor.value).toBe('spk-other')
+    expect(duplicate.value).toBe('spk-other-dupe')
+  })
+
+  it('clears a previous seed when opened manually', () => {
+    // "Merge Duplicates" in the page header is an UNSEEDED open; it must not
+    // inherit whatever the panel selected last.
+    render(<Harness />)
+    fireEvent.click(screen.getByText('panel pair A'))
+    closeModal()
+    fireEvent.click(screen.getByText('manual merge'))
+
+    const { survivor, duplicate } = selects()
+    expect(survivor.value).toBe('')
+    expect(duplicate.value).toBe('')
+  })
+})
+
+describe('SpeakerMergeModal — option labels', () => {
+  it('shows the provider so two same-name duplicates are distinguishable', () => {
+    render(<Harness />)
+    fireEvent.click(screen.getByText('manual merge'))
+
+    const { survivor } = selects()
+    const labels = Array.from(survivor.options).map((option) => option.text)
+
+    expect(labels).toContain(
+      'Ganesh Vasudevan · LinkedIn · ganesh.vasudev@gmail.com',
+    )
+    expect(labels).toContain(
+      'Ganesh Vasudevan · GitHub · ganesh.vasudevan@ericsson.com',
+    )
+    // The opaque account id is never shown.
+    expect(labels.join('|')).not.toContain('23187057')
+  })
+
+  it('labels a speaker with no provider as never signed in', () => {
+    // An organizer-created placeholder nobody has claimed — a different and
+    // safer thing to fold away than a real account.
+    render(<Harness />)
+    fireEvent.click(screen.getByText('manual merge'))
+
+    const { survivor } = selects()
+    const labels = Array.from(survivor.options).map((option) => option.text)
+    expect(labels).toContain(
+      'Marcus Noble · never signed in · m.noble@example.com',
+    )
+  })
+})

--- a/src/components/admin/SpeakerMergeModal.stories.tsx
+++ b/src/components/admin/SpeakerMergeModal.stories.tsx
@@ -102,6 +102,17 @@ export const Mobile: Story = {
 }
 
 /**
+ * HANDED OVER FROM THE DUPLICATE-CANDIDATES PANEL (#267). Both sides arrive
+ * pre-selected and the preview is already open — the organizer made the "same
+ * person" call on the panel, so the first thing they should see here is what the
+ * merge would actually repoint. The dropdowns stay editable: the panel's
+ * survivor is a suggestion, not a decision.
+ */
+export const PreSelectedFromDuplicatePanel: Story = {
+  args: { initialSurvivorId: 'spk-ada', initialLoserId: 'spk-ada-dup' },
+}
+
+/**
  * Survivor + duplicate chosen and previewed: the change summary and the red
  * "Merge and delete duplicate" action are shown. The modal portals to the body,
  * so the play function queries the whole document.

--- a/src/components/admin/SpeakerMergeModal.stories.tsx
+++ b/src/components/admin/SpeakerMergeModal.stories.tsx
@@ -11,11 +11,35 @@ import { NotificationProvider } from './NotificationProvider'
 // from the global Storybook decorators / the wrapper below; the dry-run
 // `speaker.admin.mergePreview` query is served by the msw handler.
 
+// The two Adas are the shape that matters: one person, one name, two plausible
+// addresses. The PROVIDER is what tells the options apart, so it is rendered
+// between the name and the email. `spk-noemail` has never signed in — an
+// organizer-created placeholder, labelled rather than left blank.
 const speakers: MergeCandidate[] = [
-  { _id: 'spk-ada', name: 'Ada Lovelace', email: 'ada@example.com' },
-  { _id: 'spk-ada-dup', name: 'Ada Lovelace', email: 'ada.l@work.io' },
-  { _id: 'spk-grace', name: 'Grace Hopper', email: 'grace@example.com' },
-  { _id: 'spk-noemail', name: 'Katherine Johnson', email: null },
+  {
+    _id: 'spk-ada',
+    name: 'Ada Lovelace',
+    email: 'ada@example.com',
+    providers: ['linkedin:2mtSWuh1kA'],
+  },
+  {
+    _id: 'spk-ada-dup',
+    name: 'Ada Lovelace',
+    email: 'ada.l@work.io',
+    providers: ['github:23187057'],
+  },
+  {
+    _id: 'spk-grace',
+    name: 'Grace Hopper',
+    email: 'grace@example.com',
+    providers: ['github:1', 'linkedin:9'],
+  },
+  {
+    _id: 'spk-noemail',
+    name: 'Katherine Johnson',
+    email: null,
+    providers: [],
+  },
 ]
 
 // Shape mirrors `MergePreview` from '@/lib/speaker/merge' — the exact fields the

--- a/src/components/admin/SpeakerMergeModal.tsx
+++ b/src/components/admin/SpeakerMergeModal.tsx
@@ -7,6 +7,7 @@ import { ModalShell } from '@/components/ModalShell'
 import { ConfirmationModal } from '@/components/admin/ConfirmationModal'
 import { useNotification } from '@/components/admin/NotificationProvider'
 import { api } from '@/lib/trpc/client'
+import { providerSummary } from '@/lib/speaker/providers'
 import { useQueryClient } from '@tanstack/react-query'
 
 /** Minimal speaker shape needed to pick merge candidates. */
@@ -14,6 +15,14 @@ export interface MergeCandidate {
   _id: string
   name: string
   email?: string | null
+  /**
+   * `providers[]` entries (`<provider>:<accountId>`). REQUIRED IN PRACTICE for
+   * this picker to be usable: duplicates share a name and often have two
+   * similar personal addresses, so the provider is the only field that visibly
+   * tells the two rows apart. An empty array is meaningful — see
+   * {@link NEVER_SIGNED_IN_LABEL}.
+   */
+  providers?: (string | null | undefined)[] | null
 }
 
 interface SpeakerMergeModalProps {
@@ -27,17 +36,28 @@ interface SpeakerMergeModalProps {
    * of hunting for both names in a 348-entry dropdown. The dropdowns stay
    * editable — the panel's survivor is a suggestion, not a decision.
    *
-   * REMOUNT TO RESEED. These are read once, as initial state. The page passes a
-   * `key` derived from the pair so choosing a different pair mounts a fresh
-   * modal; that keeps the seeding effect-free and means a half-finished
-   * selection can never leak into the next pair.
+   * RE-APPLIED ON EVERY OPEN, not just on mount. Closing the modal clears its
+   * internal selection (`resetAndClose`), so seeding only at mount meant that
+   * opening a suggested pair, closing it, and clicking the SAME pair again
+   * produced an empty modal — a click that visibly does nothing, in the exact
+   * flow this exists to add. Keying the modal on the pair did not help: an
+   * identical key is not a remount. See the `isOpen` transition sync below.
    */
   initialSurvivorId?: string
   initialLoserId?: string
 }
 
+/**
+ * `Ganesh Vasudevan · GitHub · ganesh.vasudevan@ericsson.com`.
+ *
+ * The provider sits BEFORE the email deliberately: in a list of duplicates the
+ * name repeats and the addresses rhyme, so the provider is the first thing that
+ * differs between two otherwise identical-looking options.
+ */
 function optionLabel(speaker: MergeCandidate): string {
-  return speaker.email ? `${speaker.name} — ${speaker.email}` : speaker.name
+  return [speaker.name, providerSummary(speaker.providers), speaker.email]
+    .filter(Boolean)
+    .join(' · ')
 }
 
 function EmailList({ emails }: { emails: string[] }) {
@@ -67,6 +87,24 @@ export function SpeakerMergeModal({
     Boolean(initialSurvivorId && initialLoserId),
   )
   const [isConfirmOpen, setIsConfirmOpen] = useState(false)
+
+  // SEED ON EVERY OPEN. React's "adjust state when a prop changes" pattern
+  // (set state during render, no effect, no extra commit): on the closed→open
+  // transition the selection is re-derived from the incoming pair. That covers
+  // reopening the SAME pair after a close — which a remount key cannot, since
+  // an identical key is not a remount — and reopening with a DIFFERENT pair, and
+  // reopening with NO pair from the "Merge Duplicates" button, which must clear
+  // whatever the panel seeded last time.
+  const [wasOpen, setWasOpen] = useState(isOpen)
+  if (isOpen !== wasOpen) {
+    setWasOpen(isOpen)
+    if (isOpen) {
+      setSurvivorId(initialSurvivorId)
+      setLoserId(initialLoserId)
+      setPreviewRequested(Boolean(initialSurvivorId && initialLoserId))
+      setIsConfirmOpen(false)
+    }
+  }
 
   const bothSelected = Boolean(survivorId && loserId)
   const sameSelected = bothSelected && survivorId === loserId

--- a/src/components/admin/SpeakerMergeModal.tsx
+++ b/src/components/admin/SpeakerMergeModal.tsx
@@ -21,6 +21,19 @@ interface SpeakerMergeModalProps {
   onClose: () => void
   speakers: MergeCandidate[]
   onMerged?: () => void
+  /**
+   * Pre-selection from the duplicate-candidates panel (#267), so an organizer
+   * goes from "these two are the same person" straight to the preview instead
+   * of hunting for both names in a 348-entry dropdown. The dropdowns stay
+   * editable — the panel's survivor is a suggestion, not a decision.
+   *
+   * REMOUNT TO RESEED. These are read once, as initial state. The page passes a
+   * `key` derived from the pair so choosing a different pair mounts a fresh
+   * modal; that keeps the seeding effect-free and means a half-finished
+   * selection can never leak into the next pair.
+   */
+  initialSurvivorId?: string
+  initialLoserId?: string
 }
 
 function optionLabel(speaker: MergeCandidate): string {
@@ -39,13 +52,20 @@ export function SpeakerMergeModal({
   onClose,
   speakers,
   onMerged,
+  initialSurvivorId = '',
+  initialLoserId = '',
 }: SpeakerMergeModalProps) {
   const queryClient = useQueryClient()
   const { showNotification } = useNotification()
 
-  const [survivorId, setSurvivorId] = useState('')
-  const [loserId, setLoserId] = useState('')
-  const [previewRequested, setPreviewRequested] = useState(false)
+  const [survivorId, setSurvivorId] = useState(initialSurvivorId)
+  const [loserId, setLoserId] = useState(initialLoserId)
+  // A seeded pair goes straight to the preview: the organizer already made the
+  // "these are the same person" call on the panel, and the preview is the only
+  // screen that shows what the merge would actually repoint.
+  const [previewRequested, setPreviewRequested] = useState(
+    Boolean(initialSurvivorId && initialLoserId),
+  )
   const [isConfirmOpen, setIsConfirmOpen] = useState(false)
 
   const bothSelected = Boolean(survivorId && loserId)

--- a/src/components/admin/SpeakersPageClient.tsx
+++ b/src/components/admin/SpeakersPageClient.tsx
@@ -1,11 +1,16 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { SpeakerTable } from '@/components/admin/SpeakerTable'
 import { SpeakerManagementModal } from '@/components/admin/SpeakerManagementModal'
 import { SpeakerActions } from '@/components/admin/SpeakerActions'
-import { SpeakerMergeModal } from '@/components/admin/SpeakerMergeModal'
+import {
+  SpeakerMergeModal,
+  type MergeCandidate,
+} from '@/components/admin/SpeakerMergeModal'
+import { DuplicateSpeakersPanel } from '@/components/admin/DuplicateSpeakersPanel'
+import { api } from '@/lib/trpc/client'
 import SpeakerProfilePreview from '@/components/SpeakerProfilePreview'
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader'
 import {
@@ -54,6 +59,50 @@ export default function SpeakersPageClient({
     (Speaker & { proposals: ProposalExisting[] }) | null
   >(null)
   const [previewTalks, setPreviewTalks] = useState<ProposalExisting[]>([])
+  // The pair the duplicate panel handed over, or null for a manual merge.
+  const [mergeSeed, setMergeSeed] = useState<{
+    survivorId: string
+    loserId: string
+  } | null>(null)
+
+  // Detection (#267). Org-scoped server-side; `retry: false` so a refusal (e.g.
+  // an unresolvable org) surfaces its message instead of hammering the scan.
+  const duplicatesQuery = api.speaker.admin.duplicateCandidates.useQuery(
+    undefined,
+    { retry: false },
+  )
+
+  // The merge dropdowns must contain the FLAGGED documents too. `speakers` only
+  // holds people with an accepted/confirmed talk, and a duplicate is very often
+  // precisely the document with no accepted talk — which is why the person's
+  // dashboard looked empty in the first place. Without this union, the panel
+  // could hand over a pair the modal cannot display.
+  const mergeCandidates = useMemo<MergeCandidate[]>(() => {
+    const byId = new Map<string, MergeCandidate>()
+    for (const speaker of speakers) {
+      byId.set(speaker._id, {
+        _id: speaker._id,
+        name: speaker.name,
+        email: speaker.email,
+      })
+    }
+    for (const group of duplicatesQuery.data?.groups ?? []) {
+      for (const member of group.members) {
+        if (byId.has(member._id)) continue
+        byId.set(member._id, {
+          _id: member._id,
+          name: member.name || 'Unnamed speaker',
+          email: member.email ?? null,
+        })
+      }
+    }
+    return Array.from(byId.values())
+  }, [speakers, duplicatesQuery.data])
+
+  const handleMergePair = (pair: { survivorId: string; loserId: string }) => {
+    setMergeSeed(pair)
+    setIsMergeModalOpen(true)
+  }
 
   const handleCreateClick = () => {
     setIsCreateModalOpen(true)
@@ -195,7 +244,10 @@ export default function SpeakersPageClient({
             },
             {
               label: 'Merge Duplicates',
-              onClick: () => setIsMergeModalOpen(true),
+              onClick: () => {
+                setMergeSeed(null)
+                setIsMergeModalOpen(true)
+              },
               icon: <ArrowsPointingInIcon className="h-4 w-4" />,
               variant: 'secondary',
             },
@@ -206,6 +258,14 @@ export default function SpeakersPageClient({
               disabled: confirmedSpeakersCount === 0,
             },
           ]}
+        />
+
+        <DuplicateSpeakersPanel
+          groups={duplicatesQuery.data?.groups ?? []}
+          scannedCount={duplicatesQuery.data?.scannedCount ?? 0}
+          isLoading={duplicatesQuery.isLoading}
+          errorMessage={duplicatesQuery.error?.message ?? null}
+          onMergePair={handleMergePair}
         />
 
         <div>
@@ -245,15 +305,23 @@ export default function SpeakersPageClient({
           />
         )}
 
+        {/* `key` reseeds the modal per pair — see `initialSurvivorId`. */}
         <SpeakerMergeModal
+          key={
+            mergeSeed
+              ? `${mergeSeed.survivorId}->${mergeSeed.loserId}`
+              : 'manual'
+          }
           isOpen={isMergeModalOpen}
           onClose={() => setIsMergeModalOpen(false)}
-          speakers={speakers.map((s) => ({
-            _id: s._id,
-            name: s.name,
-            email: s.email,
-          }))}
-          onMerged={() => router.refresh()}
+          speakers={mergeCandidates}
+          initialSurvivorId={mergeSeed?.survivorId}
+          initialLoserId={mergeSeed?.loserId}
+          onMerged={() => {
+            setMergeSeed(null)
+            duplicatesQuery.refetch()
+            router.refresh()
+          }}
         />
       </div>
 

--- a/src/components/admin/SpeakersPageClient.tsx
+++ b/src/components/admin/SpeakersPageClient.tsx
@@ -72,31 +72,32 @@ export default function SpeakersPageClient({
     { retry: false },
   )
 
-  // The merge dropdowns must contain the FLAGGED documents too. `speakers` only
-  // holds people with an accepted/confirmed talk, and a duplicate is very often
-  // precisely the document with no accepted talk — which is why the person's
-  // dashboard looked empty in the first place. Without this union, the panel
-  // could hand over a pair the modal cannot display.
+  /**
+   * THE MERGE PICKER MUST NOT BE THE PAGE'S TABLE.
+   *
+   * This page lists speakers with an accepted/confirmed talk
+   * (`getSpeakersWithAcceptedTalks`) — right for the table, catastrophic for the
+   * merge modal, which used to be handed that same array. A duplicate document
+   * almost never has an accepted talk (the talks are on the OTHER document), so
+   * BOTH dropdowns systematically excluded exactly the documents an organizer
+   * needed to select, and the merge was impossible through the UI for the very
+   * case it exists for.
+   *
+   * The candidate source is therefore the org-scoped, talk-status-agnostic
+   * corpus the duplicate scan already reads. Until it arrives we fall back to
+   * the page's list so the button is never dead — the fallback is the OLD,
+   * filtered behaviour and must never become the steady state.
+   */
   const mergeCandidates = useMemo<MergeCandidate[]>(() => {
-    const byId = new Map<string, MergeCandidate>()
-    for (const speaker of speakers) {
-      byId.set(speaker._id, {
-        _id: speaker._id,
-        name: speaker.name,
-        email: speaker.email,
-      })
-    }
-    for (const group of duplicatesQuery.data?.groups ?? []) {
-      for (const member of group.members) {
-        if (byId.has(member._id)) continue
-        byId.set(member._id, {
-          _id: member._id,
-          name: member.name || 'Unnamed speaker',
-          email: member.email ?? null,
-        })
-      }
-    }
-    return Array.from(byId.values())
+    const fromScan = duplicatesQuery.data?.mergeCandidates
+    if (fromScan && fromScan.length > 0) return fromScan
+
+    return speakers.map((speaker) => ({
+      _id: speaker._id,
+      name: speaker.name,
+      email: speaker.email,
+      providers: speaker.providers ?? [],
+    }))
   }, [speakers, duplicatesQuery.data])
 
   const handleMergePair = (pair: { survivorId: string; loserId: string }) => {
@@ -305,13 +306,10 @@ export default function SpeakersPageClient({
           />
         )}
 
-        {/* `key` reseeds the modal per pair — see `initialSurvivorId`. */}
+        {/* No remount `key`: the modal re-seeds on every closed→open
+            transition, so reopening the SAME pair works — a `key` cannot do
+            that, because an identical key is not a remount. */}
         <SpeakerMergeModal
-          key={
-            mergeSeed
-              ? `${mergeSeed.survivorId}->${mergeSeed.loserId}`
-              : 'manual'
-          }
           isOpen={isMergeModalOpen}
           onClose={() => setIsMergeModalOpen(false)}
           speakers={mergeCandidates}

--- a/src/lib/speaker/duplicates.orgscope.test.ts
+++ b/src/lib/speaker/duplicates.orgscope.test.ts
@@ -1,0 +1,235 @@
+/**
+ * @vitest-environment node
+ *
+ * TENANT SCOPING OF DUPLICATE DETECTION (#267 / #616).
+ *
+ * Detection reads every speaker document an organization can see, together with
+ * their emails and login providers — so an unscoped version is a cross-tenant
+ * dump of exactly the personal data the tenancy work exists to contain. And it
+ * would be worse than useless in the product: an organizer cannot merge a
+ * speaker who belongs to another organization (`requireExclusive`), so a
+ * cross-tenant candidate is a row they can only stare at.
+ *
+ * WHY A REAL GROQ ENGINE, not a query-text assertion. Following
+ * `src/server/tenancy.exploits.test.ts`: a mock that branches on
+ * `query.includes('$orgId')` asserts that the diff is still present, not that
+ * the predicate is still CORRECT — an inverted or widened filter keeps the
+ * substring and passes. Here `clientReadUncached.fetch` evaluates the query text
+ * the function actually sent with `groq-js` against a two-tenant document
+ * fixture, so the semantics under test are the engine's.
+ */
+
+const h = vi.hoisted(() => ({ fetch: vi.fn() }))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: h.fetch },
+  clientReadCached: { fetch: h.fetch },
+  clientWrite: { fetch: h.fetch },
+  speakerImageUrl: vi.fn(),
+}))
+vi.mock('next/cache', () => ({ cacheLife: vi.fn(), cacheTag: vi.fn() }))
+vi.mock('@/lib/profile/github', () => ({ verifiedEmails: vi.fn() }))
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationRefForCurrentConference: vi.fn().mockResolvedValue(null),
+}))
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { parse, evaluate } from 'groq-js'
+import { getDuplicateSpeakerCandidateRecords } from './sanity'
+import { findDuplicateSpeakerCandidates } from './duplicates'
+
+const ORG_A = 'org-A'
+const ORG_B = 'org-B'
+
+type Doc = Record<string, unknown> & { _id: string; _type: string }
+
+const ref = (id: string) => ({ _type: 'reference', _ref: id })
+
+/**
+ * Back `clientReadUncached.fetch` with a real GROQ evaluation over `dataset`.
+ * No branching on the query text: there is nothing here that can agree with a
+ * wrong predicate.
+ */
+function useDataset(dataset: Doc[]) {
+  h.fetch.mockImplementation(
+    async (query: string, params: Record<string, unknown> = {}) =>
+      await (await evaluate(parse(query), { dataset, params })).get(),
+  )
+}
+
+/**
+ * Two tenants, each with its OWN pair of slug-colliding speaker documents.
+ * Org A's pair is `shared-slug`; org B's is `b-shared-slug`.
+ *
+ * `spk-a3` is the pre-044 population: no `organizations[]` at all, visible to A
+ * only through PARTICIPATION (a talk at one of A's conferences), and colliding
+ * with nobody. `spk-a1` additionally has a talk at ORG B's conference, so the
+ * org-scoped talk counts have something to exclude.
+ */
+const dataset: Doc[] = [
+  { _id: ORG_A, _type: 'organization', name: 'A' },
+  { _id: ORG_B, _type: 'organization', name: 'B' },
+  { _id: 'conf-A', _type: 'conference', organization: ref(ORG_A) },
+  { _id: 'conf-B', _type: 'conference', organization: ref(ORG_B) },
+
+  {
+    _id: 'spk-a1',
+    _type: 'speaker',
+    name: 'Ganesh Vasudevan',
+    slug: { _type: 'slug', current: 'shared-slug' },
+    email: 'ganesh.vasudev@gmail.com',
+    providers: ['linkedin:2mtSWuh1kA'],
+    _createdAt: '2026-05-05T00:00:00Z',
+    organizations: [ref(ORG_A)],
+  },
+  {
+    _id: 'spk-a2',
+    _type: 'speaker',
+    name: 'Ganesh Vasudevan',
+    slug: { _type: 'slug', current: 'shared-slug' },
+    email: 'ganesh.vasudevan@ericsson.com',
+    providers: ['github:23187057'],
+    _createdAt: '2026-06-15T00:00:00Z',
+    organizations: [ref(ORG_A)],
+  },
+  {
+    _id: 'spk-a3',
+    _type: 'speaker',
+    name: 'Legacy Participant',
+    slug: { _type: 'slug', current: 'legacy-participant' },
+    email: 'legacy@example.com',
+    _createdAt: '2026-01-01T00:00:00Z',
+  },
+
+  {
+    _id: 'spk-b1',
+    _type: 'speaker',
+    name: 'Other Tenant Person',
+    slug: { _type: 'slug', current: 'b-shared-slug' },
+    email: 'other@b.example',
+    _createdAt: '2026-03-01T00:00:00Z',
+    organizations: [ref(ORG_B)],
+  },
+  {
+    _id: 'spk-b2',
+    _type: 'speaker',
+    name: 'Other Tenant Person',
+    slug: { _type: 'slug', current: 'b-shared-slug' },
+    email: 'other.dup@b.example',
+    _createdAt: '2026-04-01T00:00:00Z',
+    organizations: [ref(ORG_B)],
+  },
+
+  {
+    _id: 'talk-a1',
+    _type: 'talk',
+    status: 'confirmed',
+    conference: ref('conf-A'),
+    speakers: [ref('spk-a1')],
+  },
+  {
+    _id: 'talk-a3',
+    _type: 'talk',
+    status: 'submitted',
+    conference: ref('conf-A'),
+    speakers: [ref('spk-a3')],
+  },
+  // Org B's conference also has spk-a1 on a talk — an org-A count must not see it.
+  {
+    _id: 'talk-b1',
+    _type: 'talk',
+    status: 'confirmed',
+    conference: ref('conf-B'),
+    speakers: [ref('spk-a1')],
+  },
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useDataset(dataset)
+})
+
+describe('getDuplicateSpeakerCandidateRecords — tenant scoping', () => {
+  it('returns only speakers belonging to the requested organization', async () => {
+    const { records, err } = await getDuplicateSpeakerCandidateRecords(ORG_A)
+
+    expect(err).toBeNull()
+    expect(records.map((record) => record._id).sort()).toEqual([
+      'spk-a1',
+      'spk-a2',
+      'spk-a3',
+    ])
+  })
+
+  it('does NOT surface another tenant’s duplicate pair', async () => {
+    // spk-b1/spk-b2 are a textbook slug collision — in org B. Detection for
+    // org A must be blind to them, and detection for org B must find them.
+    const { records } = await getDuplicateSpeakerCandidateRecords(ORG_A)
+    const groups = findDuplicateSpeakerCandidates(records)
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].value).toBe('shared-slug')
+    expect(
+      groups.flatMap((group) => group.members.map((member) => member._id)),
+    ).not.toContain('spk-b1')
+
+    const forB = await getDuplicateSpeakerCandidateRecords(ORG_B)
+    const bGroups = findDuplicateSpeakerCandidates(forB.records)
+    expect(bGroups).toHaveLength(1)
+    expect(bGroups[0].value).toBe('b-shared-slug')
+    expect(bGroups[0].members.map((member) => member._id).sort()).toEqual([
+      'spk-b1',
+      'spk-b2',
+    ])
+  })
+
+  it('includes the pre-backfill population reachable only by participation', async () => {
+    // spk-a3 has no `organizations[]`, only a talk at one of A's conferences —
+    // the same fallback arm `SPEAKER_ORG_FILTER` and
+    // `requireSpeakerInCurrentOrg` use, so detection never shows a speaker the
+    // organizer has no standing over, and never hides one they do.
+    const { records } = await getDuplicateSpeakerCandidateRecords(ORG_A)
+    expect(records.map((record) => record._id)).toContain('spk-a3')
+  })
+
+  it('counts talks within the requesting organization only', async () => {
+    const { records } = await getDuplicateSpeakerCandidateRecords(ORG_A)
+    const byId = new Map(records.map((record) => [record._id, record]))
+
+    // spk-a1 has a confirmed talk at conf-A AND one at org B's conf-B. Only
+    // A's counts — the number has to answer "what would WE lose by deleting
+    // this document".
+    expect(byId.get('spk-a1')?.talkCount).toBe(1)
+    expect(byId.get('spk-a1')?.confirmedTalkCount).toBe(1)
+    expect(byId.get('spk-a2')?.talkCount).toBe(0)
+    expect(byId.get('spk-a2')?.confirmedTalkCount).toBe(0)
+    // Submitted, not confirmed.
+    expect(byId.get('spk-a3')?.talkCount).toBe(1)
+    expect(byId.get('spk-a3')?.confirmedTalkCount).toBe(0)
+  })
+
+  it('projects the slug so a collision is detectable at all', async () => {
+    const { records } = await getDuplicateSpeakerCandidateRecords(ORG_A)
+    expect(records.find((record) => record._id === 'spk-a1')?.slug).toBe(
+      'shared-slug',
+    )
+  })
+
+  it('FAILS CLOSED with no organization: refuses instead of scanning globally', async () => {
+    for (const orgId of [null, undefined, '']) {
+      const { records, err } = await getDuplicateSpeakerCandidateRecords(orgId)
+      expect(records).toEqual([])
+      expect(err).toBeInstanceOf(Error)
+    }
+    // The decisive part: no query was ever sent. A degraded-to-global scan
+    // would have listed every tenant's speakers.
+    expect(h.fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns an error rather than partial data when the read fails', async () => {
+    h.fetch.mockRejectedValueOnce(new Error('sanity down'))
+    const { records, err } = await getDuplicateSpeakerCandidateRecords(ORG_A)
+    expect(records).toEqual([])
+    expect(err).toBeInstanceOf(Error)
+  })
+})

--- a/src/lib/speaker/duplicates.test.ts
+++ b/src/lib/speaker/duplicates.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import {
-  clusterDuplicateSpeakers,
+  findDuplicateSpeakerCandidates,
   normalizeName,
+  normalizeSlug,
   speakerEmailSet,
+  SIGNAL_CONFIDENCE,
   type DuplicateSpeakerInput,
 } from './duplicates'
 
@@ -19,6 +21,17 @@ describe('normalizeName', () => {
   })
 })
 
+describe('normalizeSlug', () => {
+  it('trims and lowercases', () => {
+    expect(normalizeSlug(' Jane-Doe ')).toBe('jane-doe')
+  })
+
+  it('returns empty string for missing/blank slugs', () => {
+    expect(normalizeSlug(null)).toBe('')
+    expect(normalizeSlug('  ')).toBe('')
+  })
+})
+
 describe('speakerEmailSet', () => {
   it('unions display email with knownEmails, normalized and deduped', () => {
     expect(
@@ -31,87 +44,288 @@ describe('speakerEmailSet', () => {
   })
 })
 
-describe('clusterDuplicateSpeakers', () => {
-  it('returns no clusters when nothing overlaps', () => {
-    const speakers: DuplicateSpeakerInput[] = [
-      { _id: 'a', name: 'Jane Doe', email: 'jane@example.com' },
-      { _id: 'b', name: 'John Roe', email: 'john@example.com' },
-    ]
-    expect(clusterDuplicateSpeakers(speakers)).toEqual([])
+describe('findDuplicateSpeakerCandidates — slug collisions', () => {
+  /**
+   * THE INCIDENT, as a fixture (#267). Two documents for Ganesh Vasudevan, one
+   * slug, different providers, different emails, and the CONFIRMED talk on the
+   * older LinkedIn document — while he signs in with GitHub.
+   */
+  const incident: DuplicateSpeakerInput[] = [
+    {
+      _id: '1e80d498-4878-4341-9352-00142ce180ec',
+      name: 'Ganesh Vasudevan',
+      slug: 'ganesh-vasudevan',
+      email: 'ganesh.vasudev@gmail.com',
+      providers: ['linkedin:2mtSWuh1kA'],
+      _createdAt: '2026-05-05T00:00:00Z',
+      talkCount: 1,
+      confirmedTalkCount: 1,
+    },
+    {
+      _id: '241e8419-208a-48c2-8e1b-7080597752d8',
+      name: 'Ganesh Vasudevan',
+      slug: 'ganesh-vasudevan',
+      email: 'ganesh.vasudevan@ericsson.com',
+      providers: ['github:23187057'],
+      _createdAt: '2026-06-15T00:00:00Z',
+      talkCount: 0,
+      confirmedTalkCount: 0,
+    },
+  ]
+
+  it('reports an exact slug collision as a CERTAIN group', () => {
+    const groups = findDuplicateSpeakerCandidates(incident)
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].signal).toBe('slug')
+    expect(groups[0].confidence).toBe('certain')
+    expect(groups[0].value).toBe('ganesh-vasudevan')
+    expect(groups[0].members.map((member) => member._id).sort()).toEqual(
+      [
+        '1e80d498-4878-4341-9352-00142ce180ec',
+        '241e8419-208a-48c2-8e1b-7080597752d8',
+      ].sort(),
+    )
   })
 
-  it('clusters speakers sharing a normalized email', () => {
-    const speakers: DuplicateSpeakerInput[] = [
+  it('suggests the document holding the CONFIRMED talk as the survivor', () => {
+    // Merging the other way round would repoint a confirmed conference talk and
+    // then delete the document the schedule was built around.
+    const [group] = findDuplicateSpeakerCandidates(incident)
+
+    expect(group.suggestedSurvivorId).toBe(
+      '1e80d498-4878-4341-9352-00142ce180ec',
+    )
+    expect(group.survivorReason).toBe('confirmed-talks')
+    // Suggested survivor leads the member list.
+    expect(group.members[0]._id).toBe('1e80d498-4878-4341-9352-00142ce180ec')
+  })
+
+  it('does NOT prefer the newest or the oldest document over confirmed talks', () => {
+    const newestHasTheTalk = incident.map((member) =>
+      member._id === '241e8419-208a-48c2-8e1b-7080597752d8'
+        ? { ...member, talkCount: 2, confirmedTalkCount: 1 }
+        : { ...member, talkCount: 0, confirmedTalkCount: 0 },
+    )
+    const [group] = findDuplicateSpeakerCandidates(newestHasTheTalk)
+
+    // Same fixture, confirmed talk moved to the NEWER document: the suggestion
+    // follows the talk, not the creation date.
+    expect(group.suggestedSurvivorId).toBe(
+      '241e8419-208a-48c2-8e1b-7080597752d8',
+    )
+  })
+
+  it('falls back to the oldest document when nothing has talks', () => {
+    const noTalks = incident.map((member) => ({
+      ...member,
+      talkCount: 0,
+      confirmedTalkCount: 0,
+    }))
+    const [group] = findDuplicateSpeakerCandidates(noTalks)
+
+    expect(group.suggestedSurvivorId).toBe(
+      '1e80d498-4878-4341-9352-00142ce180ec',
+    )
+    expect(group.survivorReason).toBe('oldest')
+  })
+
+  it('groups a three-way slug collision as one group', () => {
+    const trio: DuplicateSpeakerInput[] = ['a', 'b', 'c'].map((id) => ({
+      _id: id,
+      name: `Valentin David ${id}`,
+      slug: 'valentin-david',
+      email: `${id}@example.com`,
+      _createdAt: `2026-0${id === 'a' ? 1 : id === 'b' ? 2 : 3}-01T00:00:00Z`,
+    }))
+
+    const groups = findDuplicateSpeakerCandidates(trio)
+    expect(groups).toHaveLength(1)
+    expect(groups[0].members).toHaveLength(3)
+  })
+})
+
+describe('findDuplicateSpeakerCandidates — distinct speakers', () => {
+  it('reports NOTHING for two genuinely distinct speakers', () => {
+    const distinct: DuplicateSpeakerInput[] = [
       {
         _id: 'a',
         name: 'Jane Doe',
+        slug: 'jane-doe',
         email: 'jane@example.com',
-        _createdAt: '2020-01-01T00:00:00Z',
+        knownEmails: ['jane@example.com'],
+        providers: ['github:1'],
+        _createdAt: '2026-01-01T00:00:00Z',
+        talkCount: 1,
+        confirmedTalkCount: 1,
       },
       {
         _id: 'b',
-        name: 'Jane D.',
-        knownEmails: ['JANE@example.com'],
-        _createdAt: '2021-01-01T00:00:00Z',
+        name: 'John Roe',
+        slug: 'john-roe',
+        email: 'john@example.com',
+        knownEmails: ['john@example.com'],
+        providers: ['linkedin:2'],
+        _createdAt: '2026-02-01T00:00:00Z',
+        talkCount: 3,
+        confirmedTalkCount: 2,
       },
     ]
-    const clusters = clusterDuplicateSpeakers(speakers)
-    expect(clusters).toHaveLength(1)
-    expect(clusters[0].reasons).toEqual(['email'])
-    expect(clusters[0].sharedEmails).toEqual(['jane@example.com'])
-    // Oldest _createdAt first.
-    expect(clusters[0].members.map((m) => m._id)).toEqual(['a', 'b'])
+
+    expect(findDuplicateSpeakerCandidates(distinct)).toEqual([])
   })
 
-  it('clusters speakers sharing an identical normalized name', () => {
-    const speakers: DuplicateSpeakerInput[] = [
-      { _id: 'a', name: 'Jane Doe', email: 'jane1@example.com' },
-      { _id: 'b', name: 'jane   doe', email: 'jane2@example.com' },
+  it('never groups on empty slugs, emails, providers or names', () => {
+    // Absent values are not a shared value. Grouping them would put every
+    // half-filled document in one enormous "duplicate" pile.
+    const blanks: DuplicateSpeakerInput[] = [
+      { _id: 'a', name: '', slug: '', email: '', knownEmails: [] },
+      { _id: 'b', name: '   ', slug: null, email: null, providers: [null] },
+      { _id: 'c', knownEmails: [null, undefined], providers: [' '] },
     ]
-    const clusters = clusterDuplicateSpeakers(speakers)
-    expect(clusters).toHaveLength(1)
-    expect(clusters[0].reasons).toEqual(['name'])
-    expect(clusters[0].sharedNames).toEqual(['jane doe'])
+
+    expect(findDuplicateSpeakerCandidates(blanks)).toEqual([])
+  })
+})
+
+describe('findDuplicateSpeakerCandidates — ranking', () => {
+  it('ranks slug collisions above login, email and name matches', () => {
+    expect(SIGNAL_CONFIDENCE.slug).toBe('certain')
+    expect(SIGNAL_CONFIDENCE.provider).toBe('likely')
+    expect(SIGNAL_CONFIDENCE.email).toBe('likely')
+    expect(SIGNAL_CONFIDENCE.name).toBe('possible')
+
+    const mixed: DuplicateSpeakerInput[] = [
+      { _id: 'slug1', name: 'One', slug: 'shared-slug' },
+      { _id: 'slug2', name: 'Two', slug: 'shared-slug' },
+      { _id: 'mail1', name: 'Three', slug: 's3', email: 'shared@example.com' },
+      {
+        _id: 'mail2',
+        name: 'Four',
+        slug: 's4',
+        knownEmails: ['SHARED@example.com'],
+      },
+      { _id: 'name1', name: 'Anna Hansen', slug: 's5' },
+      { _id: 'name2', name: 'anna hansen', slug: 's6' },
+    ]
+
+    const groups = findDuplicateSpeakerCandidates(mixed)
+    expect(groups.map((group) => group.confidence)).toEqual([
+      'certain',
+      'likely',
+      'possible',
+    ])
+    expect(groups.map((group) => group.signal)).toEqual([
+      'slug',
+      'email',
+      'name',
+    ])
   })
 
-  it('links transitively across email and name (union-find)', () => {
-    const speakers: DuplicateSpeakerInput[] = [
-      { _id: 'a', name: 'Jane Doe', email: 'shared@example.com' },
-      { _id: 'b', name: 'Jane Doe', email: 'other@example.com' }, // name links a-b
-      { _id: 'c', name: 'Totally Different', email: 'shared@example.com' }, // email links a-c
+  it('reports a same-name pair as POSSIBLE, not certain', () => {
+    // Two real people can share a name. This must never be presented with the
+    // weight of a slug collision.
+    const namesakes: DuplicateSpeakerInput[] = [
+      {
+        _id: 'a',
+        name: 'Anna Hansen',
+        slug: 'anna-hansen',
+        email: 'anna@one.example',
+      },
+      {
+        _id: 'b',
+        name: 'Anna Hansen',
+        slug: 'anna-hansen-2',
+        email: 'anna@two.example',
+      },
     ]
-    const clusters = clusterDuplicateSpeakers(speakers)
-    expect(clusters).toHaveLength(1)
-    expect(clusters[0].members.map((m) => m._id).sort()).toEqual([
+
+    const groups = findDuplicateSpeakerCandidates(namesakes)
+    expect(groups).toHaveLength(1)
+    expect(groups[0].confidence).toBe('possible')
+    expect(groups[0].signal).toBe('name')
+  })
+
+  it('folds a weaker signal over the SAME documents in as corroboration', () => {
+    const both: DuplicateSpeakerInput[] = [
+      {
+        _id: 'a',
+        name: 'Marcus Noble',
+        slug: 'marcus-noble',
+        email: 'm@one.example',
+      },
+      {
+        _id: 'b',
+        name: 'Marcus Noble',
+        slug: 'marcus-noble',
+        email: 'm@two.example',
+      },
+    ]
+
+    const groups = findDuplicateSpeakerCandidates(both)
+    expect(groups).toHaveLength(1)
+    expect(groups[0].signal).toBe('slug')
+    expect(groups[0].corroboratingSignals).toEqual(['name'])
+  })
+
+  it('does NOT launder a wider weak group into a stronger one', () => {
+    // a+b share a slug (certain). c only shares the NAME with them. The third
+    // document must not inherit the slug group's certainty — that is how an
+    // organizer ends up deleting a real second person.
+    const chained: DuplicateSpeakerInput[] = [
+      { _id: 'a', name: 'Same Name', slug: 'same-name' },
+      { _id: 'b', name: 'Same Name', slug: 'same-name' },
+      { _id: 'c', name: 'same name', slug: 'same-name-2' },
+    ]
+
+    const groups = findDuplicateSpeakerCandidates(chained)
+    expect(groups).toHaveLength(2)
+
+    const [certain, possible] = groups
+    expect(certain.confidence).toBe('certain')
+    expect(certain.members.map((member) => member._id).sort()).toEqual([
       'a',
       'b',
-      'c',
     ])
-    expect(clusters[0].reasons.sort()).toEqual(['email', 'name'])
+    expect(possible.confidence).toBe('possible')
+    expect(possible.members).toHaveLength(3)
   })
 
-  it('keeps unrelated duplicate groups in separate clusters, largest first', () => {
-    const speakers: DuplicateSpeakerInput[] = [
-      { _id: 'x1', name: 'Solo Group', email: 'x@example.com' },
-      { _id: 'x2', name: 'Solo Group', email: 'x2@example.com' },
-      { _id: 'y1', name: 'Trio', email: 'y@example.com' },
-      { _id: 'y2', name: 'Trio', email: 'y2@example.com' },
-      { _id: 'y3', name: 'Trio', email: 'y3@example.com' },
-      { _id: 'z1', name: 'Lonely', email: 'z@example.com' },
+  it('reports a shared provider account as its own LIKELY group', () => {
+    const shared: DuplicateSpeakerInput[] = [
+      {
+        _id: 'a',
+        name: 'One Person',
+        slug: 'one-person',
+        providers: ['github:99'],
+      },
+      {
+        _id: 'b',
+        name: 'Different Name',
+        slug: 'different-name',
+        providers: ['github:99'],
+      },
     ]
-    const clusters = clusterDuplicateSpeakers(speakers)
-    expect(clusters).toHaveLength(2)
-    // Largest cluster first.
-    expect(clusters[0].members).toHaveLength(3)
-    expect(clusters[1].members).toHaveLength(2)
+
+    const groups = findDuplicateSpeakerCandidates(shared)
+    expect(groups).toHaveLength(1)
+    expect(groups[0].signal).toBe('provider')
+    expect(groups[0].confidence).toBe('likely')
+    expect(groups[0].value).toBe('github:99')
   })
 
-  it('does not cluster on empty/blank names or emails', () => {
+  it('is deterministic', () => {
     const speakers: DuplicateSpeakerInput[] = [
-      { _id: 'a', name: '', email: '' },
-      { _id: 'b', name: '   ', email: null },
-      { _id: 'c', name: '', knownEmails: [] },
+      { _id: 'b', name: 'Two', slug: 'dup' },
+      { _id: 'a', name: 'One', slug: 'dup' },
+      { _id: 'c', name: 'Three', slug: 'other-dup' },
+      { _id: 'd', name: 'Four', slug: 'other-dup' },
     ]
-    expect(clusterDuplicateSpeakers(speakers)).toEqual([])
+
+    const first = findDuplicateSpeakerCandidates(speakers)
+    const second = findDuplicateSpeakerCandidates([...speakers].reverse())
+    expect(first.map((group) => group.id)).toEqual(
+      second.map((group) => group.id),
+    )
   })
 })

--- a/src/lib/speaker/duplicates.ts
+++ b/src/lib/speaker/duplicates.ts
@@ -124,11 +124,37 @@ export interface DuplicateCandidateSpeaker extends DuplicateSpeakerInput {
   mergeBlockedReason: MergeBlockReason | null
 }
 
+/** One speaker as the MERGE PICKER needs them: who they are, how they log in. */
+export interface MergePickerSpeaker {
+  _id: string
+  name: string
+  email: string | null
+  /** `<provider>:<accountId>` entries. EMPTY means never signed in. */
+  providers: string[]
+}
+
 /** The payload of `speaker.admin.duplicateCandidates`. */
 export interface DuplicateCandidatesReport {
   groups: DuplicateCandidateGroup<DuplicateCandidateSpeaker>[]
   /** How many speaker documents in this organization were examined. */
   scannedCount: number
+  /**
+   * EVERY speaker in this organization — the merge picker's candidate source.
+   *
+   * It ships with the scan rather than from its own endpoint because it is the
+   * SAME corpus: one org-scoped read, and no way for the picker and the detector
+   * to disagree about who exists.
+   *
+   * THE FILTER THIS REPLACES WAS THE BUG. `/admin/speakers` loads its table with
+   * `getSpeakersWithAcceptedTalks` and used to hand that array straight to the
+   * merge modal, so BOTH dropdowns only ever contained speakers with an
+   * accepted or confirmed talk. A duplicate document almost never has one — the
+   * talks are on the OTHER document, which is the entire shape of the bug — so
+   * the duplicate was unselectable and the merge was impossible through the UI.
+   * For the reported incident only the LinkedIn document appeared in the picker.
+   * Tenant scoping still applies; it is the talk-status filter that had to go.
+   */
+  mergeCandidates: MergePickerSpeaker[]
 }
 
 /** A group of two or more speaker documents that look like the same person. */

--- a/src/lib/speaker/duplicates.ts
+++ b/src/lib/speaker/duplicates.ts
@@ -1,18 +1,34 @@
 /**
- * Duplicate-speaker detection (Phase 4, Part B).
+ * DUPLICATE-SPEAKER DETECTION (#267).
  *
- * Pure clustering core shared by the read-only reporting script
- * (`scripts/report-duplicate-speakers.ts`). It groups speaker documents that
- * are LIKELY the same person so an organizer can review and later merge them
- * with the Phase 3 admin tool. It performs NO I/O and makes NO writes.
+ * ============================ READ-ONLY ============================
+ * Pure clustering core. No I/O, no writes. Merging stays a deliberate,
+ * human-reviewed action performed through `speaker.admin.merge`.
+ * ==================================================================
  *
- * Two speakers are considered linked when they share either:
- *  1. a normalized email — the intersection of their `email` + `knownEmails`
- *     match-sets is non-empty, or
- *  2. an identical normalized name.
+ * Merging duplicates has worked for a while (`SpeakerMergeModal` →
+ * `speaker.admin.merge`). FINDING them from the admin UI did not: both merge
+ * dropdowns list every speaker alphabetically, so an organizer could only merge
+ * a duplicate they already knew about — which in practice meant "after the
+ * speaker complains". The August 2026 incident on 2026.cloudnativedays.no was
+ * exactly that: two documents for one person, sharing one slug, with the
+ * confirmed talk attached to the document he does NOT sign in with.
  *
- * Linking is transitive (union-find): A↔B via email and B↔C via name puts
- * A, B and C in one cluster.
+ * This module is the single detector, shared by the admin surface
+ * (`speaker.admin.duplicateCandidates`) and the read-only ops report
+ * (`scripts/report-duplicate-speakers.ts`).
+ *
+ * CONFIDENCE IS PART OF THE OUTPUT, NOT A PRESENTATION DETAIL. A slug collision
+ * is a fact about the dataset; two people sharing a name is a guess. Presenting
+ * them with equal weight invites an organizer to delete a real second person, so
+ * the tiers are modelled here and the UI is required to render them differently.
+ *
+ * WHY NOT TRANSITIVE CLUSTERING. An earlier version union-found every signal
+ * into one component, so A↔B by email plus B↔C by name produced one three-way
+ * cluster with reasons `['email','name']` — laundering the guess about C into
+ * the same group as the near-certainty about B. Groups are now keyed on ONE
+ * signal each, and a weaker signal is only ever reported as corroboration when
+ * it covers exactly the same documents.
  */
 
 import { uniqueEmails } from './email'
@@ -21,25 +37,118 @@ import { uniqueEmails } from './email'
 export interface DuplicateSpeakerInput {
   _id: string
   name?: string | null
+  /** `slug.current` — the public profile URL segment. */
+  slug?: string | null
   email?: string | null
   knownEmails?: (string | null | undefined)[] | null
   providers?: (string | null | undefined)[] | null
   _createdAt?: string | null
+  /**
+   * Talks referencing this document. Scoped by the CALLER — the admin surface
+   * passes org-scoped counts, so they answer "what would this organization lose
+   * by deleting this document". Absent counts as zero.
+   */
+  talkCount?: number
+  /** How many of those are `confirmed` — the decisive survivor signal. */
+  confirmedTalkCount?: number
 }
 
-/** Why the members of a cluster were grouped together. */
-export type DuplicateReason = 'email' | 'name'
+/** What made two speaker documents look like the same person. */
+export type DuplicateSignal = 'slug' | 'provider' | 'email' | 'name'
 
-/** A group of two or more speakers that are likely the same person. */
-export interface DuplicateCluster<T extends DuplicateSpeakerInput> {
-  /** The signals that linked this cluster (email overlap and/or name match). */
-  reasons: DuplicateReason[]
-  /** The overlapping normalized email(s), if email linked the cluster. */
-  sharedEmails: string[]
-  /** The shared normalized name(s), if name linked the cluster. */
-  sharedNames: string[]
-  /** Cluster members, oldest `_createdAt` first (the likely canonical record). */
+/** How much a signal is worth. See {@link SIGNAL_CONFIDENCE}. */
+export type DuplicateConfidence = 'certain' | 'likely' | 'possible'
+
+/**
+ * Signal → confidence.
+ *
+ * - `slug` is CERTAIN. `slug.current` is the public profile URL and has no
+ *   uniqueness constraint. Two documents carrying the same one is a defect
+ *   whoever they belong to: `getPublicSpeaker` resolves it with `[0]`, so one of
+ *   the two is unreachable by an ordering nobody controls (#818). All ten of the
+ *   production cases in #267 are this shape, and it is the only signal that
+ *   needs no judgement to act on.
+ * - `provider` and `email` are LIKELY. They are strong identity keys — but they
+ *   are also the keys the login path already matches on, so a collision means
+ *   something unusual happened upstream and deserves a human look rather than an
+ *   automatic verdict.
+ * - `name` is POSSIBLE. Two people really can be called Anna Hansen.
+ */
+export const SIGNAL_CONFIDENCE: Record<DuplicateSignal, DuplicateConfidence> = {
+  slug: 'certain',
+  provider: 'likely',
+  email: 'likely',
+  name: 'possible',
+}
+
+/** Strongest-first evaluation order; also the display order of the groups. */
+const SIGNAL_ORDER: DuplicateSignal[] = ['slug', 'provider', 'email', 'name']
+
+const CONFIDENCE_RANK: Record<DuplicateConfidence, number> = {
+  certain: 0,
+  likely: 1,
+  possible: 2,
+}
+
+/** Short label for a signal, shared by the admin UI and the ops report. */
+export const SIGNAL_LABEL: Record<DuplicateSignal, string> = {
+  slug: 'Same profile URL',
+  provider: 'Same login account',
+  email: 'Same email address',
+  name: 'Same name',
+}
+
+/** Why the detector suggested a particular document as the survivor. */
+export type SurvivorReason = 'confirmed-talks' | 'talks' | 'oldest'
+
+/**
+ * Why a document may NOT be the DUPLICATE (loser) of a merge.
+ *
+ * `speaker.admin.merge` deletes the loser and therefore demands it be exclusive
+ * to the request's organization (`requireSpeakerInCurrentOrg(…, {
+ * requireExclusive: true })`). A candidate pair that spans tenants is real but
+ * unmergeable, and the surface has to say so rather than offer an action that
+ * will be refused. Computed server-side by `speakerExclusivityBlocks`.
+ */
+export type MergeBlockReason =
+  /** Another organization has membership or a talk. */
+  | 'other-organization'
+  /** Another organization's (or an unattributable) document references them. */
+  | 'foreign-references'
+  /** Exclusivity could not be proven; the guard fails closed, so we do too. */
+  | 'unknown'
+
+/** A detected document plus its merge eligibility, as sent to the admin UI. */
+export interface DuplicateCandidateSpeaker extends DuplicateSpeakerInput {
+  /** `null` when this document may be merged away into another. */
+  mergeBlockedReason: MergeBlockReason | null
+}
+
+/** The payload of `speaker.admin.duplicateCandidates`. */
+export interface DuplicateCandidatesReport {
+  groups: DuplicateCandidateGroup<DuplicateCandidateSpeaker>[]
+  /** How many speaker documents in this organization were examined. */
+  scannedCount: number
+}
+
+/** A group of two or more speaker documents that look like the same person. */
+export interface DuplicateCandidateGroup<
+  T extends DuplicateSpeakerInput = DuplicateSpeakerInput,
+> {
+  /** Stable React key / test handle: `<signal>:<normalized value>`. */
+  id: string
+  /** The signal that established this group. */
+  signal: DuplicateSignal
+  confidence: DuplicateConfidence
+  /** The shared value itself (the slug, the address, the login id, the name). */
+  value: string
+  /** Weaker signals that ALSO hold for exactly these documents. */
+  corroboratingSignals: DuplicateSignal[]
+  /** Suggested survivor first, then oldest-first. */
   members: T[]
+  /** Which document should be KEPT. */
+  suggestedSurvivorId: string
+  survivorReason: SurvivorReason
 }
 
 /**
@@ -51,6 +160,16 @@ export function normalizeName(name?: string | null): string {
 }
 
 /**
+ * Normalize a slug for equality comparison. Slugs are written lowercase by
+ * `generateSpeakerSlug`, but legacy and hand-edited documents are not
+ * guaranteed to be, and a case difference is not a different URL segment for
+ * our purposes.
+ */
+export function normalizeSlug(slug?: string | null): string {
+  return (slug ?? '').trim().toLowerCase()
+}
+
+/**
  * The full normalized email match-set for a speaker: the display `email` unioned
  * with every `knownEmails` entry, deduplicated. This is the key set used for
  * cross-document email overlap.
@@ -59,113 +178,189 @@ export function speakerEmailSet(speaker: DuplicateSpeakerInput): string[] {
   return uniqueEmails([speaker.email, ...(speaker.knownEmails ?? [])])
 }
 
+/** Every value of one signal for one document; empties dropped, deduplicated. */
+function signalValues(
+  signal: DuplicateSignal,
+  speaker: DuplicateSpeakerInput,
+): string[] {
+  const raw: string[] = (() => {
+    switch (signal) {
+      case 'slug':
+        return [normalizeSlug(speaker.slug)]
+      case 'provider':
+        // Already `<provider>:<accountId>` (see `providerAccount`).
+        return (speaker.providers ?? []).map((value) =>
+          (value ?? '').trim().toLowerCase(),
+        )
+      case 'email':
+        return speakerEmailSet(speaker)
+      case 'name':
+        return [normalizeName(speaker.name)]
+    }
+  })()
+  return Array.from(new Set(raw.filter((value) => value.length > 0)))
+}
+
+function pairKey(a: string, b: string): string {
+  return a < b ? `${a}|${b}` : `${b}|${a}`
+}
+
+function allPairs(ids: string[]): string[] {
+  const pairs: string[] = []
+  for (let i = 0; i < ids.length; i += 1) {
+    for (let j = i + 1; j < ids.length; j += 1) {
+      pairs.push(pairKey(ids[i], ids[j]))
+    }
+  }
+  return pairs
+}
+
 /**
- * Cluster speakers that are likely duplicates. Returns only clusters with two
- * or more members. Clusters are ordered largest-first (then by the lowest
- * member id); members within a cluster are ordered oldest-`_createdAt`-first
- * (then by id) so the likely canonical record leads. Deterministic.
+ * Pick the document to KEEP.
+ *
+ * THE ORDER OF THESE TIE-BREAKS IS THE LESSON FROM THE INCIDENT. The correct
+ * survivor there was neither the newest nor the oldest document — it was the one
+ * holding the confirmed talk. Merging the other way would have repointed a
+ * confirmed conference talk onto a document and then deleted the one the
+ * schedule was built around. So: most confirmed talks, then most talks, then
+ * oldest (the account the person has had longest), then `_id` for determinism.
+ *
+ * It is a SUGGESTION. The organizer picks the survivor in the merge modal; this
+ * only decides which way round the pre-selection points.
  */
-export function clusterDuplicateSpeakers<T extends DuplicateSpeakerInput>(
+function pickSurvivor<T extends DuplicateSpeakerInput>(
+  members: T[],
+): { id: string; reason: SurvivorReason } {
+  const sorted = [...members].sort((a, b) => {
+    const aConfirmed = a.confirmedTalkCount ?? 0
+    const bConfirmed = b.confirmedTalkCount ?? 0
+    if (aConfirmed !== bConfirmed) return bConfirmed - aConfirmed
+    const aTalks = a.talkCount ?? 0
+    const bTalks = b.talkCount ?? 0
+    if (aTalks !== bTalks) return bTalks - aTalks
+    const aCreated = a._createdAt ?? '~'
+    const bCreated = b._createdAt ?? '~'
+    if (aCreated !== bCreated) return aCreated < bCreated ? -1 : 1
+    return a._id < b._id ? -1 : 1
+  })
+
+  const best = sorted[0]
+  const reason: SurvivorReason =
+    (best.confirmedTalkCount ?? 0) > 0
+      ? 'confirmed-talks'
+      : (best.talkCount ?? 0) > 0
+        ? 'talks'
+        : 'oldest'
+  return { id: best._id, reason }
+}
+
+function orderMembers<T extends DuplicateSpeakerInput>(
+  members: T[],
+  survivorId: string,
+): T[] {
+  return [...members].sort((a, b) => {
+    if (a._id === survivorId) return -1
+    if (b._id === survivorId) return 1
+    const aCreated = a._createdAt ?? '~'
+    const bCreated = b._createdAt ?? '~'
+    if (aCreated !== bCreated) return aCreated < bCreated ? -1 : 1
+    return a._id < b._id ? -1 : 1
+  })
+}
+
+/**
+ * Group speaker documents that look like the same person, strongest signal
+ * first.
+ *
+ * OVERLAP RULE. One pair of documents can trip several signals. A group is
+ * reported only when it introduces at least one PAIR of documents that no
+ * stronger group already covers. A weaker signal over exactly the same documents
+ * is folded in as `corroboratingSignals`; a weaker signal over a WIDER set stays
+ * its own, weaker group, because the extra documents genuinely are only a guess.
+ *
+ * Deterministic and pure: the caller supplies an already tenant-scoped corpus.
+ * Returns only groups of two or more.
+ */
+export function findDuplicateSpeakerCandidates<T extends DuplicateSpeakerInput>(
   speakers: T[],
-): DuplicateCluster<T>[] {
-  const parent = speakers.map((_, index) => index)
+): DuplicateCandidateGroup<T>[] {
+  const byId = new Map(speakers.map((speaker) => [speaker._id, speaker]))
 
-  const find = (node: number): number => {
-    let root = node
-    while (parent[root] !== root) {
-      parent[root] = parent[parent[root]] // path compression
-      root = parent[root]
-    }
-    return root
+  interface RawGroup {
+    signal: DuplicateSignal
+    value: string
+    ids: string[]
   }
 
-  const union = (a: number, b: number): void => {
-    const rootA = find(a)
-    const rootB = find(b)
-    if (rootA !== rootB) parent[rootA] = rootB
-  }
-
-  // Build inverted indexes: normalized key -> speaker indices carrying it.
-  const emailIndex = new Map<string, number[]>()
-  const nameIndex = new Map<string, number[]>()
-
-  speakers.forEach((speaker, index) => {
-    for (const email of speakerEmailSet(speaker)) {
-      const bucket = emailIndex.get(email)
-      if (bucket) bucket.push(index)
-      else emailIndex.set(email, [index])
-    }
-    const name = normalizeName(speaker.name)
-    if (name) {
-      const bucket = nameIndex.get(name)
-      if (bucket) bucket.push(index)
-      else nameIndex.set(name, [index])
-    }
-  })
-
-  // Union every pair that shares an email or a name key.
-  for (const bucket of emailIndex.values()) {
-    for (let i = 1; i < bucket.length; i += 1) union(bucket[0], bucket[i])
-  }
-  for (const bucket of nameIndex.values()) {
-    for (let i = 1; i < bucket.length; i += 1) union(bucket[0], bucket[i])
-  }
-
-  // Group indices by connected component.
-  const componentsByRoot = new Map<number, number[]>()
-  speakers.forEach((_, index) => {
-    const root = find(index)
-    const bucket = componentsByRoot.get(root)
-    if (bucket) bucket.push(index)
-    else componentsByRoot.set(root, [index])
-  })
-
-  const clusters: DuplicateCluster<T>[] = []
-
-  for (const memberIndexes of componentsByRoot.values()) {
-    if (memberIndexes.length < 2) continue
-
-    const memberSet = new Set(memberIndexes)
-
-    const sharedEmails: string[] = []
-    for (const [email, indexes] of emailIndex) {
-      if (indexes.filter((index) => memberSet.has(index)).length >= 2) {
-        sharedEmails.push(email)
+  const raw: RawGroup[] = []
+  for (const signal of SIGNAL_ORDER) {
+    const buckets = new Map<string, string[]>()
+    for (const speaker of speakers) {
+      for (const value of signalValues(signal, speaker)) {
+        const bucket = buckets.get(value)
+        if (bucket) {
+          if (!bucket.includes(speaker._id)) bucket.push(speaker._id)
+        } else {
+          buckets.set(value, [speaker._id])
+        }
       }
     }
+    for (const [value, ids] of buckets) {
+      if (ids.length < 2) continue
+      raw.push({ signal, value, ids })
+    }
+  }
 
-    const sharedNames: string[] = []
-    for (const [name, indexes] of nameIndex) {
-      if (indexes.filter((index) => memberSet.has(index)).length >= 2) {
-        sharedNames.push(name)
+  raw.sort((a, b) => {
+    const rank =
+      CONFIDENCE_RANK[SIGNAL_CONFIDENCE[a.signal]] -
+      CONFIDENCE_RANK[SIGNAL_CONFIDENCE[b.signal]]
+    if (rank !== 0) return rank
+    const order =
+      SIGNAL_ORDER.indexOf(a.signal) - SIGNAL_ORDER.indexOf(b.signal)
+    if (order !== 0) return order
+    if (a.ids.length !== b.ids.length) return b.ids.length - a.ids.length
+    return a.value.localeCompare(b.value)
+  })
+
+  const coveredPairs = new Set<string>()
+  const groups: DuplicateCandidateGroup<T>[] = []
+
+  for (const candidate of raw) {
+    const pairs = allPairs(candidate.ids)
+
+    if (pairs.every((pair) => coveredPairs.has(pair))) {
+      // Adds no pair a stronger group has not already made. If it covers exactly
+      // the same documents as one of them, record it there as corroboration.
+      const twin = groups.find(
+        (group) =>
+          group.members.length === candidate.ids.length &&
+          group.members.every((member) => candidate.ids.includes(member._id)),
+      )
+      if (twin && !twin.corroboratingSignals.includes(candidate.signal)) {
+        twin.corroboratingSignals.push(candidate.signal)
       }
+      continue
     }
 
-    const reasons: DuplicateReason[] = []
-    if (sharedEmails.length > 0) reasons.push('email')
-    if (sharedNames.length > 0) reasons.push('name')
+    for (const pair of pairs) coveredPairs.add(pair)
 
-    const members = [...memberIndexes]
-      .map((index) => speakers[index])
-      .sort((a, b) => {
-        const createdA = a._createdAt ?? '~'
-        const createdB = b._createdAt ?? '~'
-        if (createdA !== createdB) return createdA < createdB ? -1 : 1
-        return a._id < b._id ? -1 : 1
-      })
+    const members = candidate.ids
+      .map((id) => byId.get(id))
+      .filter((speaker): speaker is T => Boolean(speaker))
+    const { id: survivorId, reason } = pickSurvivor(members)
 
-    clusters.push({
-      reasons,
-      sharedEmails: sharedEmails.sort(),
-      sharedNames: sharedNames.sort(),
-      members,
+    groups.push({
+      id: `${candidate.signal}:${candidate.value}`,
+      signal: candidate.signal,
+      confidence: SIGNAL_CONFIDENCE[candidate.signal],
+      value: candidate.value,
+      corroboratingSignals: [],
+      members: orderMembers(members, survivorId),
+      suggestedSurvivorId: survivorId,
+      survivorReason: reason,
     })
   }
 
-  return clusters.sort((a, b) => {
-    if (a.members.length !== b.members.length) {
-      return b.members.length - a.members.length
-    }
-    return a.members[0]._id < b.members[0]._id ? -1 : 1
-  })
+  return groups
 }

--- a/src/lib/speaker/providers.test.ts
+++ b/src/lib/speaker/providers.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import {
+  NEVER_SIGNED_IN_LABEL,
+  providerDisplayName,
+  providerDisplayNames,
+  providerSummary,
+} from './providers'
+
+describe('providerDisplayName', () => {
+  it('maps known providers to their human name', () => {
+    expect(providerDisplayName('github:23187057')).toBe('GitHub')
+    expect(providerDisplayName('linkedin:2mtSWuh1kA')).toBe('LinkedIn')
+    expect(providerDisplayName('email-link:abc')).toBe('Email link')
+  })
+
+  it('never leaks the opaque account id', () => {
+    // It identifies nothing to a human and is pure noise in a picker.
+    expect(providerDisplayName('github:23187057')).not.toContain('23187057')
+    expect(providerDisplayName('unknown-idp:xyz')).toBe('unknown-idp')
+  })
+})
+
+describe('providerDisplayNames', () => {
+  it('lists every linked provider, deduplicated, in document order', () => {
+    expect(
+      providerDisplayNames(['linkedin:1', 'github:2', 'github:3']),
+    ).toEqual(['LinkedIn', 'GitHub'])
+  })
+
+  it('drops blank entries and returns empty for no providers', () => {
+    expect(providerDisplayNames(['', null, undefined, '  '])).toEqual([])
+    expect(providerDisplayNames(undefined)).toEqual([])
+    expect(providerDisplayNames(null)).toEqual([])
+  })
+})
+
+describe('providerSummary', () => {
+  it('joins several providers', () => {
+    expect(providerSummary(['github:1', 'linkedin:2'])).toBe(
+      'GitHub + LinkedIn',
+    )
+  })
+
+  it('reports an EMPTY providers list as never signed in, not as blank', () => {
+    // The document was created by an organizer and nobody has claimed it.
+    // Folding a never-claimed placeholder away is a different, safer operation
+    // than folding two real accounts together, so it must be visible.
+    expect(providerSummary([])).toBe(NEVER_SIGNED_IN_LABEL)
+    expect(providerSummary(undefined)).toBe(NEVER_SIGNED_IN_LABEL)
+    expect(NEVER_SIGNED_IN_LABEL).not.toBe('')
+  })
+})

--- a/src/lib/speaker/providers.ts
+++ b/src/lib/speaker/providers.ts
@@ -1,0 +1,66 @@
+/**
+ * How a speaker's LOGIN IDENTITY is described to an organizer.
+ *
+ * WHY THIS IS NOT COSMETIC. Duplicate documents are the same person, so the name
+ * is identical and the two emails are often both plausible personal addresses.
+ * "Ganesh Vasudevan — ganesh.vasudev@gmail.com" next to "Ganesh Vasudevan —
+ * ganesh.vasudevan@ericsson.com" asks an operator to tell two accounts apart by
+ * squinting at an address. The PROVIDER is the fact that actually separates
+ * them: one is LinkedIn, the other is GitHub. So every surface that lists
+ * speakers for a merge — the picker dropdowns and the duplicate-candidate rows —
+ * renders the provider, and renders it the same way, from here.
+ *
+ * The account id is deliberately dropped. `providers[]` entries are shaped
+ * `<provider>:<providerAccountId>` (see `providerAccount`); the id half is an
+ * opaque string of no use to a human and pure noise in a picker.
+ */
+
+/** Known provider ids → the name a human recognises. */
+const PROVIDER_NAMES: Record<string, string> = {
+  github: 'GitHub',
+  linkedin: 'LinkedIn',
+  'email-link': 'Email link',
+}
+
+/**
+ * What to show when `providers[]` is EMPTY — a meaningful state, not missing
+ * data. A speaker with no provider has never signed in: the document was
+ * created by an organizer (`speaker.admin.create`) as a placeholder for someone
+ * who has not claimed it yet. That matters in a merge picker, because folding a
+ * never-claimed placeholder into a real account is a different, safer operation
+ * than folding two real accounts together.
+ */
+export const NEVER_SIGNED_IN_LABEL = 'never signed in'
+
+/** `github:23187057` → `GitHub`. Unknown providers keep their raw prefix. */
+export function providerDisplayName(entry: string): string {
+  const prefix = (entry ?? '').trim().toLowerCase().split(':')[0]
+  return PROVIDER_NAMES[prefix] ?? prefix
+}
+
+/**
+ * The provider names for a speaker document, deduplicated and in document
+ * order. EMPTY when the person has never signed in — callers must render
+ * {@link NEVER_SIGNED_IN_LABEL} for that case rather than a blank.
+ */
+export function providerDisplayNames(
+  providers?: (string | null | undefined)[] | null,
+): string[] {
+  const names = (providers ?? [])
+    .filter((entry): entry is string => Boolean(entry && entry.trim()))
+    .map(providerDisplayName)
+    .filter((name) => name.length > 0)
+  return Array.from(new Set(names))
+}
+
+/**
+ * One-line identity summary for a speaker row: the providers, or the
+ * never-signed-in label. Used verbatim in the merge picker's option labels,
+ * where markup is impossible.
+ */
+export function providerSummary(
+  providers?: (string | null | undefined)[] | null,
+): string {
+  const names = providerDisplayNames(providers)
+  return names.length > 0 ? names.join(' + ') : NEVER_SIGNED_IN_LABEL
+}

--- a/src/lib/speaker/sanity.ts
+++ b/src/lib/speaker/sanity.ts
@@ -12,6 +12,7 @@ import { cacheLife, cacheTag } from 'next/cache'
 import { conferenceTag } from '@/lib/cache/tags'
 import { generateUniqueSpeakerSlug } from './slug'
 import { canonicalEmail, normalizeEmail, uniqueEmails } from './email'
+import type { DuplicateSpeakerInput } from './duplicates'
 import { verifiedEmails as fetchGithubVerifiedEmails } from '@/lib/profile/github'
 import { EXCLUDE_PUSH_FIELDS } from '@/lib/sanity/helpers'
 import { getOrganizationRefForCurrentConference } from '@/lib/organization/sanity'
@@ -1072,6 +1073,69 @@ export async function getSpeakers(
   }
 
   return { speakers, err }
+}
+
+/**
+ * The ORG-SCOPED corpus for duplicate detection (#267).
+ *
+ * Deliberately WIDER than `getSpeakers`: that one only returns speakers who have
+ * a talk in one of the requested statuses, and a duplicate document is very
+ * often the one with NO accepted talk (that is exactly why the person's
+ * dashboard looks empty). The predicate here is `SPEAKER_ORG_FILTER` alone —
+ * membership ∨ participation — which is the same set `requireSpeakerInCurrentOrg`
+ * grants standing over, so detection can never surface a speaker the organizer
+ * could not already see or act on.
+ *
+ * FAILS CLOSED on an unresolvable org (#616): with no `$orgId` the root filter
+ * would be a bare `*[_type == "speaker"]` over the shared dataset, i.e. a
+ * cross-tenant listing of every person's email and login providers. Refuse
+ * instead of degrading to global, which is the opposite of what `getSpeakers`
+ * does — that one is a page that should still render, this one is a privacy
+ * surface with nothing safe to show.
+ *
+ * Talk counts are org-scoped too, so they answer the only question that matters
+ * when picking a survivor: what would THIS organization lose by deleting this
+ * document. Read-only and uncached — an organizer who has just merged must see
+ * the result immediately.
+ */
+export async function getDuplicateSpeakerCandidateRecords(
+  orgId: string | null | undefined,
+): Promise<{ records: DuplicateSpeakerInput[]; err: Error | null }> {
+  if (!orgId) {
+    return {
+      records: [],
+      err: new Error(
+        'getDuplicateSpeakerCandidateRecords requires an orgId (tenant scoping, #616)',
+      ),
+    }
+  }
+
+  try {
+    // groq-global-scoped: the root predicate IS `SPEAKER_ORG_FILTER`
+    // (`$orgId in organizations[]._ref` ∨ a talk at one of this org's
+    // conferences) — the same tenant predicate the admin speaker lists use. The
+    // `$orgId` param can never be absent; the guard above refuses that case.
+    const query = groq`*[_type == "speaker" && ${SPEAKER_ORG_FILTER}]{
+      _id,
+      name,
+      email,
+      knownEmails,
+      providers,
+      _createdAt,
+      "slug": slug.current,
+      "talkCount": count(*[_type == "talk" && references(^._id) && conference->organization._ref == $orgId]),
+      "confirmedTalkCount": count(*[_type == "talk" && references(^._id) && status == "confirmed" && conference->organization._ref == $orgId])
+    }`
+
+    const records = await clientRead.fetch<DuplicateSpeakerInput[]>(
+      query,
+      { orgId },
+      { cache: 'no-store' },
+    )
+    return { records: records ?? [], err: null }
+  } catch (error) {
+    return { records: [], err: error as Error }
+  }
 }
 
 export async function getSpeakersWithAcceptedTalks(

--- a/src/server/routers/speaker.duplicates.test.ts
+++ b/src/server/routers/speaker.duplicates.test.ts
@@ -209,6 +209,62 @@ describe('speaker.admin.duplicateCandidates', () => {
     ).toBeNull()
   })
 
+  /**
+   * THE FILTER THAT MADE THE MERGE TOOL USELESS. `/admin/speakers` lists
+   * speakers with an accepted/confirmed talk and used to hand that same array to
+   * the merge modal, so both dropdowns excluded every document WITHOUT one — and
+   * a duplicate almost never has one, because the talks are on the other
+   * document. For the reported incident only the LinkedIn half was selectable.
+   */
+  it('offers EVERY org speaker as a merge candidate, talks or not', async () => {
+    const result = await makeCaller({
+      isOrganizer: true,
+    }).admin.duplicateCandidates()
+
+    const ids = result.mergeCandidates.map((candidate) => candidate._id)
+    // `spk-dupe` has NO talk of any status. It must still be selectable.
+    expect(ids).toContain('spk-dupe')
+    // Both halves of the incident pair, which is the point of the whole tool.
+    expect(ids).toContain('spk-keep')
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        'spk-keep',
+        'spk-dupe',
+        'spk-shared-1',
+        'spk-shared-2',
+        'spk-orphan-1',
+        'spk-orphan-2',
+      ]),
+    )
+    expect(ids).toHaveLength(6)
+  })
+
+  it('carries each candidate’s providers so the picker can tell them apart', async () => {
+    // Two documents, one name, two similar personal addresses: the provider is
+    // the only field that visibly separates the rows.
+    const result = await makeCaller({
+      isOrganizer: true,
+    }).admin.duplicateCandidates()
+
+    const byId = new Map(
+      result.mergeCandidates.map((candidate) => [candidate._id, candidate]),
+    )
+    expect(byId.get('spk-keep')?.providers).toEqual(['linkedin:2mtSWuh1kA'])
+    expect(byId.get('spk-dupe')?.providers).toEqual(['github:23187057'])
+    // Never signed in — an organizer-created placeholder, not missing data.
+    expect(byId.get('spk-orphan-1')?.providers).toEqual([])
+  })
+
+  it('scopes the merge candidate list to this organization', async () => {
+    const result = await makeCaller({
+      isOrganizer: true,
+    }).admin.duplicateCandidates()
+
+    const ids = result.mergeCandidates.map((candidate) => candidate._id)
+    expect(ids).not.toContain('spk-b1')
+    expect(ids).not.toContain('spk-b2')
+  })
+
   it('never surfaces another tenant’s duplicates', async () => {
     const result = await makeCaller({
       isOrganizer: true,

--- a/src/server/routers/speaker.duplicates.test.ts
+++ b/src/server/routers/speaker.duplicates.test.ts
@@ -1,0 +1,305 @@
+/**
+ * @vitest-environment node
+ *
+ * `speaker.admin.duplicateCandidates` — the FIND half of the merge tool (#267).
+ *
+ * Both reads it performs (the org-scoped corpus and the exclusivity probe) run
+ * against a real `groq-js` evaluation of a two-tenant dataset, for the reason
+ * spelled out in `src/server/tenancy.exploits.test.ts`: a mock that branches on
+ * the query text asserts that the diff is still present, not that the predicate
+ * is still correct.
+ *
+ * What is pinned here is the contract the UI depends on:
+ *  - organizers only, and only their own organization's documents;
+ *  - a candidate this org does not hold ALONE is reported as unmergeable rather
+ *    than offered as an action `speaker.admin.merge` would refuse.
+ */
+
+const h = vi.hoisted(() => ({ fetch: vi.fn() }))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: h.fetch },
+  clientReadCached: { fetch: h.fetch },
+  clientWrite: {
+    fetch: h.fetch,
+    patch: vi.fn(),
+    delete: vi.fn(),
+    create: vi.fn(),
+  },
+  speakerImageUrl: vi.fn(),
+}))
+vi.mock('next/cache', () => ({ cacheLife: vi.fn(), cacheTag: vi.fn() }))
+vi.mock('@/lib/conference/sanity', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getConferenceForCurrentDomain: async () => ({
+    conference: {
+      _id: 'conf-A',
+      organization: { _type: 'reference', _ref: 'org-A' },
+    },
+    domain: 'a.test',
+    error: null,
+  }),
+}))
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { parse, evaluate } from 'groq-js'
+import type { Context } from '@/server/trpc'
+import { speakerRouter } from './speaker'
+
+const ORG_A = 'org-A'
+const ORG_B = 'org-B'
+
+type Doc = Record<string, unknown> & { _id: string; _type: string }
+
+const ref = (id: string) => ({ _type: 'reference', _ref: id })
+
+function useDataset(dataset: Doc[]) {
+  h.fetch.mockImplementation(
+    async (query: string, params: Record<string, unknown> = {}) =>
+      await (await evaluate(parse(query), { dataset, params })).get(),
+  )
+}
+
+function makeCaller(opts: { isOrganizer: boolean }) {
+  const speaker = {
+    _id: 'admin-1',
+    name: 'Admin',
+    isOrganizer: opts.isOrganizer,
+    organizerOrgIds: opts.isOrganizer ? [ORG_A] : [],
+  }
+  return speakerRouter.createCaller({
+    session: { speaker, user: { name: 'Admin' } },
+    speaker,
+  } as unknown as Context)
+}
+
+/**
+ * Org A holds two slug-colliding documents outright. Org A and org B BOTH have
+ * standing over the `shared-person` pair, so neither of those may be deleted
+ * from here.
+ */
+const dataset: Doc[] = [
+  { _id: ORG_A, _type: 'organization', name: 'A' },
+  { _id: ORG_B, _type: 'organization', name: 'B' },
+  { _id: 'conf-A', _type: 'conference', organization: ref(ORG_A) },
+  { _id: 'conf-B', _type: 'conference', organization: ref(ORG_B) },
+
+  {
+    _id: 'spk-keep',
+    _type: 'speaker',
+    name: 'Ganesh Vasudevan',
+    slug: { _type: 'slug', current: 'ganesh-vasudevan' },
+    email: 'ganesh.vasudev@gmail.com',
+    providers: ['linkedin:2mtSWuh1kA'],
+    _createdAt: '2026-05-05T00:00:00Z',
+    organizations: [ref(ORG_A)],
+  },
+  {
+    _id: 'spk-dupe',
+    _type: 'speaker',
+    name: 'Ganesh Vasudevan',
+    slug: { _type: 'slug', current: 'ganesh-vasudevan' },
+    email: 'ganesh.vasudevan@ericsson.com',
+    providers: ['github:23187057'],
+    _createdAt: '2026-06-15T00:00:00Z',
+    organizations: [ref(ORG_A)],
+  },
+  {
+    _id: 'talk-keep',
+    _type: 'talk',
+    status: 'confirmed',
+    conference: ref('conf-A'),
+    speakers: [ref('spk-keep')],
+  },
+
+  // A duplicate pair that BOTH organizations hold — unmergeable from here.
+  {
+    _id: 'spk-shared-1',
+    _type: 'speaker',
+    name: 'Shared Person',
+    slug: { _type: 'slug', current: 'shared-person' },
+    email: 'shared@example.com',
+    _createdAt: '2026-01-01T00:00:00Z',
+    organizations: [ref(ORG_A), ref(ORG_B)],
+  },
+  {
+    _id: 'spk-shared-2',
+    _type: 'speaker',
+    name: 'Shared Person',
+    slug: { _type: 'slug', current: 'shared-person' },
+    email: 'shared.dup@example.com',
+    _createdAt: '2026-02-01T00:00:00Z',
+    organizations: [ref(ORG_A), ref(ORG_B)],
+  },
+
+  // A pair held only by org A, but one of them is referenced by a document
+  // whose tenant cannot be established (the pre-044 population, #731).
+  {
+    _id: 'spk-orphan-1',
+    _type: 'speaker',
+    name: 'Orphan Ref Person',
+    slug: { _type: 'slug', current: 'orphan-person' },
+    _createdAt: '2026-01-01T00:00:00Z',
+    organizations: [ref(ORG_A)],
+  },
+  {
+    _id: 'spk-orphan-2',
+    _type: 'speaker',
+    name: 'Orphan Ref Person',
+    slug: { _type: 'slug', current: 'orphan-person' },
+    _createdAt: '2026-02-01T00:00:00Z',
+    organizations: [ref(ORG_A)],
+  },
+  { _id: 'conf-orphan', _type: 'conference' },
+  {
+    _id: 'talk-orphan',
+    _type: 'talk',
+    status: 'submitted',
+    conference: ref('conf-orphan'),
+    speakers: [ref('spk-orphan-2')],
+  },
+
+  // Another tenant's own duplicate pair. Never visible to org A.
+  {
+    _id: 'spk-b1',
+    _type: 'speaker',
+    name: 'B Person',
+    slug: { _type: 'slug', current: 'b-person' },
+    _createdAt: '2026-01-01T00:00:00Z',
+    organizations: [ref(ORG_B)],
+  },
+  {
+    _id: 'spk-b2',
+    _type: 'speaker',
+    name: 'B Person',
+    slug: { _type: 'slug', current: 'b-person' },
+    _createdAt: '2026-02-01T00:00:00Z',
+    organizations: [ref(ORG_B)],
+  },
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useDataset(dataset)
+})
+
+describe('speaker.admin.duplicateCandidates', () => {
+  it('rejects a non-organizer', async () => {
+    await expect(
+      makeCaller({ isOrganizer: false }).admin.duplicateCandidates(),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+  })
+
+  it('finds the slug collision and suggests the confirmed-talk document', async () => {
+    const result = await makeCaller({
+      isOrganizer: true,
+    }).admin.duplicateCandidates()
+
+    const collision = result.groups.find(
+      (group) => group.value === 'ganesh-vasudevan',
+    )
+    expect(collision).toBeDefined()
+    expect(collision!.confidence).toBe('certain')
+    expect(collision!.suggestedSurvivorId).toBe('spk-keep')
+    expect(collision!.survivorReason).toBe('confirmed-talks')
+    // The duplicate is exclusively ours, so it may be merged away.
+    expect(
+      collision!.members.find((member) => member._id === 'spk-dupe')
+        ?.mergeBlockedReason,
+    ).toBeNull()
+  })
+
+  it('never surfaces another tenant’s duplicates', async () => {
+    const result = await makeCaller({
+      isOrganizer: true,
+    }).admin.duplicateCandidates()
+
+    const ids = result.groups.flatMap((group) =>
+      group.members.map((member) => member._id),
+    )
+    expect(ids).not.toContain('spk-b1')
+    expect(ids).not.toContain('spk-b2')
+    expect(result.scannedCount).toBe(6)
+  })
+
+  it('reports an UNATTRIBUTABLE referencing document as a block, not a pass', () => {
+    // The #731 fail-open: in a pre-044 dataset the membership and participation
+    // arms both go blind, and only the reference-graph arm — which counts a
+    // document it cannot attribute as foreign — still refuses. The panel has to
+    // show that refusal rather than a button.
+    return makeCaller({ isOrganizer: true })
+      .admin.duplicateCandidates()
+      .then((result) => {
+        const orphan = result.groups.find(
+          (group) => group.value === 'orphan-person',
+        )!
+        expect(orphan).toBeDefined()
+        expect(
+          orphan.members.find((member) => member._id === 'spk-orphan-2')
+            ?.mergeBlockedReason,
+        ).toBe('foreign-references')
+        // Its sibling carries no such reference and stays mergeable.
+        expect(
+          orphan.members.find((member) => member._id === 'spk-orphan-1')
+            ?.mergeBlockedReason,
+        ).toBeNull()
+      })
+  })
+
+  it('reports a cross-tenant candidate as UNMERGEABLE instead of offering it', async () => {
+    // `speaker.admin.merge` requires the loser to be exclusive to this org, so
+    // offering a merge button here would produce a BAD_REQUEST on click.
+    const result = await makeCaller({
+      isOrganizer: true,
+    }).admin.duplicateCandidates()
+
+    const shared = result.groups.find(
+      (group) => group.value === 'shared-person',
+    )!
+    expect(shared).toBeDefined()
+    for (const member of shared.members) {
+      expect(member.mergeBlockedReason).toBe('other-organization')
+    }
+  })
+
+  /**
+   * THE ONE DELIBERATE TEXT ASSERTION, for the same reason and with the same
+   * scope as the one in `src/server/tenancy.exploits.test.ts`: `groq-js`
+   * evaluates `null != $param` as `true`, while the Sanity backend drops it as
+   * unknown. The `!defined(...) ||` arm exists purely for that backend
+   * behaviour, so the engine above cannot observe its removal — the test right
+   * before this one keeps passing without it. Do not add a second text
+   * assertion; everything else here is semantic.
+   */
+  it('keeps the !defined arm that makes an unattributable document foreign', async () => {
+    await makeCaller({ isOrganizer: true }).admin.duplicateCandidates()
+
+    const probe = h.fetch.mock.calls
+      .map((call) => call[0] as string)
+      .find((query) => query.includes('foreignRefCount'))
+
+    expect(probe).toBeDefined()
+    expect(probe).toContain(
+      '!defined(coalesce(organization._ref, conference->organization._ref)) ||',
+    )
+  })
+
+  it('fails closed when the exclusivity probe cannot be read', async () => {
+    const realFetch = h.fetch.getMockImplementation()!
+    h.fetch.mockImplementation(async (query: string, params) => {
+      if (query.includes('foreignRefCount')) throw new Error('probe down')
+      return realFetch(query, params)
+    })
+
+    const result = await makeCaller({
+      isOrganizer: true,
+    }).admin.duplicateCandidates()
+
+    expect(result.groups.length).toBeGreaterThan(0)
+    for (const group of result.groups) {
+      for (const member of group.members) {
+        expect(member.mergeBlockedReason).toBe('unknown')
+      }
+    }
+  })
+})

--- a/src/server/routers/speaker.ts
+++ b/src/server/routers/speaker.ts
@@ -21,7 +21,12 @@ import {
   updateSpeaker,
   getOrganizers,
   getSpeakers,
+  getDuplicateSpeakerCandidateRecords,
 } from '@/lib/speaker/sanity'
+import {
+  findDuplicateSpeakerCandidates,
+  type DuplicateCandidatesReport,
+} from '@/lib/speaker/duplicates'
 import { clientWrite } from '@/lib/sanity/client'
 import {
   getOrganizationRefForCurrentConference,
@@ -54,6 +59,7 @@ import { canonicalEmail } from '@/lib/speaker/email'
 import {
   requireCurrentOrgId,
   requireSpeakerInCurrentOrg,
+  speakerExclusivityBlocks,
 } from '@/server/tenancy'
 
 export const speakerRouter = router({
@@ -547,6 +553,59 @@ export const speakerRouter = router({
         })
       }
     }),
+
+    /**
+     * FIND duplicate speaker documents in THIS organization (#267).
+     *
+     * The merge tool has always been able to fold two documents together; until
+     * now nothing told an organizer WHICH two. Read-only: it runs the shared
+     * detector over the org's speakers and stamps each candidate with the merge
+     * eligibility the merge guard would compute, so a cross-tenant pair is shown
+     * as unmergeable instead of offering a button that throws.
+     *
+     * `requireCurrentOrgId` (not the best-effort `getOrganizationRefForCurrentConference`
+     * the sibling list endpoints use): with no org this would be a cross-tenant
+     * listing of every person's email and login providers, so it refuses.
+     */
+    duplicateCandidates: adminProcedure.query(
+      async (): Promise<DuplicateCandidatesReport> => {
+        const orgId = await requireCurrentOrgId()
+
+        const { records, err } =
+          await getDuplicateSpeakerCandidateRecords(orgId)
+        if (err) {
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: 'Failed to scan speakers for duplicates',
+            cause: err,
+          })
+        }
+
+        const groups = findDuplicateSpeakerCandidates(records)
+
+        // One probe for every flagged document — a bounded set, never the whole
+        // corpus (the reference-graph arm is the expensive one).
+        const flaggedIds = Array.from(
+          new Set(groups.flatMap((group) => group.members.map((m) => m._id))),
+        )
+        const blocks = await speakerExclusivityBlocks(flaggedIds, orgId)
+
+        return {
+          scannedCount: records.length,
+          groups: groups.map((group) => ({
+            ...group,
+            members: group.members.map((member) => ({
+              ...member,
+              // `has`, not `??`: `null` is the AFFIRMATIVE "may be merged"
+              // verdict, and `??` would silently downgrade it to 'unknown'.
+              mergeBlockedReason: blocks.has(member._id)
+                ? blocks.get(member._id)!
+                : 'unknown',
+            })),
+          })),
+        }
+      },
+    ),
 
     // Preview a duplicate-speaker merge (identity Phase 3). Read-only: computes
     // exactly what the mutation would repoint/change WITHOUT writing anything so

--- a/src/server/routers/speaker.ts
+++ b/src/server/routers/speaker.ts
@@ -592,6 +592,20 @@ export const speakerRouter = router({
 
         return {
           scannedCount: records.length,
+          // The picker's candidate source: EVERY speaker in the org, sorted by
+          // name, with no talk-status filter. See `mergeCandidates` on the
+          // report type for why that filter made the merge tool unable to merge
+          // the very case it exists for.
+          mergeCandidates: records
+            .map((record) => ({
+              _id: record._id,
+              name: record.name || 'Unnamed speaker',
+              email: record.email ?? null,
+              providers: (record.providers ?? []).filter(
+                (entry): entry is string => Boolean(entry),
+              ),
+            }))
+            .sort((a, b) => a.name.localeCompare(b.name)),
           groups: groups.map((group) => ({
             ...group,
             members: group.members.map((member) => ({

--- a/src/server/tenancy.ts
+++ b/src/server/tenancy.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from '@trpc/server'
 import { groq } from 'next-sanity'
 import { clientReadUncached } from '@/lib/sanity/client'
+import type { MergeBlockReason } from '@/lib/speaker/duplicates'
 import { resolveConferenceId, resolveOrganizationId } from './trpc'
 
 /**
@@ -311,6 +312,90 @@ export async function requireSpeakerInCurrentOrg(
   }
 
   return orgId
+}
+
+/**
+ * Why a speaker document may NOT be the LOSER of a merge — i.e. why
+ * `requireSpeakerInCurrentOrg(id, { requireExclusive: true })` would refuse it.
+ * Defined next to the detector that renders it so the wire type has one home.
+ */
+export type SpeakerExclusivityBlock = MergeBlockReason
+
+/**
+ * READ-ONLY mirror of the `requireExclusive` arms of
+ * {@link requireSpeakerInCurrentOrg}, for a bounded set of ids.
+ *
+ * WHY IT EXISTS. `speaker.admin.merge` deletes the loser, so it demands the
+ * loser be EXCLUSIVE to the request's org. A duplicate pair that spans tenants
+ * therefore cannot be merged at all — and the duplicate-candidates surface
+ * (#267) must say so up front rather than render a button that throws
+ * BAD_REQUEST when pressed. This returns the same verdict the guard would, one
+ * query for the whole set, and never authorizes anything itself: it is a
+ * PREDICTION of a refusal, never a substitute for it. The mutation still runs
+ * the real guard.
+ *
+ * KEEP THE PREDICATES IN LOCKSTEP with the guard above. The three arms are, in
+ * order: foreign membership refs, foreign PARTICIPATION (talks whose conference
+ * resolves to another org — a talk with no resolvable org is deliberately NOT
+ * foreign here, exactly as `speakerParticipationOrgIds` filters non-strings, and
+ * is caught instead by the third arm), and the foreign REFERENCE GRAPH, where an
+ * unattributable document counts as foreign.
+ *
+ * FAILS CLOSED: a read error marks every id `'unknown'`, so the UI reports the
+ * pair as unmergeable rather than promising an action that would be refused.
+ */
+export async function speakerExclusivityBlocks(
+  ids: string[],
+  orgId: string,
+): Promise<Map<string, SpeakerExclusivityBlock | null>> {
+  const result = new Map<string, SpeakerExclusivityBlock | null>()
+  const unique = Array.from(new Set(ids.filter(Boolean)))
+  if (unique.length === 0) return result
+
+  try {
+    // groq-global: an exclusivity probe over a bounded, already-owned id set.
+    // Like `foreignReferencingDocCount`, its whole job is to SEE other tenants'
+    // documents in order to predict a refusal — scoping it would defeat it.
+    const query = groq`*[_id in $ids && _type == "speaker"]{
+      _id,
+      "memberOrgIds": coalesce(organizations, [])[]._ref,
+      "foreignTalkCount": count(*[_type == "talk" && references(^._id) && defined(conference->organization._ref) && conference->organization._ref != $orgId]),
+      "foreignRefCount": count(*[references(^._id) && _id != ^._id && (!defined(coalesce(organization._ref, conference->organization._ref)) || coalesce(organization._ref, conference->organization._ref) != $orgId)])
+    }`
+    const rows = await clientReadUncached.fetch<
+      {
+        _id: string
+        memberOrgIds?: (string | null)[] | null
+        foreignTalkCount?: number | null
+        foreignRefCount?: number | null
+      }[]
+    >(query, { ids: unique, orgId }, { cache: 'no-store' })
+
+    const byId = new Map((rows ?? []).map((row) => [row._id, row]))
+    for (const id of unique) {
+      const row = byId.get(id)
+      if (!row) {
+        // The id is not a speaker we can read — the guard would refuse it too.
+        result.set(id, 'unknown')
+        continue
+      }
+      const foreignMember = (row.memberOrgIds ?? []).some(
+        (ref) => typeof ref === 'string' && ref.length > 0 && ref !== orgId,
+      )
+      if (foreignMember || (row.foreignTalkCount ?? 0) > 0) {
+        result.set(id, 'other-organization')
+      } else if ((row.foreignRefCount ?? 0) > 0) {
+        result.set(id, 'foreign-references')
+      } else {
+        result.set(id, null)
+      }
+    }
+  } catch {
+    // FAIL CLOSED: an unreadable probe proves nothing, so nothing is mergeable.
+    for (const id of unique) result.set(id, 'unknown')
+  }
+
+  return result
 }
 
 /**


### PR DESCRIPTION
Closes the detection half of #267 — and fixes a structural defect found during review that made the merge tool unable to merge the case it exists for.

## The gap

Merging works. **Finding** does not. `/admin/speakers` → "Merge Duplicates" opens `SpeakerMergeModal` with two dropdowns listing speakers alphabetically, so an organizer can only merge a duplicate they already know about — which in practice means *after the speaker complains*.

That is exactly how the incident happened: two documents for Ganesh Vasudevan sharing the slug `ganesh-vasudevan`, the confirmed talk on the LinkedIn document, and he signs in with GitHub. The census in #267 found **10 shared slugs, nine of them real people**.

## The defect underneath it (found in review, fixed here)

`/admin/speakers` loads its table with **`getSpeakersWithAcceptedTalks`**, and handed that same array to the merge modal. So **both** dropdowns — survivor *and* duplicate — only ever contained speakers with an accepted or confirmed talk.

A duplicate document almost never has one. **The talks are on the other document — that is the entire shape of the bug.** For the reported incident only the LinkedIn half was selectable, so the merge was impossible through the UI. A raw dataset census and the admin UI disagreed about what exists, because the UI was a filtered view.

The picker now reads the **org-scoped, talk-status-agnostic** corpus the duplicate scan already loads, shipped with the scan as `mergeCandidates` so the picker and the detector cannot disagree about who exists. Tenant scoping is unchanged — it is the *talk-status* filter that had to go. Detection itself was never affected (it has always used `SPEAKER_ORG_FILTER` alone), so it would have found the incident; the picker it fed could not act on it.

## What an organizer now sees

A **"Possible duplicate speakers"** card on `/admin/speakers`, between the header stats and the table. It opens itself when there is something *certain* to act on (or when the scan failed), otherwise it sits collapsed behind `4 candidate groups covering 10 of 348 speakers · 3 certain`.

Each group is a bordered block with a confidence chip, the signal, the shared value and a plain-language caption. Inside, one card per document:

| | |
|---|---|
| **Talks** | `2 talks · 1 confirmed` — confirmed in green, `none in this organization` in muted italic |
| **Logins** | `LinkedIn` / `GitHub` chips, or an amber **`never signed in`** chip |
| **Email** | display email |
| **Created** | house-locale date via `src/lib/time.ts` |

The document to keep carries a green **"Keep this one"** badge and a caption saying *why* (`holds the confirmed talk(s)` / `holds the most talks` / `oldest account — no talks to separate them`). Every other document gets **"Merge into the kept document…"** — deliberately not "Merge into ⟨name⟩", since duplicates share a name and that reads as a no-op.

### Providers, because the name and the emails don't separate them

Duplicates are the same person: identical name, two plausible personal addresses. `Ganesh Vasudevan — ganesh.vasudev@gmail.com` next to `Ganesh Vasudevan — ganesh.vasudevan@ericsson.com` asks an operator to tell two accounts apart by squinting at an address. The **provider** is the fact that separates them, so it is rendered in both surfaces from one shared module (`src/lib/speaker/providers.ts`):

- picker option: `Ganesh Vasudevan · GitHub · ganesh.vasudevan@ericsson.com` — provider *before* the email, because that is what differs first;
- candidate row: provider chips.

Provider **name only** — the opaque `:23187057` account id is never shown. An **empty** `providers[]` is labelled `never signed in` rather than left blank: that document was created by an organizer (`speaker.admin.create`) and nobody has claimed it, and folding a never-claimed placeholder into a real account is a different, safer operation than folding two real accounts together.

## Signals, ranked — and never flattened

| Signal | Confidence | Why |
|---|---|---|
| `slug.current` collision | **certain** | The public profile URL. `getPublicSpeaker` resolves it with `[0]`, so one of the two is unreachable by an ordering nobody controls (#818). All ten production cases are this shape. |
| Same provider account id | likely | Strong key, but it is also what login already matches on — a collision means something unusual happened upstream. |
| Overlapping `email` / `knownEmails` | likely | Same. |
| Identical normalized name | possible | Two people really can be called Anna Hansen. |

**Overlap rule.** A group is reported only when it introduces at least one *pair* of documents no stronger group already covers. A weaker signal over exactly the same documents is folded in as `corroboratingSignals` ("also same name"); a weaker signal over a **wider** set stays its own weaker group — so a name guess can never inherit a slug collision's certainty. The previous union-find clustering did exactly that laundering, and is replaced.

**Survivor suggestion follows confirmed talks, never age.** Most confirmed talks → most talks → oldest → id. In the incident the correct survivor was neither the newer nor the older document; picking by date would have repointed a confirmed conference talk and then deleted the document the schedule was built around. With unfiltered candidates most rows now show no talks at all, which makes the one that does stand out as the survivor.

## Handoff to the existing merge flow

No merge logic is duplicated. The button opens the existing `SpeakerMergeModal` with `initialSurvivorId` / `initialLoserId`, landing straight on the preview. The dropdowns stay editable — the suggestion is a suggestion.

**Re-seeds on every open** (review finding, found independently by Greptile and Copilot). Seeding only at mount was wrong: closing clears the modal's selection, so opening a suggested pair, closing it, and clicking the *same* pair again produced an empty modal — a click that visibly did nothing, in the exact flow this PR adds. A remount `key` keyed on the pair cannot fix that, because an identical key is not a remount. The modal now re-derives its selection on every closed→open transition, which also covers a *different* pair after a close and an unseeded open from the "Merge Duplicates" header button.

## Honest about what cannot be done

`speaker.admin.merge` requires `requireExclusive` on the **loser**, so a candidate pair spanning tenants cannot be merged at all. `speakerExclusivityBlocks` (new, in `src/server/tenancy.ts`) is a read-only mirror of the guard's three arms — foreign membership, foreign participation, foreign/unattributable reference graph — run once over the flagged ids only. Blocked rows show the reason instead of a button; a group with nothing mergeable says so at the top. It fails closed, and never authorizes anything: the mutation still runs the real guard.

The panel also says in as many words that candidates are *a starting point, not a verdict*: some may be test or placeholder accounts (`test-user` ×4 in production), and two people really can share a name.

## Tenant scoping

`getDuplicateSpeakerCandidateRecords` uses `SPEAKER_ORG_FILTER` — membership ∨ participation, the same terms as the admin lists and `requireSpeakerInCurrentOrg` — so neither detection nor the picker can surface a speaker the organizer has no standing over. Talk counts are org-scoped too, so they answer "what would **we** lose by deleting this document".

Unlike `getSpeakers`, it **fails closed** with no resolvable org: an unscoped version is a cross-tenant dump of every person's email and login providers, and there is nothing safe to degrade to. The router uses `requireCurrentOrgId`, not the best-effort org helper.

The offline operator report (`scripts/report-duplicate-speakers.ts`) stays deliberately cross-tenant — it runs with a dataset credential — but now shares the same detector, so the two can never disagree about what a duplicate is. Its inbound-reference probes are now one batched query, since its flagged set grows with the whole dataset rather than staying the ~25 documents one tenant sees.

## Follow-up, deliberately not in this PR

`slug.current` still has **no uniqueness constraint**, which is why this recurs: a second sign-in with a different provider mints a second document with an identical slug. Adding the constraint needs a de-dup migration of the existing ten first. Detection is the stopgap that makes the recurrence visible.

## Verification

Baseline re-derived on `origin/main` in this worktree.

| | before | after |
|---|---|---|
| `pnpm test` | 480 files / 6923 tests | **484 files / 6961 tests**, all passing |
| `pnpm typecheck` | clean | clean |
| `npx prettier --check .` | clean | clean |
| `npx eslint .` | 216 warnings, 0 errors | **216 warnings, 0 errors** (new GROQ carries a `groq-global-scoped:` annotation) |
| `pnpm knip` | 1 config hint | 1 config hint (unchanged) |

Org-scoping and exclusivity tests evaluate the **real query text** with `groq-js` against a two-tenant document fixture, following `src/server/tenancy.exploits.test.ts` — no branching on `query.includes(...)`, so a semantically wrong predicate that keeps the right substrings still fails. There is exactly one deliberate text assertion, scoped to the `!defined(...) ||` clause and labelled, for the one thing `groq-js` cannot observe (it evaluates `null != $param` as `true`; the backend drops it).

### Sabotage results

| Removed | Tests that failed |
|---|---|
| `'slug'` from the signal set | **8** |
| the empty-value filter (so blanks group) | **1** |
| `SPEAKER_ORG_FILTER` from the corpus query | **3** |
| the null-org fail-closed guard | **1** |
| the foreign-membership/participation block | **1** |
| the `!defined(...) \|\|` unattributable arm | **1** |
| **restored the accepted-talks-only corpus** | **12** (incl. `offers EVERY org speaker as a merge candidate, talks or not`) |
| **the modal's open-transition re-seed** | **3** (incl. `re-seeds the SAME pair after closing without merging`) |
| the `never signed in` fallback | **2** |
| the provider from the picker's option label | **2** |

Two bugs were caught by these tests during development:

- `blocks.get(id) ?? 'unknown'` silently downgraded the affirmative `null` ("may be merged") verdict to `unknown`, which would have disabled every merge button. Now `blocks.has(id)`.
- The mount-only seeding turned out to be broken even on the *first* open, not just on reopen — the modal mounts closed on the page, so the initial props were read before any pair existed. Only the Storybook story (which mounts already-open) hid it.

### Visual inspection

Per `AGENTS.md`, via `pnpm shoot` against a Storybook served from this worktree (`SHOOT_PORT`), not a deployed URL:

- `DuplicateSpeakersPanel/Default` at 1280×2600 — four groups (three certain incl. the `test-user` ×4 case, one possible name), amber `never signed in` chips on the unclaimed placeholders, 0 cards exceed the viewport.
- `SlugCollision` at 393×1100 (iPhone portrait) — cards stack, no clipping. The header summary had `truncate` and clipped to "1 candidate group c…" at that width; removed, since on mobile that line is the only place the counts appear.
- `CrossTenantAndUnmergeable` at 900×700 in **dark** — chips, the amber block notice and the green survivor card all resolve.
- `SpeakerMergeModal/PreSelectedFromDuplicatePanel` at 900×800 — both dropdowns seeded and reading `Ada Lovelace · LinkedIn · …` vs `Ada Lovelace · GitHub · …`, preview already open.

New stories: `Systems/Speakers/Admin/DuplicateSpeakersPanel` (7 states, running the real detector over fixtures) and one added to the merge modal.