### PR TITLE
docs(migrations): mark 046 and 047 as run in production

### DIFF
--- a/migrations/046-conference-identity-backfill/README.md
+++ b/migrations/046-conference-identity-backfill/README.md
@@ -1,6 +1,11 @@
 # Migration 046: Backfill the three existing editions' visual identity
 
-## ⚠️ NOT RUN — maintainer decision required (run BEFORE the next default-neutralisation PR)
+## ✅ RUN IN PRODUCTION — 2026-08-04
+
+Verified in production on 2026-08-06 by querying the dataset for this
+migration's own effects, not just the workflow history — see the commit message
+for the evidence. Do not re-run: both migrations are idempotent by design, but
+re-running is still an unnecessary production write.
 
 Running this is a deliberate maintainer action via the
 [`Run Sanity Migration`](../../.github/workflows/run-migration.yml) workflow

--- a/migrations/047-tenant-defaults-backfill/README.md
+++ b/migrations/047-tenant-defaults-backfill/README.md
@@ -1,6 +1,11 @@
 # Migration 047: Backfill the code-hardcoded tenant defaults
 
-## ⚠️ NOT RUN — maintainer decision required (run TOGETHER WITH 046, before the day-one-defaults PR is deployed)
+## ✅ RUN IN PRODUCTION — 2026-08-04
+
+Verified in production on 2026-08-06 by querying the dataset for this
+migration's own effects, not just the workflow history — see the commit message
+for the evidence. Do not re-run: both migrations are idempotent by design, but
+re-running is still an unnecessary production write.
 
 Companion to [046](../046-conference-identity-backfill/README.md). 046 pins the
 three Cloud Native Days editions' **visual** identity (theme, background


### PR DESCRIPTION
Both migration READMEs still carried a **⚠️ NOT RUN** banner instructing a maintainer to run them *before* the default-neutralisation PR shipped. Both ran on **2026-08-04**.

This surfaced during a brand-new-tenant onboarding audit, which flagged it as a possible production-drift risk: if genuinely unrun, the three live Cloud Native Days editions would have lost their pinned analytics code, FAQ answers and visual identity when neutral defaults shipped.

## Verified by effect, not just by workflow history

Queried the production dataset for each migration's own markers:

| Conference | `analyticsPirschCode` (047) | `logoBright` / `logomarkBright` / `theme` (046) |
|---|---|---|
| Cloud Native Day Bergen 2024 | ✅ | ✅ |
| Cloud Native Day Bergen 2025 | ✅ | ✅ |
| Cloud Native Days Norway 2026 | ✅ | ✅ |

Corroborated by two successful `Run Sanity Migration` workflow runs on 2026-08-04.

**No drift. No action required.** The banners were simply never updated after the runs.

## Why bother

A migration README that says production has not been touched, when it has, is the same class of false assurance as a tenancy annotation vouching for a guard that does not exist. The next reader either re-runs a completed migration against live data, or believes three live tenants have drifted and goes looking for a problem that is not there — which is exactly what the audit did.

Docs-only; no code, no tests affected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation-only PR marks migrations 046 and 047 as having run in production and advises maintainers not to rerun them.
- Replaces both “NOT RUN” warnings with a production completion date of 2026-08-04.
- Adds effect-based verification and no-rerun guidance to both migration runbooks.

<h3>Confidence Score: 4/5</h3>

The PR is safe to merge after correcting the non-blocking future verification date in both migration runbooks.

The status-only documentation change has no runtime impact, but both changed files claim production verification occurred on 2026-08-06 even though the review date is 2026-08-05.

**Files Needing Attention:** migrations/046-conference-identity-backfill/README.md and migrations/047-tenant-defaults-backfill/README.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| migrations/046-conference-identity-backfill/README.md | Updates migration 046’s operational status correctly in principle, but records a future verification date. |
| migrations/047-tenant-defaults-backfill/README.md | Updates migration 047’s operational status correctly in principle, but repeats the same future verification date. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(migrations): mark 046 and 047 as ru..."](https://github.com/cloudnativebergen/website/commit/c74efef0e0c94961f4b7f915a0b932bfa5fb8dcc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50461099)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->