### PR TITLE
fix(cfp): stop a freshly provisioned tenant's public CFP page from 500ing

### DIFF
--- a/__tests__/api/trpc/proposal.test.ts
+++ b/__tests__/api/trpc/proposal.test.ts
@@ -680,6 +680,75 @@ describe('proposal router', () => {
       ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
     })
 
+    it('should refuse submitting a draft when the conference offers no formats', async () => {
+      // `action` is the OTHER route to `submitted` — it is what ProposalForm
+      // uses for an existing draft. Gating only `proposal.create` would leave
+      // the trap open: prepare a draft (still allowed), then submit it here
+      // onto a conference offering no formats, carrying the schema's default
+      // format that the conference never offered.
+      vi.mocked(isCfpOpen).mockReturnValue(true)
+      vi.mocked(hasSubmittableFormats).mockReturnValue(false)
+      vi.mocked(getProposalSanity).mockResolvedValue({
+        proposal: { ...mockProposal, status: Status.draft } as any,
+        proposalError: null,
+      })
+      vi.mocked(getProposals).mockResolvedValue({
+        proposals: [],
+        proposalsError: null,
+      })
+      vi.mocked(updateProposalStatus).mockClear()
+
+      const caller = createAuthenticatedCaller(regularSpeaker._id)
+      await expect(
+        caller.proposal.action({ id: 'proposal-1', action: Action.submit }),
+      ).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+        message: expect.stringContaining('session formats'),
+      })
+      expect(updateProposalStatus).not.toHaveBeenCalled()
+    })
+
+    it('should refuse an ORGANIZER submitting a draft with no formats either', async () => {
+      // No organizer carve-out: a submitted proposal on a formats-less
+      // conference is wrong whoever creates it (unlike the 3-proposal cap,
+      // which is a per-speaker fairness rule organizers may override).
+      vi.mocked(isCfpOpen).mockReturnValue(true)
+      vi.mocked(hasSubmittableFormats).mockReturnValue(false)
+      vi.mocked(getProposalSanity).mockResolvedValue({
+        proposal: { ...mockProposal, status: Status.draft } as any,
+        proposalError: null,
+      })
+
+      const caller = createAdminCaller()
+      await expect(
+        caller.proposal.action({ id: 'proposal-1', action: Action.submit }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    })
+
+    it('should allow submitting a draft once formats are configured', async () => {
+      vi.mocked(isCfpOpen).mockReturnValue(true)
+      vi.mocked(hasSubmittableFormats).mockReturnValue(true)
+      vi.mocked(getProposalSanity).mockResolvedValue({
+        proposal: { ...mockProposal, status: Status.draft } as any,
+        proposalError: null,
+      })
+      vi.mocked(getProposals).mockResolvedValue({
+        proposals: [],
+        proposalsError: null,
+      })
+      vi.mocked(updateProposalStatus).mockResolvedValue({
+        proposal: { ...mockProposal, status: Status.submitted } as any,
+        err: null,
+      })
+
+      const caller = createAuthenticatedCaller(regularSpeaker._id)
+      const result = await caller.proposal.action({
+        id: 'proposal-1',
+        action: Action.submit,
+      })
+      expect(result.proposalStatus).toBe(Status.submitted)
+    })
+
     it('should enforce proposal cap when submitting a draft', async () => {
       vi.mocked(isCfpOpen).mockReturnValue(true)
       const draftProposal = { ...mockProposal, status: Status.draft }

--- a/__tests__/api/trpc/proposal.test.ts
+++ b/__tests__/api/trpc/proposal.test.ts
@@ -444,6 +444,28 @@ describe('proposal router', () => {
       ).rejects.toMatchObject({ code: 'FORBIDDEN' })
       expect(createProposal).not.toHaveBeenCalled()
     })
+
+    it('still allows a DRAFT when the conference offers no formats', async () => {
+      // Drafts are the incomplete-work path (they skip strict validation too),
+      // so preparing one before the organizers announce formats is legitimate.
+      vi.mocked(isCfpOpen).mockReturnValue(true)
+      vi.mocked(hasSubmittableFormats).mockReturnValue(false)
+      vi.mocked(getProposals).mockResolvedValue({
+        proposals: [],
+        proposalsError: null,
+      })
+      vi.mocked(createProposal).mockResolvedValue({
+        proposal: { ...mockProposal, status: Status.draft } as any,
+        err: null,
+      })
+
+      const caller = createAuthenticatedCaller(regularSpeaker._id)
+      const result = await caller.proposal.create({
+        data: { title: 'Draft ahead of the formats' },
+        status: Status.draft,
+      })
+      expect(result.status).toBe(Status.draft)
+    })
   })
 
   describe('action', () => {

--- a/__tests__/api/trpc/proposal.test.ts
+++ b/__tests__/api/trpc/proposal.test.ts
@@ -72,6 +72,9 @@ vi.mock('@/lib/conference/state', () => ({
   isCfpOpen: vi.fn(),
   isConferenceOver: vi.fn(),
   isWithdrawalCutoffActive: vi.fn(),
+  // Defaults to "the conference offers formats" so the existing cases keep
+  // exercising the CFP-window gate alone; the case below flips it.
+  hasSubmittableFormats: vi.fn(() => true),
 }))
 
 // Messaging M4/S2: the action procedure mirrors organizer decision comments into
@@ -106,7 +109,11 @@ import {
 } from '@/lib/proposal/data/sanity'
 import { getProposalSanity, updateProposalStatus } from '@/lib/proposal/server'
 import { eventBus } from '@/lib/events/bus'
-import { isCfpOpen, isWithdrawalCutoffActive } from '@/lib/conference/state'
+import {
+  hasSubmittableFormats,
+  isCfpOpen,
+  isWithdrawalCutoffActive,
+} from '@/lib/conference/state'
 import { ensureProposalConversation, addMessage } from '@/lib/messaging/sanity'
 import { notifyNewMessage } from '@/lib/messaging/notify'
 import {
@@ -413,6 +420,29 @@ describe('proposal router', () => {
           status: Status.submitted,
         }),
       ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    })
+
+    it('should refuse a new proposal when the conference offers no formats', async () => {
+      // An OPEN CFP window on a conference that configured no session formats
+      // cannot accept anything — a proposal must carry a format. A fresh tenant
+      // is provisioned in exactly that state, so this closes the loop behind
+      // the page and form, which already refuse.
+      vi.mocked(isCfpOpen).mockReturnValue(true)
+      vi.mocked(hasSubmittableFormats).mockReturnValue(false)
+      vi.mocked(getProposals).mockResolvedValue({
+        proposals: [],
+        proposalsError: null,
+      })
+      vi.mocked(createProposal).mockClear()
+
+      const caller = createAuthenticatedCaller(regularSpeaker._id)
+      await expect(
+        caller.proposal.create({
+          data: validProposalData,
+          status: Status.submitted,
+        }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+      expect(createProposal).not.toHaveBeenCalled()
     })
   })
 

--- a/__tests__/app/cfp/fresh-tenant.test.tsx
+++ b/__tests__/app/cfp/fresh-tenant.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * @vitest-environment node
+ *
+ * THE DAY-ONE SCENARIO. `@/lib/onboarding/create.ts` provisions a brand-new
+ * tenant with NO `formats` and NO `topics` on the reasoning that "the admin
+ * surfaces are empty-safe". The PUBLIC surfaces were not: the conference
+ * projection is a bare `...` spread, so both fields come back `undefined`, and
+ * `/cfp` did `conference.formats.filter(...)` unguarded. With no `error.tsx`
+ * anywhere under `src/app`, that is a bare 500 on the first CFP link a new
+ * organizer shares with speakers.
+ *
+ * This suite builds the conference document EXACTLY the way provisioning builds
+ * it — no fixture that "looks fresh", the real builder — pushes it through the
+ * real `getConferenceForDomain` boundary, and walks the public CFP page.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactElement } from 'react'
+
+const conferenceFetchMock = vi.fn()
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: { fetch: (...args: unknown[]) => conferenceFetchMock(...args) },
+  clientReadUncached: {
+    fetch: (...args: unknown[]) => conferenceFetchMock(...args),
+  },
+}))
+
+vi.mock('next/cache', () => ({
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
+}))
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn(async () => new Headers({ host: FRESH_HOST })),
+}))
+
+vi.mock('@/lib/gallery/sanity', () => ({
+  getGalleryImages: vi.fn(async () => []),
+  getFeaturedGalleryImages: vi.fn(async () => []),
+}))
+
+vi.mock('@/lib/sponsor-crm/sanity', () => ({
+  getPublicSponsorsForConference: vi.fn(async () => []),
+}))
+
+import { buildOnboardingDocuments } from '@/lib/onboarding/create'
+import { getConferenceForDomain } from '@/lib/conference/sanity'
+import CFPPage from '@/app/(main)/cfp/page'
+
+const FRESH_HOST = 'brand-new.konf.run'
+
+/**
+ * The conference document a concierge provisioning run actually writes. Built
+ * by the real `buildOnboardingDocuments` so this fixture can never drift away
+ * from what production creates — if provisioning starts seeding formats, this
+ * test stops being about an empty tenant and should be updated deliberately.
+ */
+function provisionedConferenceDocument() {
+  let key = 0
+  const { conference } = buildOnboardingDocuments(
+    {
+      organization: {
+        name: 'Brand New Events',
+        slug: 'brand-new-events',
+        contactEmail: 'hello@brand-new.example',
+      },
+      conference: {
+        title: 'Brand New Conf',
+        city: 'Bergen',
+        country: 'Norway',
+      },
+      organizer: { name: 'Ada Organizer', email: 'ada@brand-new.example' },
+      domains: [FRESH_HOST],
+    },
+    {
+      organizationId: 'org-fresh',
+      conferenceId: 'conf-fresh',
+      speakerId: 'speaker-fresh',
+      mintKey: () => `key-${++key}`,
+    },
+    null,
+  )
+  return conference
+}
+
+/**
+ * `/cfp` is a server component wrapping ONE async child (`CachedCFPContent`).
+ * Awaiting the page yields that child's element; awaiting the child gives a
+ * tree of ordinary components that `renderToStaticMarkup` can finish. Anything
+ * that throws while dereferencing the conference throws right here — which is
+ * the whole point of the test.
+ */
+async function renderCfpPage(): Promise<string> {
+  const pageElement = (await CFPPage()) as ReactElement<{ domain: string }>
+  const inner = await (
+    pageElement.type as (props: {
+      domain: string
+    }) => Promise<ReactElement | null>
+  )(pageElement.props)
+  return inner === null ? '' : renderToStaticMarkup(inner)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('a freshly provisioned tenant (no formats, no topics)', () => {
+  it('provisioning really does omit formats and topics', () => {
+    // Guards the premise: if this ever fails, the rest of the suite is
+    // testing a scenario that no longer exists.
+    const doc = provisionedConferenceDocument()
+    expect(doc.formats).toBeUndefined()
+    expect(doc.topics).toBeUndefined()
+  })
+
+  it('the conference boundary hands out arrays, not undefined', async () => {
+    conferenceFetchMock.mockResolvedValue(provisionedConferenceDocument())
+
+    const { conference } = await getConferenceForDomain(FRESH_HOST, {
+      topics: true,
+    })
+
+    expect(Array.isArray(conference.formats)).toBe(true)
+    expect(conference.formats).toHaveLength(0)
+    expect(Array.isArray(conference.topics)).toBe(true)
+    expect(conference.topics).toHaveLength(0)
+    // `domains` is also optional at provisioning time (an operator may create a
+    // tenant with none) and is typed non-optional — same crash class.
+    expect(Array.isArray(conference.domains)).toBe(true)
+  })
+
+  it('renders the public CFP page WITHOUT throwing', async () => {
+    conferenceFetchMock.mockResolvedValue(provisionedConferenceDocument())
+
+    const html = await renderCfpPage()
+
+    expect(html).toContain('Call for Presentations')
+    expect(html).toContain('Brand New Conf')
+  })
+
+  it('does not invite a submission it cannot accept', async () => {
+    conferenceFetchMock.mockResolvedValue(provisionedConferenceDocument())
+
+    const html = await renderCfpPage()
+
+    // No trap: a proposal REQUIRES a format (`validateProposalForm`) and this
+    // conference offers none, so the CTA must not be there.
+    expect(html).not.toContain('Submit your proposal')
+    expect(html).not.toContain('href="/cfp/proposal"')
+    expect(html).toContain('Submissions are not open yet')
+    // Honest copy points at the organizers, which provisioning defaults to the
+    // org contact address.
+    expect(html).toContain('hello@brand-new.example')
+    // And no heading over an empty list.
+    expect(html).not.toContain('Presentation formats')
+    expect(html).not.toContain('Workshop formats')
+  })
+
+  it('still shows placeholder topics rather than crashing on an absent list', async () => {
+    conferenceFetchMock.mockResolvedValue(provisionedConferenceDocument())
+
+    const html = await renderCfpPage()
+
+    expect(html).toContain('Engineering practice')
+  })
+})
+
+describe('a configured tenant keeps the submit CTA', () => {
+  it('advertises formats and links to the proposal form', async () => {
+    conferenceFetchMock.mockResolvedValue({
+      ...provisionedConferenceDocument(),
+      cfpStartDate: '2026-01-01',
+      cfpEndDate: '2026-12-01',
+      formats: ['lightning_10', 'presentation_25', 'workshop_120'],
+    })
+
+    const html = await renderCfpPage()
+
+    expect(html).toContain('Submit your proposal')
+    expect(html).toContain('href="/cfp/proposal"')
+    expect(html).toContain('Presentation formats')
+    expect(html).toContain('Workshop formats')
+    expect(html).not.toContain('Submissions are not open yet')
+  })
+})

--- a/__tests__/app/cfp/fresh-tenant.test.tsx
+++ b/__tests__/app/cfp/fresh-tenant.test.tsx
@@ -55,7 +55,7 @@ const FRESH_HOST = 'brand-new.konf.run'
  * from what production creates — if provisioning starts seeding formats, this
  * test stops being about an empty tenant and should be updated deliberately.
  */
-function provisionedConferenceDocument() {
+function provisionedConferenceDocument(domains: string[] = [FRESH_HOST]) {
   let key = 0
   const { conference } = buildOnboardingDocuments(
     {
@@ -70,7 +70,7 @@ function provisionedConferenceDocument() {
         country: 'Norway',
       },
       organizer: { name: 'Ada Organizer', email: 'ada@brand-new.example' },
-      domains: [FRESH_HOST],
+      domains,
     },
     {
       organizationId: 'org-fresh',
@@ -111,6 +111,22 @@ describe('a freshly provisioned tenant (no formats, no topics)', () => {
     const doc = provisionedConferenceDocument()
     expect(doc.formats).toBeUndefined()
     expect(doc.topics).toBeUndefined()
+  })
+
+  it('provisioning omits domains too when the operator supplies none', () => {
+    // `create.ts` writes `domains` conditionally, so an operator-created tenant
+    // with no domain yet produces a document missing a THIRD non-optional array
+    // field — the same crash class, one field over.
+    expect(provisionedConferenceDocument([]).domains).toBeUndefined()
+  })
+
+  it('the boundary normalises a document with no domains end to end', async () => {
+    conferenceFetchMock.mockResolvedValue(provisionedConferenceDocument([]))
+
+    const { conference } = await getConferenceForDomain(FRESH_HOST)
+
+    expect(conference.domains).toEqual([])
+    expect(conference.formats).toEqual([])
   })
 
   it('the conference boundary hands out arrays, not undefined', async () => {

--- a/__tests__/app/cfp/proposal-page-gate.test.tsx
+++ b/__tests__/app/cfp/proposal-page-gate.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * @vitest-environment node
+ *
+ * The SUBMIT page's honesty gate. A conference whose CFP window is open but
+ * which has configured NO session formats cannot accept a proposal — a proposal
+ * must carry a format (`validateProposalForm`) and the form only offers the
+ * formats the conference configured. Provisioning creates every new tenant in
+ * exactly that state (`@/lib/onboarding/create.ts`), so a speaker following the
+ * CFP link must be told that, not handed a form with an empty dropdown.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactElement } from 'react'
+
+const getConferenceMock = vi.fn()
+const getSpeakerMock = vi.fn()
+const getProposalsMock = vi.fn()
+
+vi.mock('next/server', () => ({ connection: vi.fn(async () => {}) }))
+vi.mock('next/headers', () => ({
+  headers: vi.fn(async () => new Headers({ 'x-url': 'https://conf/cfp' })),
+}))
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(() => {
+    throw new Error('unexpected redirect')
+  }),
+}))
+vi.mock('@/lib/auth', () => ({
+  getAuthSession: vi.fn(async () => ({
+    speaker: { _id: 'speaker-1', email: 'ada@example.com' },
+  })),
+}))
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    getConferenceMock(...args),
+}))
+vi.mock('@/lib/speaker/sanity', () => ({
+  getSpeaker: (...args: unknown[]) => getSpeakerMock(...args),
+}))
+vi.mock('@/lib/proposal/data/sanity', () => ({
+  getProposals: (...args: unknown[]) => getProposalsMock(...args),
+}))
+
+import NewProposalPage from '@/app/(cfp)/cfp/proposal/page'
+
+/** An open window around the frozen clock set in each test. */
+const OPEN_CFP = { cfpStartDate: '2026-01-01', cfpEndDate: '2026-12-01' }
+
+function conference(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: 'conf-1',
+    title: 'Brand New Conf',
+    contactEmail: 'hello@brand-new.example',
+    // The provisioned shape: normalised to `[]` by the conference boundary.
+    formats: [],
+    topics: [],
+    ...OPEN_CFP,
+    ...overrides,
+  }
+}
+
+async function renderPage(): Promise<string> {
+  const element = (await NewProposalPage({
+    searchParams: Promise.resolve({}),
+  })) as ReactElement
+  return renderToStaticMarkup(element)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-06-01T12:00:00Z'))
+  getSpeakerMock.mockResolvedValue({
+    speaker: { _id: 'speaker-1', name: 'Ada', email: 'ada@example.com' },
+    err: null,
+  })
+  getProposalsMock.mockResolvedValue({ proposals: [], proposalsError: null })
+})
+
+describe('the CFP submit page with no configured formats', () => {
+  it('explains that submissions are not open yet instead of rendering the form', async () => {
+    getConferenceMock.mockResolvedValue({
+      conference: conference(),
+      error: null,
+    })
+
+    const html = await renderPage()
+
+    expect(html).toContain('Submissions Not Open Yet')
+    expect(html).toContain('session formats have not been announced')
+    expect(html).toContain('hello@brand-new.example')
+    // Not the pre-existing closed-window message — the window IS open.
+    expect(html).not.toContain('The Call for Papers is currently closed')
+  })
+
+  it('still reports a genuinely closed CFP as closed', async () => {
+    getConferenceMock.mockResolvedValue({
+      conference: conference({
+        cfpStartDate: '2025-01-01',
+        cfpEndDate: '2025-02-01',
+        formats: ['lightning_10'],
+      }),
+      error: null,
+    })
+
+    const html = await renderPage()
+
+    expect(html).toContain('CFP Closed')
+    expect(html).not.toContain('Submissions Not Open Yet')
+  })
+})

