### PR TITLE
fix(sponsor-crm): scope historic-sponsor import to the requesting organization

### DIFF
--- a/src/lib/sponsor-crm/sanity.tenancy.test.ts
+++ b/src/lib/sponsor-crm/sanity.tenancy.test.ts
@@ -1,0 +1,260 @@
+/**
+ * @vitest-environment node
+ *
+ * TENANCY REGRESSIONS for the sponsor-CRM bulk-import paths (#823).
+ *
+ * `importAllHistoricSponsors` asked for "every conference that started before
+ * mine" with NO organization predicate, then read every `sponsorForConference`
+ * hanging off that set. In a shared multi-tenant dataset that is one tenant's
+ * entire historic sponsor roster — company names, and via the copy path their
+ * contacts and billing details — offered inside another tenant's import flow.
+ * `copySponsorsFromPreviousYear` was worse in kind: its `sourceConferenceId` is
+ * CLIENT INPUT used directly as the scope key, so a foreign conference id was
+ * accepted verbatim.
+ *
+ * WHY THIS SUITE RUNS A REAL GROQ ENGINE (the `tenancy.exploits.test.ts`
+ * precedent). Asserting `expect(query).toContain('organization._ref == $orgId')`
+ * pins the DIFF, not the meaning: a predicate that keeps the substring and
+ * inverts the semantics — an `|| defined(_id)` disjunct, a reordered `&&` that
+ * escapes the root bracket — passes a substring harness while reading every
+ * tenant. So the mock below evaluates the query text the code actually sent with
+ * `groq-js` against a two-tenant fixture. Precedence, `in`, `->`, `order()` and
+ * projection semantics are the engine's, not a re-implementation of them, and
+ * the assertions are about which DOCUMENTS came back and which writes happened.
+ *
+ * SABOTAGE-VERIFIED. Deleting `organization._ref == $orgId` from the
+ * previous-conferences read (the fix, one exact string) makes
+ * "a sponsor of organization B is never offered to organization A" fail; the
+ * happy-path tests stay green either way, which is what proves they are not the
+ * thing doing the work.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { parse, evaluate } from 'groq-js'
+
+type Doc = Record<string, unknown> & { _id: string; _type: string }
+
+const h = vi.hoisted(() => ({
+  fetch: vi.fn(),
+  create: vi.fn(),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: h.fetch },
+  clientReadCached: { fetch: h.fetch },
+  clientWrite: { fetch: h.fetch, create: h.create },
+}))
+
+import {
+  importAllHistoricSponsors,
+  copySponsorsFromPreviousYear,
+} from './sanity'
+
+const ORG_A = 'org-A'
+const ORG_B = 'org-B'
+
+const ref = (id: string) => ({ _type: 'reference', _ref: id })
+
+/**
+ * Two tenants, each with one past edition that has a closed-won sponsor, and one
+ * upcoming edition for A to import into. The B rows are the ones that must never
+ * be reachable from an A request.
+ */
+const dataset: Doc[] = [
+  { _id: ORG_A, _type: 'organization', name: 'Org A' },
+  { _id: ORG_B, _type: 'organization', name: 'Org B' },
+
+  {
+    _id: 'conf-a-2024',
+    _type: 'conference',
+    organization: ref(ORG_A),
+    startDate: '2024-05-01',
+    organizers: [ref('spk-a')],
+  },
+  {
+    _id: 'conf-a-2025',
+    _type: 'conference',
+    organization: ref(ORG_A),
+    startDate: '2025-05-01',
+    organizers: [ref('spk-a')],
+  },
+  // B's edition starts BEFORE A's target, so a date-only filter reaches it.
+  {
+    _id: 'conf-b-2024',
+    _type: 'conference',
+    organization: ref(ORG_B),
+    startDate: '2024-06-01',
+    organizers: [ref('spk-b')],
+  },
+
+  { _id: 'sponsor-a1', _type: 'sponsor', name: 'Acme A' },
+  { _id: 'sponsor-b1', _type: 'sponsor', name: 'Acme B' },
+
+  {
+    _id: 'sfc-a1',
+    _type: 'sponsorForConference',
+    conference: ref('conf-a-2024'),
+    sponsor: ref('sponsor-a1'),
+    status: 'closed-won',
+    assignedTo: ref('spk-a'),
+    contractCurrency: 'NOK',
+    contactPersons: [
+      { _key: 'c1', name: 'Ann A', email: 'ann@a.test', isPrimary: true },
+    ],
+    billing: { invoiceFormat: 'email', email: 'billing@a.test' },
+  },
+  {
+    _id: 'sfc-b1',
+    _type: 'sponsorForConference',
+    conference: ref('conf-b-2024'),
+    sponsor: ref('sponsor-b1'),
+    status: 'closed-won',
+    assignedTo: ref('spk-b'),
+    contractCurrency: 'NOK',
+    contactPersons: [
+      { _key: 'c1', name: 'Bob B', email: 'bob@b.test', isPrimary: true },
+    ],
+    billing: { invoiceFormat: 'email', email: 'billing@b.test' },
+  },
+]
+
+/** Every created document, in order. */
+function createdDocs(): Array<Record<string, unknown>> {
+  return h.create.mock.calls.map((c) => c[0] as Record<string, unknown>)
+}
+
+/** The `sponsor._ref` of every document the run created. */
+function createdSponsorRefs(): string[] {
+  return createdDocs().map(
+    (d) => (d.sponsor as { _ref: string } | undefined)?._ref ?? '',
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // No branch on the query text: the engine decides what each query returns, so
+  // nothing here can agree with a predicate that is wrong.
+  h.fetch.mockImplementation(
+    async (query: string, params: Record<string, unknown> = {}) =>
+      await (await evaluate(parse(query), { dataset, params })).get(),
+  )
+  let n = 0
+  h.create.mockImplementation(async (doc: Record<string, unknown>) => ({
+    ...doc,
+    _id: `created-${++n}`,
+  }))
+})
+
+describe('importAllHistoricSponsors — historic import must not cross tenants', () => {
+  it('imports THIS organization’s own history (the feature still works)', async () => {
+    const { result, error } = await importAllHistoricSponsors({
+      targetConferenceId: 'conf-a-2025',
+      organizationId: ORG_A,
+    })
+
+    expect(error).toBeUndefined()
+    expect(result).toMatchObject({
+      created: 1,
+      skipped: 0,
+      taggedAsReturning: 1,
+      // A's own past edition — and ONLY it.
+      sourceConferencesCount: 1,
+    })
+    expect(createdSponsorRefs()).toEqual(['sponsor-a1'])
+  })
+
+  /**
+   * THE BUG. `conf-b-2024` starts before A's target, so the date-only filter
+   * swept it in and B's sponsor became an A import candidate. `sponsorForConference`
+   * carries no organization key of its own, so the ONLY place this can be closed
+   * is the conference read.
+   */
+  it('never offers organization B’s sponsors to organization A', async () => {
+    await importAllHistoricSponsors({
+      targetConferenceId: 'conf-a-2025',
+      organizationId: ORG_A,
+    })
+
+    expect(createdSponsorRefs()).not.toContain('sponsor-b1')
+    expect(h.create).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses a target conference belonging to another organization', async () => {
+    const { result, error } = await importAllHistoricSponsors({
+      targetConferenceId: 'conf-a-2025',
+      organizationId: ORG_B,
+    })
+
+    expect(result).toBeUndefined()
+    expect(error?.message).toBe('Target conference not found')
+    expect(h.create).not.toHaveBeenCalled()
+  })
+
+  it('FAILS CLOSED on an unresolvable organization: no query, no write', async () => {
+    const { result, error } = await importAllHistoricSponsors({
+      targetConferenceId: 'conf-a-2025',
+      organizationId: null,
+    })
+
+    expect(result).toBeUndefined()
+    expect(error).toBeInstanceOf(Error)
+    expect(h.fetch).not.toHaveBeenCalled()
+    expect(h.create).not.toHaveBeenCalled()
+  })
+})
+
+describe('copySponsorsFromPreviousYear — the SOURCE id is client input', () => {
+  it('copies from this organization’s own edition (the feature still works)', async () => {
+    const { result, error } = await copySponsorsFromPreviousYear({
+      sourceConferenceId: 'conf-a-2024',
+      targetConferenceId: 'conf-a-2025',
+      organizationId: ORG_A,
+    })
+
+    expect(error).toBeUndefined()
+    expect(result).toMatchObject({ created: 1, skipped: 0 })
+    expect(createdSponsorRefs()).toEqual(['sponsor-a1'])
+    // The copy carries contacts and billing — this is the payload that must not
+    // be reachable across a tenant boundary.
+    expect(createdDocs()[0]).toMatchObject({
+      billing: { email: 'billing@a.test' },
+    })
+  })
+
+  it('refuses a SOURCE conference belonging to another organization', async () => {
+    const { result, error } = await copySponsorsFromPreviousYear({
+      sourceConferenceId: 'conf-b-2024',
+      targetConferenceId: 'conf-a-2025',
+      organizationId: ORG_A,
+    })
+
+    expect(result).toBeUndefined()
+    expect(error?.message).toBe('Source conference not found')
+    expect(h.create).not.toHaveBeenCalled()
+  })
+
+  it('refuses a TARGET conference belonging to another organization', async () => {
+    const { result, error } = await copySponsorsFromPreviousYear({
+      sourceConferenceId: 'conf-b-2024',
+      targetConferenceId: 'conf-b-2024',
+      organizationId: ORG_A,
+    })
+
+    expect(result).toBeUndefined()
+    expect(error).toBeInstanceOf(Error)
+    expect(h.create).not.toHaveBeenCalled()
+  })
+
+  it('FAILS CLOSED on an unresolvable organization: no query, no write', async () => {
+    const { result, error } = await copySponsorsFromPreviousYear({
+      sourceConferenceId: 'conf-a-2024',
+      targetConferenceId: 'conf-a-2025',
+      organizationId: null,
+    })
+
+    expect(result).toBeUndefined()
+    expect(error).toBeInstanceOf(Error)
+    expect(h.fetch).not.toHaveBeenCalled()
+    expect(h.create).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/sponsor-crm/sanity.tenancy.test.ts
+++ b/src/lib/sponsor-crm/sanity.tenancy.test.ts
@@ -22,11 +22,17 @@
  * projection semantics are the engine's, not a re-implementation of them, and
  * the assertions are about which DOCUMENTS came back and which writes happened.
  *
- * SABOTAGE-VERIFIED. Deleting `organization._ref == $orgId` from the
- * previous-conferences read (the fix, one exact string) makes
- * "a sponsor of organization B is never offered to organization A" fail; the
- * happy-path tests stay green either way, which is what proves they are not the
- * thing doing the work.
+ * SABOTAGE-VERIFIED, one exact string at a time. Each of the four org-scoped
+ * reads, and each fail-closed guard, has a case that FAILS when it is removed;
+ * the happy-path cases stay green under those sabotages, which is what proves
+ * they are not the thing doing the work.
+ *
+ * A case must REACH the guard it names. The target-conference refusals pass a
+ * legitimately OWNED source/target for the dimension they are not testing —
+ * otherwise an earlier guard returns first and the case passes while the guard
+ * it claims to cover is unscoped. Every refusal here asserts the exact error
+ * MESSAGE for that reason: it pins which layer refused, not merely that
+ * something did.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
@@ -190,6 +196,15 @@ describe('importAllHistoricSponsors — historic import must not cross tenants',
     expect(h.create).not.toHaveBeenCalled()
   })
 
+  /**
+   * The refusal is DOUBLE-layered: this explicit guard, and `scopedFetch`,
+   * which throws on an empty scope before it reaches the client. Asserting only
+   * `instanceof Error` + "no query" therefore passes with the guard DELETED —
+   * the second layer produces the same observable. So the message is pinned to
+   * THIS layer ("refusing to run without…"), which `scopedFetch`'s own
+   * "empty tenant scope" error does not satisfy. Verified: deleting the guard
+   * fails this case.
+   */
   it('FAILS CLOSED on an unresolvable organization: no query, no write', async () => {
     const { result, error } = await importAllHistoricSponsors({
       targetConferenceId: 'conf-a-2025',
@@ -197,7 +212,9 @@ describe('importAllHistoricSponsors — historic import must not cross tenants',
     })
 
     expect(result).toBeUndefined()
-    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toBe(
+      'importAllHistoricSponsors: refusing to run without a resolved organization',
+    )
     expect(h.fetch).not.toHaveBeenCalled()
     expect(h.create).not.toHaveBeenCalled()
   })
@@ -233,18 +250,27 @@ describe('copySponsorsFromPreviousYear — the SOURCE id is client input', () =>
     expect(h.create).not.toHaveBeenCalled()
   })
 
+  /**
+   * THE WRITE DIRECTION — the one that puts another tenant's sponsor PII into
+   * documents we own. The source MUST be a legitimately owned conference
+   * (`conf-a-2024`): naming a foreign source here would trip the source guard
+   * and return before the target read is ever reached, and the case would pass
+   * without exercising the guard it is named for. The message assertion pins
+   * WHICH guard refused, so that substitution can never go unnoticed again.
+   */
   it('refuses a TARGET conference belonging to another organization', async () => {
     const { result, error } = await copySponsorsFromPreviousYear({
-      sourceConferenceId: 'conf-b-2024',
+      sourceConferenceId: 'conf-a-2024',
       targetConferenceId: 'conf-b-2024',
       organizationId: ORG_A,
     })
 
     expect(result).toBeUndefined()
-    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toBe('Target conference not found')
     expect(h.create).not.toHaveBeenCalled()
   })
 
+  /** Message pinned to THIS layer, not `scopedFetch`'s — see the import case. */
   it('FAILS CLOSED on an unresolvable organization: no query, no write', async () => {
     const { result, error } = await copySponsorsFromPreviousYear({
       sourceConferenceId: 'conf-a-2024',
@@ -253,7 +279,9 @@ describe('copySponsorsFromPreviousYear — the SOURCE id is client input', () =>
     })
 
     expect(result).toBeUndefined()
-    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toBe(
+      'copySponsorsFromPreviousYear: refusing to run without a resolved organization',
+    )
     expect(h.fetch).not.toHaveBeenCalled()
     expect(h.create).not.toHaveBeenCalled()
   })

--- a/src/lib/sponsor-crm/sanity.ts
+++ b/src/lib/sponsor-crm/sanity.ts
@@ -3,6 +3,7 @@ import {
   clientReadUncached as clientRead,
 } from '@/lib/sanity/client'
 import { prepareArrayWithKeys } from '@/lib/sanity/helpers'
+import { scopedFetch } from '@/lib/sanity/scoped'
 import { tierExistenceQuery } from './tier-validation'
 import type { ConferenceSponsor } from '@/lib/sponsor/types'
 import type {
@@ -513,11 +514,60 @@ export async function copySponsorsFromPreviousYear(
   result?: CopySponsorsResult
   error?: Error
 }> {
-  try {
-    const { sourceConferenceId, targetConferenceId } = params
+  const { sourceConferenceId, targetConferenceId, organizationId } = params
 
-    // Get source sponsors
+  // FAIL CLOSED: no tenant, no query, no write.
+  if (!organizationId) {
+    return {
+      error: new Error(
+        'copySponsorsFromPreviousYear: refusing to run without a resolved organization',
+      ),
+    }
+  }
+
+  try {
+    // OWNERSHIP FIRST (#823). BOTH conference ids are client input, so neither
+    // may be used as a scope key until an ORG-scoped read has proven it belongs
+    // to the request's tenant. Without this an organizer of one organization
+    // could name another organization's conference as the SOURCE and copy that
+    // tenant's closed-won sponsor roster — names, contacts and billing details —
+    // into their own. `scopedFetch` prepends `organization._ref == $orgId` and
+    // throws on an empty scope; a foreign id simply resolves to null here, so
+    // the refusal never confirms that it exists.
+    const sourceConference = await scopedFetch<{ _id: string } | null>(
+      clientRead,
+      { orgId: organizationId },
+      `*[_type == "conference" && _id == $sourceConferenceId][0]{ _id }`,
+      { sourceConferenceId },
+    )
+
+    if (!sourceConference) {
+      return { error: new Error('Source conference not found') }
+    }
+
+    // Get target conference organizers — same org-scoped ownership check.
+    const targetConference = await scopedFetch<{
+      organizers: Array<{ _ref: string }>
+    } | null>(
+      clientRead,
+      { orgId: organizationId },
+      `*[_type == "conference" && _id == $targetConferenceId][0]{
+        organizers[]
+      }`,
+      { targetConferenceId },
+    )
+
+    if (!targetConference) {
+      return { error: new Error('Target conference not found') }
+    }
+
+    // Get source sponsors. `sponsorForConference` carries no `organization` key
+    // of its own, so its tenant is the one of the conference it hangs off —
+    // proven ours by the org-scoped read above.
     const sourceSponsors = await clientRead.fetch<SponsorForConference[]>(
+      // groq-global-scoped: `conference._ref == $conferenceId` IS the tenant
+      // predicate, and `$conferenceId` is an id the org-scoped read above
+      // proved belongs to the request's organization.
       `*[_type == "sponsorForConference" && conference._ref == $conferenceId && status == "closed-won"]{
         _id,
         sponsor,
@@ -530,20 +580,6 @@ export async function copySponsorsFromPreviousYear(
       }`,
       { conferenceId: sourceConferenceId },
     )
-
-    // Get target conference organizers
-    const targetConference = await clientRead.fetch<{
-      organizers: Array<{ _ref: string }>
-    }>(
-      `*[_type == "conference" && _id == $conferenceId][0]{
-        organizers[]
-      }`,
-      { conferenceId: targetConferenceId },
-    )
-
-    if (!targetConference) {
-      return { error: new Error('Target conference not found') }
-    }
 
     const targetOrganizerIds = new Set(
       targetConference.organizers.map((o: { _ref: string }) => o._ref),
@@ -559,6 +595,9 @@ export async function copySponsorsFromPreviousYear(
     const existingSponsors = await clientRead.fetch<
       Array<{ sponsor: { _ref: string } }>
     >(
+      // groq-global-scoped: `conference._ref == $conferenceId` IS the tenant
+      // predicate, bound to the target conference the org-scoped read above
+      // proved belongs to the request's organization.
       `*[_type == "sponsorForConference" && conference._ref == $conferenceId]{
         sponsor
       }`,
@@ -624,14 +663,26 @@ export async function importAllHistoricSponsors(
   result?: ImportAllHistoricSponsorsResult
   error?: Error
 }> {
-  try {
-    const { targetConferenceId } = params
+  const { targetConferenceId, organizationId } = params
 
-    // Get target conference start date
-    const targetConference = await clientRead.fetch<{
+  // FAIL CLOSED: no tenant, no query, no write.
+  if (!organizationId) {
+    return {
+      error: new Error(
+        'importAllHistoricSponsors: refusing to run without a resolved organization',
+      ),
+    }
+  }
+
+  try {
+    // OWNERSHIP FIRST (#823): `targetConferenceId` is client input, so it is
+    // only usable as a scope key once an ORG-scoped read has proven it ours.
+    const targetConference = await scopedFetch<{
       _id: string
       startDate: string
-    }>(
+    } | null>(
+      clientRead,
+      { orgId: organizationId },
       `*[_type == "conference" && _id == $conferenceId][0]{
         _id,
         startDate
@@ -643,8 +694,16 @@ export async function importAllHistoricSponsors(
       return { error: new Error('Target conference not found') }
     }
 
-    // Get all conferences before the target conference
-    const previousConferences = await clientRead.fetch<Array<{ _id: string }>>(
+    // Get all of THIS ORGANIZATION's conferences before the target conference.
+    //
+    // TENANCY (#823): the org predicate is the whole fix. Unscoped, this asks
+    // for every conference in the shared dataset that started before ours —
+    // which made `historicSponsors` below a cross-tenant read and offered one
+    // tenant's sponsor roster inside another tenant's import flow. Date is not
+    // a tenant key; `organization._ref` is, and `scopedFetch` prepends it.
+    const previousConferences = await scopedFetch<Array<{ _id: string }>>(
+      clientRead,
+      { orgId: organizationId },
       `*[_type == "conference" && startDate < $targetStartDate] | order(startDate desc) {
         _id
       }`,
@@ -673,6 +732,9 @@ export async function importAllHistoricSponsors(
         conference: { _ref: string }
       }>
     >(
+      // groq-global-scoped: `conference._ref in $conferenceIds` IS the tenant
+      // predicate — `$conferenceIds` is exactly the set the ORG-scoped read
+      // above returned, so this cannot reach a conference of another tenant.
       `*[_type == "sponsorForConference" && conference._ref in $conferenceIds]{
         sponsor,
         status,
@@ -685,6 +747,9 @@ export async function importAllHistoricSponsors(
     const existingSponsors = await clientRead.fetch<
       Array<{ sponsor: { _ref: string } }>
     >(
+      // groq-global-scoped: `conference._ref == $conferenceId` IS the tenant
+      // predicate, bound to the target conference the org-scoped read above
+      // proved belongs to the request's organization.
       `*[_type == "sponsorForConference" && conference._ref == $conferenceId]{
         sponsor
       }`,

--- a/src/lib/sponsor-crm/types.ts
+++ b/src/lib/sponsor-crm/types.ts
@@ -271,6 +271,13 @@ export interface SponsorActivityInput {
 export interface CopySponsorsParams {
   sourceConferenceId: string
   targetConferenceId: string
+  /**
+   * TENANCY (#823). The REQUEST's organization, taken from the authorization
+   * waist (`ctx.orgId`) and never from client input. Both conference ids above
+   * ARE client input, so they are only honoured after an org-scoped read proves
+   * they belong to this tenant. `null` (unresolvable host) fails closed.
+   */
+  organizationId: string | null
 }
 
 export interface CopySponsorsResult {
@@ -281,6 +288,8 @@ export interface CopySponsorsResult {
 
 export interface ImportAllHistoricSponsorsParams {
   targetConferenceId: string
+  /** TENANCY (#823) — see {@link CopySponsorsParams.organizationId}. */
+  organizationId: string | null
 }
 
 export interface ImportAllHistoricSponsorsResult {

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -1668,8 +1668,14 @@ export const sponsorRouter = router({
 
     copyFromPreviousYear: adminProcedure
       .input(CopySponsorsSchema)
-      .mutation(async ({ input }) => {
-        const { result, error } = await copySponsorsFromPreviousYear(input)
+      .mutation(async ({ input, ctx }) => {
+        // TENANCY (#823): the tenant comes from the authorization waist, never
+        // from `input` — both conference ids in it are client-supplied, and the
+        // lib re-proves each one against this org before reading any sponsor.
+        const { result, error } = await copySponsorsFromPreviousYear({
+          ...input,
+          organizationId: ctx.orgId,
+        })
 
         if (error) {
           throw new TRPCError({
@@ -1684,8 +1690,12 @@ export const sponsorRouter = router({
 
     importAllHistoric: adminProcedure
       .input(ImportAllHistoricSponsorsSchema)
-      .mutation(async ({ input }) => {
-        const { result, error } = await importAllHistoricSponsors(input)
+      .mutation(async ({ input, ctx }) => {
+        // TENANCY (#823): see `copyFromPreviousYear` above.
+        const { result, error } = await importAllHistoricSponsors({
+          ...input,
+          organizationId: ctx.orgId,
+        })
 
         if (error) {
           throw new TRPCError({


### PR DESCRIPTION
Fixes #823.

## The finding held — and it was not alone

`importAllHistoricSponsors` resolved "all previous conferences" with a **date-only** filter:

```groq
*[_type == "conference" && startDate < $targetStartDate] | order(startDate desc) { _id }
```

A date is not a tenant key. That set was then fed to `*[_type == "sponsorForConference" && conference._ref in $conferenceIds]`, so the historic-sponsor import offered **one tenant's entire sponsor roster inside another tenant's import flow**. No caller-side guard scoped it: the router handed `input` straight through, and `adminProcedure` only proves the caller is an organizer of the *request's* org — it says nothing about the conferences the query reaches.

The neighbouring `copySponsorsFromPreviousYear` is **worse in kind**. Its `sourceConferenceId` is client input used *directly* as the scope key, entirely unvalidated:

```groq
*[_type == "sponsorForConference" && conference._ref == $conferenceId && status == "closed-won"]{ … contactPersons[…], billing{…} }
```

An organizer of org B could name org A's conference as the source and copy A's closed-won sponsors — names, contact people, billing emails and references — into their own pipeline. Same for `targetConferenceId`, which is a cross-tenant **write**.

## The fix

The established module pattern, not a new mechanism: the router passes the request tenant (`ctx.orgId`, resolved by the authz waist from the domain — never from input), the lib **fails closed** on an unresolvable one, and every client-supplied conference id is proven with `scopedFetch(clientRead, { orgId }, …)` before it is used as a scope key. This mirrors `deleteSponsor(id, ctx.orgId)` and `bulkUpdateSponsors(…, await resolveConferenceId())`.

`sponsorForConference` carries no `organization` key of its own, so the **conference read is the only place this can be closed**. The sponsor reads that hang off an id already proven ours are annotated `groq-global-scoped:` with the mechanism rather than given a redundant predicate.

## Sweep of the neighbouring queries

Every root filter in `src/lib/sponsor-crm/` was checked, not just the flagged one.

| Site | Verdict |
|---|---|
| `sanity.ts` import ×2 conference reads | **FIXED** — org-scoped |
| `sanity.ts` copy ×2 conference reads | **FIXED** — org-scoped (source id was fully client-controlled) |
| `sanity.ts` import/copy `sponsorForConference` reads ×3 | scoped **transitively** by an id the org read proved; annotated |
| `sanity.ts:218/301/326/375` `_id ==` point reads | guarded caller-side — `getSponsorForCurrentConference` (router:172) precedes all four `updateSponsorForConference` calls, `requireDocumentInCurrentConference` precedes delete. **No redundant filter added.** |
| `sanity.ts:143/455/500` list/count/public | conference-scoped on a server-resolved id |
| `sanity.ts:336` `sanity.fileAsset` orphan count | deliberately cross-tenant — scoping it would delete an asset another tenant still references (same reasoning as `bulk.ts:280`) |
| `sanity.ts:21/348` `sponsorActivity` by `^._id` / parent id | joined to the parent row; scope follows the parent |
| `activities.ts:37/57` | by parent sponsor id / `sponsorForConference->conference._ref` traversal |
| `activity.ts:469/516` | by-id, then gated on `createdBy == userId` and activity type |
| `contract-templates.ts` ×6 | conference-scoped, or by-id behind `requireDocumentInCurrentConference(input.id, 'contractTemplate')` |
| `registration.ts:115` `registrationToken ==` | **intentionally** cross-tenant: an unguessable token is the credential on an unauthenticated portal |
| `registration.ts` ×4 by-id | server-derived or token-derived ids |
| `bulk.ts`, `tier-validation.ts` | already `scopedFetch`/conference-scoped |

Nothing else in the module has the "widen from one key to a global sweep" shape.

## Why `no-unscoped-groq` missed it — NOT a #792 blind spot

It did **not** miss it. Both queries were flagged. They were warnings **#N of 216**.

The rule reports `unscoped` for *any* root filter outside `scopedFetch` that is not annotated — it never inspects the filter for a literal tenant predicate. Probed directly:

```
*[_type == "x" && conference._ref == $conferenceId]  → FLAGGED
*[_type == "x" && organization._ref == $orgId]       → FLAGGED
*[conference._ref == $conferenceId && _type == "x"]  → silent (predicate-reorder gap, #792)
*[_type == "x"]                                      → FLAGGED
```

A genuinely scoped query and a genuinely unscoped one produce **byte-identical diagnostics**. On `b616f2a`, **50** of the 208 `unscoped` warnings sit on a root filter carrying the canonical `conference._ref == $conferenceId` / `organization._ref == $orgId` (57 counting `._ref in $…` and `->` traversals; 79 counting any `._ref ==/in $param`). Most of the rest are point reads whose ownership check lives at the caller. The one way to get a *clean* run for a hand-written scoped query today is to trip a known blind spot (line 3 above).

`docs/TENANT_SCOPING.md` describes `unscoped` as *"with no tenant predicate"* — the implementation does not check that. So the finding is a **precision** problem, not a visibility one, and it is why this bug sat in plain sight. Written up on #792, where the parser rewrite is the fix that would close it.

## Tests

New `src/lib/sponsor-crm/sanity.tenancy.test.ts`, 8 tests, following the `tenancy.exploits.test.ts` precedent: the Sanity mock evaluates the **query text the code actually sent** with `groq-js` against a two-tenant fixture, so a predicate that keeps the right substrings and inverts the meaning still fails. Assertions are about which documents came back and which writes happened.

Every refusal case asserts the exact error **message**, so it pins *which* guard refused — and each case passes an owned id for the dimension it is not testing, so it actually reaches the guard it names rather than returning at an earlier one.

**Sabotage matrix** — each guard removed by exact string, one at a time:

| # | Sabotage | Result |
|---|---|---|
| 1 | unscope the import previous-conferences read | **2 failed** — `['sponsor-a1', 'sponsor-b1']`, org B's sponsor imported into org A; `created: 2` |
| 2 | unscope the copy SOURCE conference read | **1 failed** — B's roster copied into A |
| 3 | unscope the import TARGET conference read | **1 failed** — B's admin writes into A's conference |
| 4 | unscope the copy TARGET conference read | **1 failed** — the write direction: B's sponsor PII into A's documents |
| 5 | delete the import fail-closed `!organizationId` guard | **1 failed** |
| 6 | delete the copy fail-closed `!organizationId` guard | **1 failed** |
| — | restored | **8 passed** |

6 for 6: every org-scoped read and every fail-closed guard has a case that fails when it is removed. The happy-path tests ("the feature still works") stay green under sabotage 1, which is what proves they are not the thing doing the work.

## Numbers

| | baseline (`b616f2a`) | this branch |
|---|---|---|
| `pnpm test` | 487 files / 7008 tests | **488 files / 7016 tests**, all passing |
| `pnpm typecheck` | clean | clean |
| `npx prettier --check .` | clean | clean |
| `npx eslint .` | 216 warnings, 0 errors | **209 warnings, 0 errors** (−7) |