--- a/__tests__/components/cfp/proposal-empty-formats.test.tsx
+++ b/__tests__/components/cfp/proposal-empty-formats.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment node
+ *
+ * The SPEAKER-FACING leaves of the proposal path, fed a conference that has not
+ * configured any formats. Both used to dereference the field directly —
+ * `conference.formats.map(...)` in the sidebar, `allowedFormats.includes(...)`
+ * in the details form — so a freshly provisioned tenant (which is created with
+ * no `formats`; see `@/lib/onboarding/create.ts`) crashed them.
+ *
+ * These are deliberately tested WITHOUT the conference data boundary in the
+ * loop: both take a `Conference` as a prop and are rendered from Storybook and
+ * from admin surfaces that build their own objects, so they must survive an
+ * unnormalised one on their own.
+ */
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { ProposalGuidanceSidebar } from '@/components/cfp/ProposalGuidanceSidebar'
+import { ProposalDetailsForm } from '@/components/proposal/ProposalDetailsForm'
+import type { Conference } from '@/lib/conference/types'
+import {
+  Format,
+  Language,
+  Level,
+  type ProposalInput,
+} from '@/lib/proposal/types'
+
+/** No `formats`, no `topics` — exactly what provisioning writes. */
+const FRESH_CONFERENCE = {
+  _id: 'conf-fresh',
+  title: 'Brand New Conf',
+} as Conference
+
+const CONFIGURED_CONFERENCE = {
+  ...FRESH_CONFERENCE,
+  formats: [Format.lightning_10, Format.presentation_25],
+} as Conference
+
+const PROPOSAL: ProposalInput = {
+  title: '',
+  language: Language.norwegian,
+  description: [],
+  format: Format.lightning_10,
+  level: Level.beginner,
+  audiences: [],
+  topics: [],
+  outline: '',
+  tos: false,
+}
+
+describe('ProposalGuidanceSidebar with no configured formats', () => {
+  it('renders without throwing', () => {
+    const html = renderToStaticMarkup(
+      <ProposalGuidanceSidebar conference={FRESH_CONFERENCE} />,
+    )
+    expect(html).toContain('Proposal Tips')
+  })
+
+  it('omits the Accepted Formats card rather than showing an empty one', () => {
+    const html = renderToStaticMarkup(
+      <ProposalGuidanceSidebar conference={FRESH_CONFERENCE} />,
+    )
+    expect(html).not.toContain('Accepted Formats')
+  })
+
+  it('omits the Important Dates card when the conference has no dates', () => {
+    // Same class of emptiness: every date on a provisioned conference is
+    // absent, which left a heading over an empty list.
+    const html = renderToStaticMarkup(
+      <ProposalGuidanceSidebar conference={FRESH_CONFERENCE} />,
+    )
+    expect(html).not.toContain('Important Dates')
+
+    const withDates = renderToStaticMarkup(
+      <ProposalGuidanceSidebar
+        conference={
+          { ...FRESH_CONFERENCE, cfpEndDate: '2026-06-01' } as Conference
+        }
+      />,
+    )
+    expect(withDates).toContain('Important Dates')
+    expect(withDates).toContain('CFP Closes')
+  })
+
+  it('still lists formats when the conference has them', () => {
+    const html = renderToStaticMarkup(
+      <ProposalGuidanceSidebar conference={CONFIGURED_CONFERENCE} />,
+    )
+    expect(html).toContain('Accepted Formats')
+    expect(html).toContain('Lightning Talk')
+  })
+})
+
+describe('ProposalDetailsForm with no allowed formats', () => {
+  it('renders an empty Format dropdown instead of crashing', () => {
+    const html = renderToStaticMarkup(
+      <ProposalDetailsForm
+        proposal={PROPOSAL}
+        setProposal={() => {}}
+        conference={FRESH_CONFERENCE}
+      />,
+    )
+    expect(html).toContain('Presentation Format')
+    expect(html).not.toContain('Lightning Talk')
+  })
+
+  it('offers the allowed formats when the conference has them', () => {
+    const html = renderToStaticMarkup(
+      <ProposalDetailsForm
+        proposal={PROPOSAL}
+        setProposal={() => {}}
+        conference={CONFIGURED_CONFERENCE}
+        allowedFormats={CONFIGURED_CONFERENCE.formats}
+      />,
+    )
+    expect(html).toContain('Lightning Talk')
+  })
+})

--- a/src/app/(cfp)/cfp/proposal/page.tsx
+++ b/src/app/(cfp)/cfp/proposal/page.tsx
@@ -67,14 +67,26 @@ export default async function NewProposalPage({
   }
 
   if (conference) {
-    const { isCfpOpen } = await import('@/lib/conference/state')
+    const { isCfpOpen, hasSubmittableFormats } =
+      await import('@/lib/conference/state')
+    const contactEmail = conference.cfpEmail || conference.contactEmail
     if (!isCfpOpen(conference)) {
-      const contactEmail = conference.cfpEmail || conference.contactEmail
       loadingError = {
         type: 'CFP Closed',
         message: contactEmail
           ? `The Call for Papers is currently closed. We'd love to have you speak at our next conference! Please check back when the next CFP opens, or reach out to ${contactEmail} if you have any questions.`
           : 'The Call for Papers is currently closed. We&apos;d love to have you speak at our next conference! Please check back when the next CFP opens, or contact the organizers if you have any questions.',
+      }
+    } else if (!hasSubmittableFormats(conference)) {
+      // The CFP window is open but the organizers have not configured a single
+      // session format — and a proposal cannot be submitted without one
+      // (`validateProposalForm`). Say so, instead of rendering a form whose
+      // Format dropdown has no options.
+      loadingError = {
+        type: 'Submissions Not Open Yet',
+        message: contactEmail
+          ? `The organizers are still setting up the Call for Papers — the session formats have not been announced yet, so proposals cannot be submitted. Please check back soon, or reach out to ${contactEmail} if you have any questions.`
+          : 'The organizers are still setting up the Call for Papers — the session formats have not been announced yet, so proposals cannot be submitted. Please check back soon.',
       }
     }
   }

--- a/src/app/(main)/cfp/page.tsx
+++ b/src/app/(main)/cfp/page.tsx
@@ -5,8 +5,10 @@ import {
   ClipboardDocumentCheckIcon,
 } from '@heroicons/react/20/solid'
 import { Button } from '@/components/Button'
+import { SubmissionsNotOpenNotice } from '@/components/cfp/SubmissionsNotOpenNotice'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
 import { isUnknownHost } from '@/lib/conference/guard'
+import { hasSubmittableFormats } from '@/lib/conference/state'
 import { formatDate } from '@/lib/time'
 import { Topic } from '@/lib/topic/types'
 import { formats } from '@/lib/proposal/types'
@@ -59,6 +61,29 @@ async function CachedCFPContent({ domain }: { domain: string }) {
   const hasWorkshops =
     Array.isArray(workshopFormats) && workshopFormats.length > 0
 
+  // A CFP with NO configured formats cannot receive anything: a proposal must
+  // carry a format, and the submit form only offers what the conference
+  // configured. Every freshly provisioned tenant starts here
+  // (@/lib/onboarding/create.ts), so this page must not hand a speaker a
+  // "Submit your proposal" button that leads to an empty dropdown.
+  const acceptingSubmissions = hasSubmittableFormats(conference)
+  const cfpContactEmail = conference.cfpEmail || conference.contactEmail
+
+  // Fact rows are OMITTED rather than rendered empty: an unconfigured
+  // "Presentation formats" heading over nothing reads as a broken page, and a
+  // talks-only conference should not advertise a blank workshop track.
+  const factRows: [string, string[]][] = [
+    ['Languages', ['Norwegian', 'English']],
+  ]
+  const namedTalkFormats = talkFormats.filter((f): f is string => !!f)
+  if (namedTalkFormats.length > 0) {
+    factRows.push(['Presentation formats', namedTalkFormats])
+  }
+  const namedWorkshopFormats = workshopFormats.filter((f): f is string => !!f)
+  if (namedWorkshopFormats.length > 0) {
+    factRows.push(['Workshop formats', namedWorkshopFormats])
+  }
+
   const datesToRemember = [
     {
       name: 'CFP Close',
@@ -99,16 +124,16 @@ async function CachedCFPContent({ domain }: { domain: string }) {
         {conference.description ? <p>{conference.description}</p> : null}
       </div>
 
-      <Button href="/cfp/proposal" variant="warning" className="mt-10 w-full">
-        Submit your proposal
-      </Button>
+      {acceptingSubmissions ? (
+        <Button href="/cfp/proposal" variant="warning" className="mt-10 w-full">
+          Submit your proposal
+        </Button>
+      ) : (
+        <SubmissionsNotOpenNotice contactEmail={cfpContactEmail} />
+      )}
 
       <dl className="mt-10 grid grid-cols-2 gap-x-10 gap-y-6 sm:mt-16 sm:gap-x-16 sm:gap-y-10 sm:text-center lg:auto-cols-auto lg:grid-flow-col lg:grid-cols-none lg:justify-start lg:text-left">
-        {[
-          ['Languages', ['Norwegian', 'English']],
-          ['Presentation formats', talkFormats],
-          ['Workshop formats', workshopFormats],
-        ].map(([name, value]) => (
+        {factRows.map(([name, value]) => (
           <div key={String(name)}>
             <dt className="font-jetbrains text-sm text-brand-cloud-blue dark:text-blue-400">
               {name}

--- a/src/components/admin/ActivationChecklist.stories.tsx
+++ b/src/components/admin/ActivationChecklist.stories.tsx
@@ -56,6 +56,7 @@ const NEARLY_DONE: ConferenceForActivation = {
   endDate: '2026-05-02',
   cfpStartDate: '2026-01-01',
   cfpEndDate: '2026-03-01',
+  formats: ['lightning_10', 'presentation_25'],
   topics: [{ _id: 't1', title: 'Kubernetes' }],
   contactEmail: 'hi@example.com',
   cfpEmail: 'cfp@example.com',

--- a/src/components/cfp/ProposalForm.tsx
+++ b/src/components/cfp/ProposalForm.tsx
@@ -40,7 +40,8 @@ export function ProposalForm({
   proposalId?: string
   userEmail: string
   conference: Conference
-  allowedFormats: Format[]
+  /** See `ProposalDetailsForm` — optional, a conference may offer no formats. */
+  allowedFormats?: Format[]
   currentUserSpeaker: Speaker
   mode?: 'user' | 'admin' | 'readOnly'
   initialStatus?: Status

--- a/src/components/cfp/ProposalGuidanceSidebar.stories.tsx
+++ b/src/components/cfp/ProposalGuidanceSidebar.stories.tsx
@@ -158,6 +158,23 @@ export const ManyTopics: Story = {
   },
 }
 
+/**
+ * A FRESHLY PROVISIONED tenant: `@/lib/onboarding/create.ts` writes neither
+ * `formats` nor `topics`, and the conference projection is a bare `...` spread,
+ * so both arrive `undefined` rather than `[]`. This used to throw on
+ * `conference.formats.map`. Both cards are now omitted, so the sidebar degrades
+ * to dates and guidance instead of showing empty headings.
+ */
+export const FreshlyProvisionedTenant: Story = {
+  args: {
+    conference: {
+      _id: 'conf-fresh',
+      title: 'Brand New Conf',
+      organizer: 'Brand New Events',
+    } as unknown as Conference,
+  },
+}
+
 export const NoTopics: Story = {
   args: {
     conference: createMockConference({

--- a/src/components/cfp/ProposalGuidanceSidebar.tsx
+++ b/src/components/cfp/ProposalGuidanceSidebar.tsx
@@ -12,48 +12,56 @@ interface ProposalGuidanceSidebarProps {
 export function ProposalGuidanceSidebar({
   conference,
 }: ProposalGuidanceSidebarProps) {
+  // Every date here is optional and a freshly provisioned conference has NONE
+  // of them, which rendered an "Important Dates" heading over an empty list.
+  const hasImportantDates = Boolean(
+    conference.cfpEndDate || conference.cfpNotifyDate || conference.startDate,
+  )
+
   return (
     <div className="space-y-6">
-      <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
-          Important Dates
-        </h3>
-        <dl className="mt-2 space-y-2 text-sm">
-          {conference.cfpEndDate && (
-            <div>
-              <dt className="font-medium text-gray-900 dark:text-white">
-                CFP Closes
-              </dt>
-              <dd className="text-gray-700 dark:text-gray-300">
-                {formatConferenceDateLong(conference.cfpEndDate)}
-              </dd>
-            </div>
-          )}
-          {conference.cfpNotifyDate && (
-            <div>
-              <dt className="font-medium text-gray-900 dark:text-white">
-                Notifications
-              </dt>
-              <dd className="text-gray-700 dark:text-gray-300">
-                {formatConferenceDateLong(conference.cfpNotifyDate)}
-              </dd>
-            </div>
-          )}
-          {conference.startDate && (
-            <div>
-              <dt className="font-medium text-gray-900 dark:text-white">
-                Conference
-              </dt>
-              <dd className="text-gray-700 dark:text-gray-300">
-                {formatConferenceDateLong(conference.startDate)}
-                {conference.endDate &&
-                  conference.endDate !== conference.startDate &&
-                  ` - ${formatConferenceDateLong(conference.endDate)}`}
-              </dd>
-            </div>
-          )}
-        </dl>
-      </div>
+      {hasImportantDates && (
+        <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+            Important Dates
+          </h3>
+          <dl className="mt-2 space-y-2 text-sm">
+            {conference.cfpEndDate && (
+              <div>
+                <dt className="font-medium text-gray-900 dark:text-white">
+                  CFP Closes
+                </dt>
+                <dd className="text-gray-700 dark:text-gray-300">
+                  {formatConferenceDateLong(conference.cfpEndDate)}
+                </dd>
+              </div>
+            )}
+            {conference.cfpNotifyDate && (
+              <div>
+                <dt className="font-medium text-gray-900 dark:text-white">
+                  Notifications
+                </dt>
+                <dd className="text-gray-700 dark:text-gray-300">
+                  {formatConferenceDateLong(conference.cfpNotifyDate)}
+                </dd>
+              </div>
+            )}
+            {conference.startDate && (
+              <div>
+                <dt className="font-medium text-gray-900 dark:text-white">
+                  Conference
+                </dt>
+                <dd className="text-gray-700 dark:text-gray-300">
+                  {formatConferenceDateLong(conference.startDate)}
+                  {conference.endDate &&
+                    conference.endDate !== conference.startDate &&
+                    ` - ${formatConferenceDateLong(conference.endDate)}`}
+                </dd>
+              </div>
+            )}
+          </dl>
+        </div>
+      )}
 
       <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800/50 dark:bg-blue-900/20">
         <h3 className="text-sm font-semibold text-blue-900 dark:text-blue-200">
@@ -67,21 +75,30 @@ export function ProposalGuidanceSidebar({
         </ul>
       </div>
 
-      <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
-          Accepted Formats
-        </h3>
-        <div className="mt-2 space-y-1.5">
-          {conference.formats.map((format) => (
-            <div
-              key={format}
-              className="text-sm text-gray-700 dark:text-gray-300"
-            >
-              {formats.get(format)}
-            </div>
-          ))}
+      {/*
+        Same shape as the Topics card below: a conference that has not
+        configured formats yet (every FRESHLY PROVISIONED tenant — see
+        @/lib/onboarding/create.ts) gets no card at all, rather than an
+        "Accepted Formats" heading over nothing. The length test is also what
+        keeps `.map` off an undefined `formats`.
+      */}
+      {conference.formats && conference.formats.length > 0 && (
+        <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+            Accepted Formats
+          </h3>
+          <div className="mt-2 space-y-1.5">
+            {conference.formats.map((format) => (
+              <div
+                key={format}
+                className="text-sm text-gray-700 dark:text-gray-300"
+              >
+                {formats.get(format)}
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
 
       {conference.topics && conference.topics.length > 0 && (
         <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">

--- a/src/components/cfp/SubmissionsNotOpenNotice.stories.tsx
+++ b/src/components/cfp/SubmissionsNotOpenNotice.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { SubmissionsNotOpenNotice } from './SubmissionsNotOpenNotice'
+
+/**
+ * Replaces the "Submit your proposal" CTA on the public `/cfp` page when the
+ * conference has configured no session formats — the state every freshly
+ * provisioned tenant starts in. Honest copy beats a button that leads to a
+ * form with an empty format dropdown.
+ */
+const meta = {
+  title: 'Systems/Proposals/SubmissionsNotOpenNotice',
+  component: SubmissionsNotOpenNotice,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SubmissionsNotOpenNotice>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const WithContactEmail: Story = {
+  args: { contactEmail: 'cfp@brand-new.example' },
+}
+
+/** No contact address configured — the offer to email is simply dropped. */
+export const WithoutContactEmail: Story = {
+  args: {},
+}

--- a/src/components/cfp/SubmissionsNotOpenNotice.tsx
+++ b/src/components/cfp/SubmissionsNotOpenNotice.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link'
+
+/**
+ * Shown on the public CFP page IN PLACE OF the "Submit your proposal" button
+ * when the conference has not configured a single session format.
+ *
+ * A proposal must carry a format (`validateProposalForm`) and the submit form
+ * only offers the formats the conference configured, so a CTA here would lead
+ * a speaker to an empty dropdown. Every freshly provisioned tenant starts in
+ * this state — see `@/lib/onboarding/create.ts`.
+ */
+export function SubmissionsNotOpenNotice({
+  contactEmail,
+}: {
+  /** CFP or general contact address; omitted → the offer to email is dropped. */
+  contactEmail?: string
+}) {
+  return (
+    <div
+      role="status"
+      className="mt-10 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/20"
+    >
+      <h2 className="font-space-grotesk text-lg font-semibold text-amber-900 dark:text-amber-200">
+        Submissions are not open yet
+      </h2>
+      <p className="font-inter mt-2 text-base text-amber-800 dark:text-amber-300">
+        The organizers are still putting the call for presentations together —
+        the session formats have not been announced. Please check back soon
+        {contactEmail ? (
+          <>
+            , or reach out to{' '}
+            <Link
+              href={`mailto:${contactEmail}`}
+              className="underline hover:no-underline"
+            >
+              {contactEmail}
+            </Link>{' '}
+            if you have questions
+          </>
+        ) : null}
+        .
+      </p>
+    </div>
+  )
+}

--- a/src/components/proposal/ProposalDetailsForm.tsx
+++ b/src/components/proposal/ProposalDetailsForm.tsx
@@ -33,13 +33,20 @@ export function ProposalDetailsForm({
   proposal,
   setProposal,
   conference,
-  allowedFormats,
+  allowedFormats = [],
   readOnly = false,
 }: {
   proposal: ProposalInput
   setProposal: (proposal: ProposalInput) => void
   conference: Conference
-  allowedFormats: Format[]
+  /**
+   * The formats this conference accepts. OPTIONAL — matching the already
+   * optional contract on the admin `ProposalsFilter`/`ProposalsList` — because
+   * a conference that has not configured formats yet has none to offer. An
+   * absent value must render an empty Format dropdown, never crash
+   * `allowedFormats.includes` on `undefined`.
+   */
+  allowedFormats?: Format[]
   readOnly?: boolean
 }) {
   const [title, setTitle] = useState(proposal?.title ?? '')

--- a/src/lib/conference/normalize.test.ts
+++ b/src/lib/conference/normalize.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeConference } from './normalize'
+import type { Conference } from './types'
+import { Format } from '@/lib/proposal/types'
+
+describe('normalizeConference', () => {
+  it('turns every absent required array into an empty array', () => {
+    // The shape a freshly provisioned tenant produces: the projection is a bare
+    // `...` spread, so fields the document does not have are simply missing.
+    const conference = normalizeConference({
+      _id: 'conf-1',
+      title: 'Brand New Conf',
+    } as Conference)
+
+    expect(conference.formats).toEqual([])
+    expect(conference.topics).toEqual([])
+    expect(conference.domains).toEqual([])
+    expect(conference.organizers).toEqual([])
+  })
+
+  it('leaves configured values untouched', () => {
+    const formats = [Format.lightning_10, Format.workshop_120]
+    const conference = normalizeConference({
+      _id: 'conf-1',
+      formats,
+      domains: ['example.com'],
+    } as Conference)
+
+    expect(conference.formats).toBe(formats)
+    expect(conference.domains).toEqual(['example.com'])
+  })
+
+  it('replaces a non-array value rather than trusting the type', () => {
+    // Sanity is schemaless at read time — a legacy or hand-edited document can
+    // carry a scalar where the schema says array, which would blow up on
+    // `.filter` exactly like `undefined` does.
+    const conference = normalizeConference({
+      _id: 'conf-1',
+      formats: 'lightning_10',
+    } as unknown as Conference)
+
+    expect(conference.formats).toEqual([])
+  })
+
+  it('is idempotent and returns the same object', () => {
+    const input = { _id: 'conf-1' } as Conference
+    const once = normalizeConference(input)
+    const twice = normalizeConference(once)
+
+    expect(twice).toBe(input)
+    expect(twice.formats).toEqual([])
+  })
+
+  it('tolerates the empty unknown-host conference', () => {
+    const conference = normalizeConference({} as Conference)
+    expect(conference.formats).toEqual([])
+    // Still an unknown host — normalising arrays must not fabricate an `_id`.
+    expect(conference._id).toBeUndefined()
+  })
+})

--- a/src/lib/conference/normalize.ts
+++ b/src/lib/conference/normalize.ts
@@ -1,0 +1,51 @@
+import type { Conference } from './types'
+
+/**
+ * The conference fields the `Conference` TYPE declares as required arrays but
+ * that a real `conference` DOCUMENT is routinely missing.
+ *
+ * The main conference projection is a bare `...` spread, so an absent field
+ * comes back as `undefined` rather than `[]` — and
+ * `@/lib/onboarding/create.ts` deliberately provisions a brand-new tenant with
+ * NO `formats`, NO `topics` and (when the operator supplies none) no
+ * `domains`. The type says `Format[]`, the data says `undefined`, and the
+ * first `.filter` / `.map` / `.includes` on a public page is a TypeError — a
+ * bare 500 on the first CFP link a new organizer shares (there is no
+ * `error.tsx` boundary in this app).
+ *
+ * KEEP THIS LIST HONEST: only fields the type declares NON-optional belong
+ * here. A field typed `foo?: T[]` is already telling every caller to check.
+ */
+const REQUIRED_ARRAY_FIELDS = [
+  'formats',
+  'topics',
+  'domains',
+  'organizers',
+] as const satisfies readonly (keyof Conference)[]
+
+/**
+ * Make a resolved conference match the shape its type promises.
+ *
+ * Applied ONCE at the data boundary (`getConferenceForDomain`) rather than as
+ * a `?? []` at every read: there are dozens of reads across public pages,
+ * admin surfaces, components and stories, and every one of them is a place a
+ * future change can forget the guard. Normalising where the document enters
+ * the app makes the non-optional array types TRUE for every consumer instead
+ * of merely usually-true.
+ *
+ * Mutates in place (and returns the same object) — the caller already mutates
+ * the fetched document to attach sponsors and gallery images, and Next's
+ * `'use cache'` hands back a freshly deserialized object per call.
+ */
+export function normalizeConference<T extends Conference>(conference: T): T {
+  if (!conference) return conference
+  for (const field of REQUIRED_ARRAY_FIELDS) {
+    if (!Array.isArray(conference[field])) {
+      // The cast is confined to this loop: the key is proven to be a
+      // `Conference` key above, and `[]` is assignable to every field in the
+      // list — TypeScript just cannot narrow a union-keyed write.
+      ;(conference as Record<string, unknown>)[field] = []
+    }
+  }
+  return conference
+}

--- a/src/lib/conference/normalize.ts
+++ b/src/lib/conference/normalize.ts
@@ -36,6 +36,13 @@ const REQUIRED_ARRAY_FIELDS = [
  * Mutates in place (and returns the same object) — the caller already mutates
  * the fetched document to attach sponsors and gallery images, and Next's
  * `'use cache'` hands back a freshly deserialized object per call.
+ *
+ * DELIBERATELY OUTSIDE THE BOUNDARY: two other fetchers in `./sanity.ts` —
+ * `getConferencesForWeeklyUpdate` and `getConferenceByCheckinEventId` — do NOT
+ * pass through here. Their only consumers (the weekly-update Slack cron and the
+ * ticket-sold webhook) never touch the four arrays, so normalising them would
+ * be ceremony rather than safety. If a consumer of either ever starts reading
+ * `formats`/`topics`/`domains`/`organizers`, route it through this function.
  */
 export function normalizeConference<T extends Conference>(conference: T): T {
   if (!conference) return conference

--- a/src/lib/conference/sanity.ts
+++ b/src/lib/conference/sanity.ts
@@ -1,6 +1,7 @@
 import { clientWrite, clientReadUncached } from '../sanity/client'
 import { Conference } from './types'
 import { normalizeDomain } from './domains'
+import { normalizeConference } from './normalize'
 import { isConferenceOver } from './state'
 import { headers } from 'next/headers'
 import { cacheLife, cacheTag } from 'next/cache'
@@ -83,7 +84,7 @@ export async function getConferenceForCurrentDomain({
     })
   } catch (err) {
     const error = err as Error
-    const conference = {} as Conference
+    const conference = normalizeConference({} as Conference)
     return { conference, domain, error }
   }
 }
@@ -387,7 +388,12 @@ export async function getConferenceForDomain(
     }
   }
 
-  return { conference, domain, error }
+  // THE data boundary. Every conference this module hands out — resolved,
+  // unknown-host or errored — leaves here with its non-optional array fields
+  // actually being arrays, so no consumer has to guess. A freshly provisioned
+  // tenant has no `formats` and no `topics` (see @/lib/onboarding/create.ts),
+  // and the public CFP page dereferences both. See ./normalize.ts.
+  return { conference: normalizeConference(conference), domain, error }
 }
 
 /**

--- a/src/lib/conference/state.test.ts
+++ b/src/lib/conference/state.test.ts
@@ -28,7 +28,17 @@ describe('hasSubmittableFormats', () => {
   })
 
   it('is false when the field is absent entirely (a fresh tenant)', () => {
-    expect(hasSubmittableFormats({} as Conference)).toBe(false)
+    // No cast: the parameter type admits an absent `formats`, which is the
+    // whole reason the predicate exists.
+    expect(hasSubmittableFormats({})).toBe(false)
+  })
+
+  it('is false for a non-array value from a legacy document', () => {
+    expect(
+      hasSubmittableFormats({
+        formats: 'lightning_10',
+      } as unknown as Conference),
+    ).toBe(false)
   })
 
   it('is true once a single format is configured', () => {

--- a/src/lib/conference/state.test.ts
+++ b/src/lib/conference/state.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { hasSubmittableFormats, isCfpOpen } from './state'
+import type { Conference } from './types'
+import { Format } from '@/lib/proposal/types'
+
+/** An open CFP window around the frozen "now" used below. */
+const OPEN_WINDOW = {
+  cfpStartDate: '2026-01-01',
+  cfpEndDate: '2026-06-01',
+}
+
+function conference(overrides: Partial<Conference> = {}): Conference {
+  return { _id: 'conf-1', ...OPEN_WINDOW, ...overrides } as Conference
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function freezeInsideWindow() {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-03-01T12:00:00Z'))
+}
+
+describe('hasSubmittableFormats', () => {
+  it('is false for a conference that configured no formats', () => {
+    expect(hasSubmittableFormats(conference({ formats: [] }))).toBe(false)
+  })
+
+  it('is false when the field is absent entirely (a fresh tenant)', () => {
+    expect(hasSubmittableFormats({} as Conference)).toBe(false)
+  })
+
+  it('is true once a single format is configured', () => {
+    expect(
+      hasSubmittableFormats(conference({ formats: [Format.lightning_10] })),
+    ).toBe(true)
+  })
+})
+
+describe('the CFP-open / can-submit split', () => {
+  it('an open window with no formats is open but unsubmittable', () => {
+    freezeInsideWindow()
+    const conf = conference({ formats: [] })
+
+    // The window really is open — this is the trap the predicate exists for:
+    // an "open" CFP that cannot accept a submission, because a proposal must
+    // carry a format. Surfaces that INVITE a new submission must test both.
+    expect(isCfpOpen(conf)).toBe(true)
+    expect(hasSubmittableFormats(conf)).toBe(false)
+  })
+
+  it('does NOT widen isCfpOpen itself', () => {
+    freezeInsideWindow()
+    // The homepage lifecycle stage, the admin phase summary and the
+    // edit/unsubmit gates all read `isCfpOpen`; widening it would silently
+    // change all of them. It stays purely date-based.
+    expect(isCfpOpen(conference({ formats: [] }))).toBe(true)
+    expect(isCfpOpen(conference({}))).toBe(true)
+  })
+
+  it('a closed window is closed regardless of formats', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-09-01T12:00:00Z'))
+    const conf = conference({ formats: [Format.lightning_10] })
+    expect(isCfpOpen(conf)).toBe(false)
+    expect(hasSubmittableFormats(conf)).toBe(true)
+  })
+})

--- a/src/lib/conference/state.ts
+++ b/src/lib/conference/state.ts
@@ -61,6 +61,29 @@ export function isCfpOpen(conference: Conference): boolean {
 }
 
 /**
+ * Whether the conference offers any session format a speaker could submit.
+ *
+ * A proposal MUST carry a format (`validateProposalForm`), and the submit form
+ * only offers the formats this conference configured — so with `formats` empty
+ * there is literally nothing submittable. A freshly provisioned tenant starts
+ * in exactly that state (see `@/lib/onboarding/create.ts`), which makes an
+ * "open" CFP a trap: the page advertises "Submit your proposal" and the form
+ * shows an empty format dropdown.
+ *
+ * DELIBERATELY SEPARATE FROM {@link isCfpOpen} rather than folded into it.
+ * `isCfpOpen` answers a purely date-based question and is consumed by surfaces
+ * that only care about the window — the homepage lifecycle stage, the admin
+ * phase summary, the edit/unsubmit gates on proposals that ALREADY exist.
+ * Widening that predicate would silently change all of them. Pair the two only
+ * on surfaces that invite a NEW submission.
+ */
+export function hasSubmittableFormats(
+  conference: Pick<Conference, 'formats'>,
+): boolean {
+  return Array.isArray(conference.formats) && conference.formats.length > 0
+}
+
+/**
  * Check if the program has been published
  */
 export function isProgramPublished(conference: Conference): boolean {

--- a/src/lib/conference/state.ts
+++ b/src/lib/conference/state.ts
@@ -76,10 +76,16 @@ export function isCfpOpen(conference: Conference): boolean {
  * phase summary, the edit/unsubmit gates on proposals that ALREADY exist.
  * Widening that predicate would silently change all of them. Pair the two only
  * on surfaces that invite a NEW submission.
+ *
+ * The parameter type says `formats?` even though `Conference` declares it
+ * required, because the whole point of this predicate is the case where the
+ * document does NOT have it — a caller holding a not-yet-normalised conference
+ * must be able to ask without a cast. The `Array.isArray` test additionally
+ * covers a legacy document carrying a scalar where the schema says array.
  */
-export function hasSubmittableFormats(
-  conference: Pick<Conference, 'formats'>,
-): boolean {
+export function hasSubmittableFormats(conference: {
+  formats?: Conference['formats']
+}): boolean {
   return Array.isArray(conference.formats) && conference.formats.length > 0
 }
 

--- a/src/lib/settings/activation.test.ts
+++ b/src/lib/settings/activation.test.ts
@@ -17,6 +17,7 @@ const FULLY_LIVE: ConferenceForActivation = {
   endDate: '2026-05-02',
   cfpStartDate: '2026-01-01',
   cfpEndDate: '2026-03-01',
+  formats: ['lightning_10', 'presentation_25'],
   topics: [{ _id: 't1', title: 'Kubernetes' }],
   contactEmail: 'hi@example.com',
   cfpEmail: 'cfp@example.com',
@@ -99,6 +100,44 @@ describe('buildActivationChecklist', () => {
     expect(checklist.allDone).toBe(false)
     expect(checklist.done).toBeGreaterThan(0)
     expect(checklist.done).toBeLessThan(checklist.required)
+  })
+
+  describe('the formats row', () => {
+    // Provisioning creates a tenant with NO formats and defers to "the
+    // activation checklist walks the organizer through CFP configuration" —
+    // which only works if the checklist actually has this row. A proposal
+    // cannot be submitted without a format (`validateProposalForm`), so this is
+    // a launch blocker, not a nicety.
+    it('is outstanding for a freshly provisioned conference', () => {
+      const checklist = buildActivationChecklist({ title: 'Brand New' }, [])
+      const row = rowById(checklist, 'formats')
+      expect(row.done).toBe(false)
+      expect(row.optional).toBeUndefined()
+    })
+
+    it('is outstanding for an explicitly empty formats array', () => {
+      expect(
+        rowById(buildActivationChecklist({ formats: [] }, []), 'formats').done,
+      ).toBe(false)
+    })
+
+    it('is done once a single format is configured', () => {
+      expect(
+        rowById(
+          buildActivationChecklist({ formats: ['lightning_10'] }, []),
+          'formats',
+        ).done,
+      ).toBe(true)
+    })
+
+    it('counts toward required progress and links to the editor', () => {
+      const row = rowById(buildActivationChecklist({}, []), 'formats')
+      expect(row.anchor).toBe('#team-content')
+      const required = buildActivationChecklist({}, []).rows.filter(
+        (r) => !r.optional,
+      )
+      expect(required.map((r) => r.id)).toContain('formats')
+    })
   })
 
   it('the emails row needs all three addresses', () => {

--- a/src/lib/settings/activation.ts
+++ b/src/lib/settings/activation.ts
@@ -73,6 +73,7 @@ export interface ConferenceForActivation {
   cfpStartDate?: string
   cfpEndDate?: string
   topics?: unknown[]
+  formats?: unknown[]
   logoBright?: string
   logoDark?: string
   logomarkBright?: string
@@ -212,6 +213,18 @@ export function buildActivationChecklist(
       done: present(conference.cfpStartDate) && present(conference.cfpEndDate),
       anchor: '#schedule',
       hint: 'Open the CFP by setting its start and end dates.',
+    },
+    {
+      // REQUIRED to submit, not cosmetic: a proposal must carry a format
+      // (`validateProposalForm`), and the CFP page only advertises the formats
+      // this conference configured. A new tenant is provisioned with NONE (see
+      // @/lib/onboarding/create.ts), so without this row the checklist would
+      // report "ready to launch" for a CFP that can accept nothing.
+      id: 'formats',
+      label: 'At least one session format',
+      done: Array.isArray(conference.formats) && conference.formats.length > 0,
+      anchor: '#team-content',
+      hint: 'Choose the session formats speakers may submit (talks, workshops).',
     },
     {
       id: 'topics',

--- a/src/server/routers/proposal.ts
+++ b/src/server/routers/proposal.ts
@@ -349,12 +349,24 @@ export const proposalRouter = router({
           })
         }
 
-        const { isCfpOpen } = await import('@/lib/conference/state')
+        const { isCfpOpen, hasSubmittableFormats } =
+          await import('@/lib/conference/state')
         if (!isCfpOpen(conference)) {
           throw new TRPCError({
             code: 'FORBIDDEN',
             message:
               'The Call for Papers is currently closed. We&apos;d love to have you speak at our next conference! Please check back when the next CFP opens, or contact the organizers if you have any questions.',
+          })
+        }
+        // Closes the loop on the CFP-open-but-unsubmittable trap: the page and
+        // the form already refuse, this refuses a direct call. Only NEW
+        // proposals are gated — editing and unsubmitting an existing proposal
+        // stay on the plain `isCfpOpen` window.
+        if (!hasSubmittableFormats(conference)) {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message:
+              'The organizers have not announced any session formats yet, so proposals cannot be submitted. Please check back soon.',
           })
         }
 

--- a/src/server/routers/proposal.ts
+++ b/src/server/routers/proposal.ts
@@ -358,13 +358,16 @@ export const proposalRouter = router({
               'The Call for Papers is currently closed. We&apos;d love to have you speak at our next conference! Please check back when the next CFP opens, or contact the organizers if you have any questions.',
           })
         }
-        // Closes the loop on the CFP-open-but-unsubmittable trap: the page and
-        // the form already refuse, this refuses a direct call. Scoped to
-        // SUBMISSION, matching the strict-validation gate below — a draft is
-        // explicitly the incomplete-work path, and an API/CLI caller must stay
-        // able to prepare one before the organizers announce their formats.
-        // Editing and unsubmitting an existing proposal stay on the plain
-        // `isCfpOpen` window.
+        // The CFP-open-but-unsubmittable trap, refused server-side for a direct
+        // call that skipped the page and the form. Scoped to SUBMISSION,
+        // matching the strict-validation gate below — a draft is explicitly the
+        // incomplete-work path, and an API/CLI caller must stay able to prepare
+        // one before the organizers announce their formats.
+        //
+        // THIS IS NOT THE ONLY SUBMIT ROUTE. `proposal.action` performs the
+        // draft → submitted transition and carries the SAME gate; a change
+        // here almost certainly belongs there too. Editing and unsubmitting an
+        // existing proposal stay on the plain `isCfpOpen` window.
         if (
           input.status !== Status.draft &&
           !hasSubmittableFormats(conference)
@@ -804,6 +807,28 @@ export const proposalRouter = router({
               code: 'FORBIDDEN',
               message:
                 'Withdrawals are closed within 14 days of the event — please contact the organizers.',
+            })
+          }
+        }
+
+        // THE OTHER SUBMIT ROUTE. `proposal.create` is not the only way a
+        // proposal reaches `submitted` — this action performs the
+        // draft → submitted transition, and it is the path `ProposalForm` uses
+        // for an existing draft. Gating only `create` would leave the trap wide
+        // open: prepare a draft (still legitimate), then submit it here onto a
+        // conference that offers no formats. Applies to organizers too — a
+        // submitted proposal on a formats-less conference is wrong whoever
+        // creates it, and `ProposalDraftSchema` would leave it carrying the
+        // schema default (`lightning_10`), a format the conference never
+        // offered.
+        if (proposal.status === Status.draft && status === Status.submitted) {
+          const { hasSubmittableFormats } =
+            await import('@/lib/conference/state')
+          if (!hasSubmittableFormats(conference)) {
+            throw new TRPCError({
+              code: 'FORBIDDEN',
+              message:
+                'The organizers have not announced any session formats yet, so proposals cannot be submitted. Please check back soon.',
             })
           }
         }

--- a/src/server/routers/proposal.ts
+++ b/src/server/routers/proposal.ts
@@ -359,10 +359,16 @@ export const proposalRouter = router({
           })
         }
         // Closes the loop on the CFP-open-but-unsubmittable trap: the page and
-        // the form already refuse, this refuses a direct call. Only NEW
-        // proposals are gated — editing and unsubmitting an existing proposal
-        // stay on the plain `isCfpOpen` window.
-        if (!hasSubmittableFormats(conference)) {
+        // the form already refuse, this refuses a direct call. Scoped to
+        // SUBMISSION, matching the strict-validation gate below — a draft is
+        // explicitly the incomplete-work path, and an API/CLI caller must stay
+        // able to prepare one before the organizers announce their formats.
+        // Editing and unsubmitting an existing proposal stay on the plain
+        // `isCfpOpen` window.
+        if (
+          input.status !== Status.draft &&
+          !hasSubmittableFormats(conference)
+        ) {
           throw new TRPCError({
             code: 'FORBIDDEN',
             message:


### PR DESCRIPTION
## The bug

`src/lib/onboarding/create.ts:167-171` deliberately provisions a new tenant with **no `formats` and no `topics`**, on the stated reasoning that "the admin surfaces are empty-safe" and "the activation checklist walks the organizer through CFP configuration". Both halves fail.

1. **The public surfaces are not empty-safe.** The conference GROQ is a bare `...` spread, so an absent field comes back `undefined`, not `[]` — while `Conference` declares `formats: Format[]`. `src/app/(main)/cfp/page.tsx:53` did `conference.formats.filter(...)` unguarded. There is **no `error.tsx` anywhere under `src/app`**, so that is a bare Next 500 on the first CFP link a new organizer shares with speakers. The tell: every *admin* call site already guards with `?? []`; the public ones did not.
2. **The checklist had no `formats` row**, so the remedy the comment defers to did not exist — even though a format is genuinely REQUIRED to submit (`src/lib/proposal/validation.ts`).

## Unguarded sites found

Swept `.formats` / `.topics` across `src/app/(main)`, `src/app/(cfp)`, `src/components/cfp`, `src/components/proposal` and the rest of the tree. **Three** genuinely unguarded reads, all public — the same three reported, no more:

| Site | Read |
|---|---|
| `src/app/(main)/cfp/page.tsx:53,56` | `conference.formats.filter(...)` x2 |
| `src/components/cfp/ProposalGuidanceSidebar.tsx:75` | `conference.formats.map(...)` |
| `src/components/proposal/ProposalDetailsForm.tsx:272` | `allowedFormats.includes(...)`, fed `conference.formats` by `(cfp)/cfp/proposal/page.tsx:181` and `[id]/page.tsx:201` |

Everything else already guards (`conference.topics || []`, `conference.formats ?? []`, `Array.isArray(...)`, `talk.topics && ...`). `src/app/(main)/program/page.tsx:122`, the admin settings page, `ProposalManagementModal`, `ProposalsFilter`, `useProposalFilters` etc. were all already safe.

## Where the fix lives, and why

**At the data boundary**, not as `?? []` at every use. `normalizeConference` (`src/lib/conference/normalize.ts`) is applied on every exit path of `getConferenceForDomain`, and coerces the fields the type declares NON-optional but the document routinely lacks: `formats`, `topics`, `domains`, `organizers`.

Rationale: there are dozens of reads across pages, components and stories, and every one is a place a future change can forget the guard. Sprinkling `?? []` leaves the type lying and the next unguarded read one commit away. Normalising where the document enters the app makes the non-optional array types *true* for every consumer instead of merely usually-true. (`domains` is in the list because provisioning also omits it when the operator supplies none — same crash class, one line away.)

Two exceptions keep a local guard, deliberately: `ProposalGuidanceSidebar` and `ProposalDetailsForm` take a `Conference` / `Format[]` as a **prop** and are rendered from Storybook and from admin surfaces that build their own objects, so they never see the boundary. `allowedFormats` becomes optional-with-default, matching the already-optional contract on the admin `ProposalsFilter` / `ProposalsList`.

Two other fetchers in the same module — `getConferencesForWeeklyUpdate` and `getConferenceByCheckinEventId` — are deliberately **outside** the boundary: their only consumers (the weekly-update Slack cron, the ticket-sold webhook) never read the four arrays. That is recorded in the normaliser's doc comment so the next reader does not have to re-derive it.

## Activation checklist

New required `formats` row — "At least one session format" — mirroring the `topics` row (same `#team-content` anchor, which is where the `FormatsEditor` lives). Without it the checklist reported "ready to launch" for a CFP that could accept nothing.

## CFP open with no formats

**Decided in this PR, not deferred** — but *without* widening `isCfpOpen`.

`isCfpOpen` answers a purely date-based question and is consumed by the homepage lifecycle stage, the admin phase summary, and the edit/unsubmit gates on proposals that already exist. Folding a formats requirement into it would silently change all of them. Instead there is a separate `hasSubmittableFormats`, paired with `isCfpOpen` only on surfaces that invite a **new** submission:

- `/cfp` — the "Submit your proposal" CTA is replaced by an honest `SubmissionsNotOpenNotice` ("Submissions are not open yet... the session formats have not been announced", with the CFP/contact address when set). Fact rows with nothing in them are omitted rather than rendered as an empty heading.
- `/cfp/proposal` — a "Submissions Not Open Yet" card instead of a form whose Format dropdown has no options. The pre-existing "CFP Closed" branch is untouched.
- **Both server routes that reach `submitted`:**
  - `proposal.create`, scoped to non-drafts. A draft is the incomplete-work path (it already skips strict validation), so an API/CLI caller can still prepare one before formats are announced.
  - `proposal.action`, on the draft -> submitted transition — the path `ProposalForm` uses for an existing draft, from an edit page with no gate of its own. Without this the draft carve-out above *was* the bypass: prepare a draft, then submit it here, landing a proposal carrying `ProposalDraftSchema`'s default `lightning_10` that the conference never offered. Unlike the 3-proposal cap beside it, this gate has **no organizer carve-out**: the cap is a per-speaker fairness rule an organizer may override, whereas a submitted proposal on a formats-less conference is wrong whoever creates it.

  `update` cannot flip status (no `status` in its schema) and there is no REST proposal endpoint, so those two are the whole surface. Editing and unsubmitting an existing proposal stay on the plain `isCfpOpen` window.

## Also fixed (found by looking at it)

The sidebar's **"Important Dates"** card rendered a heading over an empty list on a fresh tenant — every date it shows is optional and provisioning sets none. Same emptiness class, so it is hidden too. Verified visually with `pnpm shoot` (new `FreshlyProvisionedTenant` story); the configured `Default` story is unchanged.

## Not done here

**No `error.tsx` boundary added** — filed as #825 instead. It is a real finding (any unguarded error in this app is currently a bare 500) but it is an app-wide UX surface that wants its own design pass, and adding it would have masked the very crash this PR is proving is gone.

## Tests

5 new files; **96 tests across the PR's seven test files, up from 59 on the two it modifies — +37**.

The one that matters: `__tests__/app/cfp/fresh-tenant.test.tsx` builds the conference document with the **real `buildOnboardingDocuments`** — not a fixture that looks fresh — pushes it through the real `getConferenceForDomain`, and walks the public CFP page. It also asserts the premise (provisioning really does omit `formats`, `topics`, and `domains` when none are supplied), so it fails loudly if provisioning ever changes.

**Sabotage-proven.** Each guard removed by exact string, matching test confirmed failing, restored, confirmed green:

| Guard | Sabotaged result |
|---|---|
| G1 boundary normaliser (`conference/sanity.ts`) | 5 failed / 3 passed |
| G2 sidebar Accepted-Formats guard | 3 failed / 3 passed |
| G3 `allowedFormats = []` default | 1 failed / 5 passed |
| G4 Important-Dates emptiness guard | 1 failed / 5 passed |
| B1 activation `formats` row | 5 failed / 18 passed |
| B2a public CFP submit-CTA gate | 1 failed / 7 passed |
| B2b submit-page gate | 1 failed / 1 passed |
| B2c server `proposal.create` gate | 1 failed / 44 passed |
| B2d server `proposal.action` draft -> submitted gate | 2 failed / 43 passed |
| **restored** | **84 passed (84)** — the five files the sabotage targets, not the PR total |

## Numbers

| Check | Baseline (`origin/main` @ b616f2ab) | This branch |
|---|---|---|
| `pnpm test` | 487 files / 7008 tests, **1 failed** (`migrations/046.../plan.test.ts` canvas-rasterize timeout; passes in isolation — pre-existing flake) | **492 files / 7045 tests, 0 failed** |
| `pnpm typecheck` | clean | clean |
| `npx prettier --check .` | clean | clean |
| `npx eslint .` | 0 errors, 216 warnings | 0 errors, 216 warnings |
| `pnpm knip` | 1 pre-existing config hint | same hint, nothing new |