### PR TITLE
feat(admin): gate ticketing and badges instead of dead-ending tenants

### DIFF
--- a/__tests__/app/admin/badge-gate.test.tsx
+++ b/__tests__/app/admin/badge-gate.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * @vitest-environment node
+ *
+ * REACHABILITY of the speaker badge admin surface.
+ *
+ * The page had NO gate at all: it rendered in full for every tenant, and
+ * `issueBadgeForSpeaker`'s platform-org tripwire (RunKonf/platform#46) then
+ * failed every action with a message naming our internal issue tracker — once
+ * per speaker. This asserts the page now 404s for a tenant that can never
+ * issue, and still loads for the platform org.
+ *
+ * Only the Sanity boundary is mocked; the real entitlement resolution decides,
+ * and `notFound()` is mocked to throw the way Next.js does.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const mockGetConference = vi.fn()
+const mockGetOrganizationById = vi.fn()
+const mockGetBadgeStats = vi.fn()
+const mockListBadges = vi.fn()
+const mockGetSpeakers = vi.fn()
+const mockGetOrganizers = vi.fn()
+
+class NotFoundError extends Error {
+  digest = 'NEXT_NOT_FOUND'
+}
+
+vi.mock('next/navigation', () => ({
+  notFound: () => {
+    throw new NotFoundError('NEXT_NOT_FOUND')
+  },
+}))
+
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    mockGetConference(...args),
+}))
+
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationById: (...args: unknown[]) => mockGetOrganizationById(...args),
+  getOrganizationRefForCurrentConference: () => null,
+}))
+
+vi.mock('@/lib/badge/sanity', () => ({
+  getBadgeStats: (...args: unknown[]) => mockGetBadgeStats(...args),
+  listBadgesForConference: (...args: unknown[]) => mockListBadges(...args),
+}))
+
+vi.mock('@/lib/speaker/sanity', () => ({
+  getSpeakers: (...args: unknown[]) => mockGetSpeakers(...args),
+  getOrganizers: (...args: unknown[]) => mockGetOrganizers(...args),
+}))
+
+/** TRIPWIRE: platform standing is pure env and must read no Sanity. */
+const h = vi.hoisted(() => ({ fetch: vi.fn(async () => null) }))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: h.fetch },
+}))
+
+import AdminBadgePage from '@/app/(admin)/admin/speakers/badge/page'
+
+/** A configured platform org distinct from the request org (`org-A`). */
+const OTHER_PLATFORM_ORG_ID = 'org-platform'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubEnv('PLATFORM_ORG_ID', OTHER_PLATFORM_ORG_ID)
+  mockGetBadgeStats.mockResolvedValue({
+    totalBadges: 0,
+    speakerBadges: 0,
+    organizerBadges: 0,
+    emailsSent: 0,
+    emailsFailed: 0,
+  })
+  mockListBadges.mockResolvedValue({ badges: [], error: null })
+  mockGetSpeakers.mockResolvedValue({ speakers: [], err: null })
+  mockGetOrganizers.mockResolvedValue({ speakers: [], err: null })
+  mockGetConference.mockResolvedValue({
+    conference: {
+      _id: 'conf-1',
+      title: 'Tenant Conf',
+      organization: { _ref: 'org-A', _type: 'reference' },
+    },
+    error: null,
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('/admin/speakers/badge — feature gate', () => {
+  it('404s for a tenant that can never issue a badge, on every plan', async () => {
+    for (const plan of ['community', 'pro', 'enterprise'] as const) {
+      mockGetOrganizationById.mockResolvedValue({
+        _id: 'org-A',
+        name: 'Tenant A',
+        slug: 'tenant-a',
+        plan,
+      })
+      await expect(AdminBadgePage()).rejects.toBeInstanceOf(NotFoundError)
+    }
+    // …and never reached the badge/speaker reads behind the gate.
+    expect(mockGetBadgeStats).not.toHaveBeenCalled()
+    expect(mockGetSpeakers).not.toHaveBeenCalled()
+  })
+
+  it('404s when the organization cannot be resolved (fail closed)', async () => {
+    mockGetConference.mockResolvedValue({
+      conference: { _id: 'conf-1', title: 'Orphan' },
+      error: null,
+    })
+    await expect(AdminBadgePage()).rejects.toBeInstanceOf(NotFoundError)
+    expect(mockGetOrganizationById).not.toHaveBeenCalled()
+  })
+
+  it('renders for the platform org — today’s behaviour is unchanged', async () => {
+    vi.stubEnv('PLATFORM_ORG_ID', 'org-A')
+    mockGetOrganizationById.mockResolvedValue({
+      _id: 'org-A',
+      name: 'Platform',
+      slug: 'platform-org',
+    })
+
+    await expect(AdminBadgePage()).resolves.toBeTruthy()
+    expect(mockGetBadgeStats).toHaveBeenCalledWith('conf-1')
+    expect(h.fetch).not.toHaveBeenCalled()
+  })
+
+  it('renders for an org granted badges by an explicit override', async () => {
+    mockGetOrganizationById.mockResolvedValue({
+      _id: 'org-A',
+      name: 'Pilot',
+      slug: 'pilot',
+      plan: 'community',
+      featureOverrides: [{ feature: 'badges', enabled: true }],
+    })
+
+    await expect(AdminBadgePage()).resolves.toBeTruthy()
+  })
+})

--- a/__tests__/app/admin/badge-gate.test.tsx
+++ b/__tests__/app/admin/badge-gate.test.tsx
@@ -13,6 +13,7 @@
  * and `notFound()` is mocked to throw the way Next.js does.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
 
 const mockGetConference = vi.fn()
 const mockGetOrganizationById = vi.fn()
@@ -128,7 +129,13 @@ describe('/admin/speakers/badge — feature gate', () => {
     expect(h.fetch).not.toHaveBeenCalled()
   })
 
-  it('renders for an org granted badges by an explicit override', async () => {
+  /**
+   * An override may REVOKE badges but never GRANT them: issuance still refuses
+   * every non-platform org, so opening the page on a grant would hand an
+   * organizer a management UI whose every action fails — the exact dead end
+   * this gate removes. See `src/lib/features/badges.ts`.
+   */
+  it('still 404s for an org granted badges by an explicit override', async () => {
     mockGetOrganizationById.mockResolvedValue({
       _id: 'org-A',
       name: 'Pilot',
@@ -137,6 +144,54 @@ describe('/admin/speakers/badge — feature gate', () => {
       featureOverrides: [{ feature: 'badges', enabled: true }],
     })
 
-    await expect(AdminBadgePage()).resolves.toBeTruthy()
+    await expect(AdminBadgePage()).rejects.toBeInstanceOf(NotFoundError)
+    expect(mockGetBadgeStats).not.toHaveBeenCalled()
+  })
+
+  it('404s for the platform org when an explicit DENY revokes badges', async () => {
+    vi.stubEnv('PLATFORM_ORG_ID', 'org-A')
+    mockGetOrganizationById.mockResolvedValue({
+      _id: 'org-A',
+      name: 'Platform',
+      slug: 'platform-org',
+      featureOverrides: [{ feature: 'badges', enabled: false }],
+    })
+
+    await expect(AdminBadgePage()).rejects.toBeInstanceOf(NotFoundError)
+  })
+})
+
+/**
+ * FAILING CLOSED IS RIGHT; FAILING CLOSED AS "THIS PAGE DOES NOT EXIST" IS NOT.
+ *
+ * `getConferenceForCurrentDomain` returns a TRUTHY `{} as Conference` alongside
+ * its error, so a gate placed above the error handling turned a transient Sanity
+ * failure — and an unknown host — into a bare 404. Both still deny; they now say
+ * which one happened.
+ */
+describe('/admin/speakers/badge — failure states are not 404s', () => {
+  it('shows an error state, not a 404, on a transient conference read failure', async () => {
+    mockGetConference.mockResolvedValue({
+      conference: {},
+      error: new Error('sanity unavailable'),
+    })
+
+    const markup = renderToStaticMarkup(
+      (await AdminBadgePage()) as React.ReactElement,
+    )
+    expect(markup).toContain('Error Loading Conference')
+    expect(markup).toContain('sanity unavailable')
+    // The entitlement lookup is not even reached — there is no tenant to key on.
+    expect(mockGetOrganizationById).not.toHaveBeenCalled()
+  })
+
+  it('shows the unknown-host state, not a 404, for a host with no conference', async () => {
+    mockGetConference.mockResolvedValue({ conference: {}, error: null })
+
+    const markup = renderToStaticMarkup(
+      (await AdminBadgePage()) as React.ReactElement,
+    )
+    expect(markup).toContain('No Conference Found')
+    expect(mockGetBadgeStats).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/app/admin/layout-features.test.tsx
+++ b/__tests__/app/admin/layout-features.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * @vitest-environment node
+ *
+ * WHAT THE ADMIN SHELL IS TOLD the current org is entitled to.
+ *
+ * The layout used to compute `enabledFeatures` as literally `['workshops']` or
+ * `[]`, so the registry's `feature` tag could gate exactly one destination and
+ * nothing else — tagging Tickets or Badges would have had no effect at all.
+ * This pins the layout to the REAL entitlement resolution: only the Sanity org
+ * document and the auth boundary are mocked, and `AdminLayout` itself is a
+ * probe that records the feature list it was handed.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const mockGetConference = vi.fn()
+const mockGetOrganizationById = vi.fn()
+const mockIsOrganizer = vi.fn()
+
+vi.mock('@/lib/auth', () => ({
+  getAuthSession: async () => ({ speaker: { _id: 'speaker-1' } }),
+}))
+
+vi.mock('@/lib/authz/organizer', () => ({
+  isOrganizerForCurrentOrg: (...args: unknown[]) => mockIsOrganizer(...args),
+  resolveCurrentOrgId: async () => null,
+}))
+
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    mockGetConference(...args),
+}))
+
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationById: (...args: unknown[]) => mockGetOrganizationById(...args),
+  getOrganizationRefForCurrentConference: () => null,
+}))
+
+const h = vi.hoisted(() => ({ fetch: vi.fn(async () => null) }))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientRead: { fetch: h.fetch },
+  clientReadUncached: { fetch: h.fetch },
+}))
+
+vi.mock('@/components/admin', () => ({
+  AdminLayout: ({ enabledFeatures }: { enabledFeatures: string[] }) => (
+    <div data-features={enabledFeatures.join(',')} />
+  ),
+}))
+
+import AdminRootLayout from '@/app/(admin)/admin/layout'
+
+const PLATFORM_ORG_ID = 'org-platform'
+
+/** The feature list the shell received, parsed back out of the probe. */
+async function enabledFeatures(): Promise<string[]> {
+  const markup = renderToStaticMarkup(
+    (await AdminRootLayout({ children: null })) as React.ReactElement,
+  )
+  const match = markup.match(/data-features="([^"]*)"/)
+  if (!match) throw new Error(`AdminLayout was not rendered: ${markup}`)
+  return match[1] ? match[1].split(',') : []
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubEnv('PLATFORM_ORG_ID', PLATFORM_ORG_ID)
+  vi.stubEnv('TENANT_SECRETS_JSON', '')
+  mockIsOrganizer.mockResolvedValue(true)
+  mockGetConference.mockResolvedValue({
+    conference: {
+      _id: 'conf-1',
+      title: 'Tenant Conf',
+      organization: { _ref: 'org-A', _type: 'reference' },
+    },
+    error: null,
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('admin layout — enabled features', () => {
+  it('hands a brand-new tenant NO features, so every gated destination hides', async () => {
+    mockGetOrganizationById.mockResolvedValue({
+      _id: 'org-A',
+      name: 'Tenant A',
+      slug: 'tenant-a',
+      plan: 'community',
+    })
+    await expect(enabledFeatures()).resolves.toEqual([])
+  })
+
+  it('hands the platform org its platform-default features', async () => {
+    mockGetConference.mockResolvedValue({
+      conference: {
+        _id: 'conf-1',
+        title: 'Platform Conf',
+        organization: { _ref: PLATFORM_ORG_ID, _type: 'reference' },
+      },
+      error: null,
+    })
+    mockGetOrganizationById.mockResolvedValue({
+      _id: PLATFORM_ORG_ID,
+      name: 'Platform',
+      slug: 'platform-org',
+    })
+    await expect(enabledFeatures()).resolves.toEqual([
+      'workshops',
+      'ticketing',
+      'badges',
+    ])
+  })
+
+  it('honours a per-feature override — not just workshops', async () => {
+    mockGetOrganizationById.mockResolvedValue({
+      _id: 'org-A',
+      name: 'Pilot',
+      slug: 'pilot',
+      plan: 'community',
+      featureOverrides: [{ feature: 'ticketing', enabled: true }],
+    })
+    await expect(enabledFeatures()).resolves.toEqual(['ticketing'])
+  })
+
+  it('hands NO features to an unresolvable tenant (fail closed)', async () => {
+    mockGetConference.mockResolvedValue({
+      conference: { _id: 'conf-1', title: 'Orphan' },
+      error: null,
+    })
+    await expect(enabledFeatures()).resolves.toEqual([])
+    expect(mockGetOrganizationById).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/app/admin/tickets-states.test.tsx
+++ b/__tests__/app/admin/tickets-states.test.tsx
@@ -350,10 +350,17 @@ describe('a Tito-bound conference', () => {
     }
   })
 
-  /** Discount codes are a Checkin-only API — say so, do not fail. */
-  it('/admin/tickets/discount says discounts are managed in the vendor', async () => {
+  /**
+   * Discount codes are a Checkin-only API on OUR side — say so, do not fail.
+   * The copy must name the conference's OWN vendor: telling a Tito organizer to
+   * go to Checkin.no sends them somewhere they have no account, and re-hardcodes
+   * the vendor this PR exists to stop hardcoding.
+   */
+  it('/admin/tickets/discount names Tito, never sends the organizer to Checkin.no', async () => {
     const markup = await html(DiscountCodesAdminPage)
-    expect(markup).toContain('Tito does not support this')
+    expect(markup).toContain('Discount codes are not available for Tito')
+    expect(markup).toContain('Tito dashboard')
+    expect(markup).not.toContain('Checkin.no')
     expect(markup).not.toContain('Configuration Error')
   })
 })

--- a/__tests__/app/admin/tickets-states.test.tsx
+++ b/__tests__/app/admin/tickets-states.test.tsx
@@ -1,0 +1,359 @@
+/**
+ * @vitest-environment node
+ *
+ * WHAT AN ORGANIZER SEES on the five provider-backed ticket pages.
+ *
+ * All five used to render a red `ErrorDisplay "Checkin.no Configuration Error"`
+ * whenever the Checkin binding was absent — an error frame for "not set up
+ * yet", with no link to settings, hardcoded to one vendor so a Tito-bound
+ * conference could never open any of them. Two of them lied on top of that:
+ * orders claimed "No tickets have been sold" and ticket types rendered silently
+ * empty for an org that simply had no credentials.
+ *
+ * These assertions pin the replacement: empty ≠ error ≠ unavailable, per page,
+ * per state. Everything the app owns runs for real (the resolver, the feature
+ * gate, the pages' own composition); only Sanity and the provider HTTP clients
+ * are mocked.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const mockGetConference = vi.fn()
+const mockGetOrganizationById = vi.fn()
+
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    mockGetConference(...args),
+}))
+
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationById: (...args: unknown[]) => mockGetOrganizationById(...args),
+  getOrganizationRefForCurrentConference: () => null,
+}))
+
+const h = vi.hoisted(() => ({
+  fetch: vi.fn(async () => null),
+  fetchEventTickets: vi.fn(),
+  fetchPublicTicketTypes: vi.fn(),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientRead: { fetch: h.fetch },
+  clientReadUncached: { fetch: h.fetch },
+  clientWrite: { fetch: h.fetch },
+}))
+
+/**
+ * The provider HTTP clients are the ONLY thing stubbed inside the ticketing
+ * stack — `resolveTicketingProvider` still picks which one to construct, which
+ * is what proves the Tito routing.
+ */
+vi.mock('@/lib/tickets/provider/checkin', () => ({
+  CheckinProvider: class {
+    readonly name = 'Checkin.no'
+    isConfigured() {
+      return true
+    }
+    fetchEventTickets = h.fetchEventTickets
+    fetchPublicTicketTypes = h.fetchPublicTicketTypes
+  },
+}))
+
+vi.mock('@/lib/tickets/provider/tito', () => ({
+  TitoProvider: class {
+    readonly name = 'Tito'
+    isConfigured() {
+      return true
+    }
+    fetchEventTickets = h.fetchEventTickets
+    fetchPublicTicketTypes = h.fetchPublicTicketTypes
+  },
+}))
+
+/**
+ * Two CLIENT components in the ready path need a live tRPC provider and app
+ * router, which a static server render has neither of. They are stubbed as
+ * markers so the ready paths still assert "the page opened and rendered its
+ * real body" — everything under test (the state resolution and the vendor
+ * routing) happens before these render.
+ */
+vi.mock('@/components/admin/TicketAnalysisClient', () => ({
+  TicketAnalysisClient: () => <div>ticket analysis</div>,
+}))
+
+vi.mock('@/components/admin/DiscountCodeManager', () => ({
+  DiscountCodeManager: () => <div>discount manager</div>,
+}))
+
+vi.mock('@/lib/speaker/sanity', () => ({
+  getSpeakers: vi.fn(async () => ({ speakers: [], err: null })),
+  getOrganizerCount: vi.fn(async () => ({ count: 0, err: null })),
+  getOrganizers: vi.fn(async () => ({ speakers: [], err: null })),
+}))
+
+import AdminTickets from '@/app/(admin)/admin/tickets/page'
+import OrdersAdminPage from '@/app/(admin)/admin/tickets/orders/page'
+import TicketTypesAdminPage from '@/app/(admin)/admin/tickets/types/page'
+import DiscountCodesAdminPage from '@/app/(admin)/admin/tickets/discount/page'
+import CompaniesAdminPage from '@/app/(admin)/admin/tickets/companies/page'
+
+const PLATFORM_ORG_ID = 'org-platform'
+const TENANT_ORG_ID = 'org-A'
+
+type Binding = Record<string, unknown>
+
+function stubConference(orgId: string | null, binding: Binding = {}) {
+  mockGetConference.mockResolvedValue({
+    conference: {
+      _id: 'conf-1',
+      title: 'Tenant Conf',
+      city: 'Bergen',
+      country: 'Norway',
+      startDate: '2026-10-01',
+      domains: ['tenant.example'],
+      sponsors: [],
+      ...(orgId ? { organization: { _ref: orgId, _type: 'reference' } } : {}),
+      ...binding,
+    },
+    domain: 'tenant.example',
+    error: null,
+  })
+}
+
+const CHECKIN_BINDING = { checkinCustomerId: 42, checkinEventId: 4242 }
+const TITO_BINDING = {
+  ticketingProvider: 'tito',
+  titoAccountSlug: 'cndn',
+  titoEventSlug: '2026',
+}
+
+/** Render a server page component to HTML. */
+async function html(page: () => Promise<React.ReactNode>): Promise<string> {
+  return renderToStaticMarkup((await page()) as React.ReactElement)
+}
+
+const PAGES: [string, () => Promise<React.ReactNode>][] = [
+  ['/admin/tickets', AdminTickets],
+  ['/admin/tickets/orders', OrdersAdminPage],
+  ['/admin/tickets/types', TicketTypesAdminPage],
+  ['/admin/tickets/discount', DiscountCodesAdminPage],
+  ['/admin/tickets/companies', CompaniesAdminPage],
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubEnv('PLATFORM_ORG_ID', PLATFORM_ORG_ID)
+  vi.stubEnv('TENANT_SECRETS_JSON', '')
+  vi.stubEnv('CHECKIN_API_KEY', 'platform-checkin-key')
+  vi.stubEnv('CHECKIN_API_SECRET', 'platform-checkin-secret')
+  vi.stubEnv('TITO_API_KEY', 'platform-tito-key')
+  h.fetchEventTickets.mockResolvedValue([])
+  h.fetchPublicTicketTypes.mockResolvedValue({
+    event: { id: 1, name: 'Event', currencies: ['NOK'] },
+    tickets: [],
+  })
+  mockGetOrganizationById.mockResolvedValue({
+    _id: TENANT_ORG_ID,
+    name: 'Tenant A',
+    slug: 'tenant-a',
+    plan: 'community',
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+/**
+ * THE DAY-ONE TENANT. Nothing configured, no entitlement: every page says so
+ * once, plainly, and none of them shows an error frame or a fabricated fact.
+ */
+describe('a non-entitled organization', () => {
+  beforeEach(() => stubConference(TENANT_ORG_ID))
+
+  for (const [route, page] of PAGES) {
+    it(`${route} shows the unavailable state, not an error wall`, async () => {
+      const markup = await html(page)
+
+      expect(markup).toContain(
+        'Ticketing is not available for your organization',
+      )
+      expect(markup).not.toContain('Configuration Error')
+      expect(markup).not.toContain('Missing required')
+      // No dead end to a settings form that cannot help.
+      expect(markup).not.toContain('Open ticket settings')
+      // Never our internal vocabulary.
+      expect(markup).not.toContain('RunKonf/platform')
+    })
+  }
+
+  it('/admin/tickets/orders does not claim zero sales', async () => {
+    const markup = await html(OrdersAdminPage)
+    expect(markup).not.toContain('No tickets have been sold')
+    expect(markup).not.toContain('No orders found')
+  })
+
+  it('/admin/tickets/types does not render a silently empty list', async () => {
+    const markup = await html(TicketTypesAdminPage)
+    expect(markup).not.toContain('No ticket types found')
+  })
+
+  it('never calls the provider for an unentitled org', async () => {
+    for (const [, page] of PAGES) await html(page)
+    expect(h.fetchEventTickets).not.toHaveBeenCalled()
+    expect(h.fetchPublicTicketTypes).not.toHaveBeenCalled()
+  })
+
+  /**
+   * #820: filling the ids in is not enough without credentials. That used to
+   * reach the fetch and surface a raw "Missing checkin configuration".
+   */
+  it('still says unavailable when the ids are filled in but no credentials exist', async () => {
+    stubConference(TENANT_ORG_ID, CHECKIN_BINDING)
+    const markup = await html(AdminTickets)
+    expect(markup).toContain('Ticketing is not available for your organization')
+    expect(markup).not.toContain('Missing checkin configuration')
+  })
+})
+
+/** Entitled but not bound yet — actionable, and NOT an error. */
+describe('an entitled organization with no event binding', () => {
+  beforeEach(() => {
+    stubConference(PLATFORM_ORG_ID)
+    mockGetOrganizationById.mockResolvedValue({
+      _id: PLATFORM_ORG_ID,
+      name: 'Platform',
+      slug: 'platform-org',
+    })
+  })
+
+  for (const [route, page] of PAGES) {
+    it(`${route} offers the ticket settings instead of an error`, async () => {
+      const markup = await html(page)
+      expect(markup).toContain('Ticketing is not connected yet')
+      expect(markup).toContain('/admin/settings#tickets-registration')
+      expect(markup).not.toContain('Configuration Error')
+    })
+  }
+})
+
+/** The platform org's own conference keeps working exactly as before. */
+describe('the platform organization with a bound Checkin event', () => {
+  beforeEach(() => {
+    stubConference(PLATFORM_ORG_ID, CHECKIN_BINDING)
+    mockGetOrganizationById.mockResolvedValue({
+      _id: PLATFORM_ORG_ID,
+      name: 'Platform',
+      slug: 'platform-org',
+    })
+  })
+
+  it('/admin/tickets/types lists the event’s ticket types', async () => {
+    h.fetchPublicTicketTypes.mockResolvedValue({
+      event: { id: 1, name: 'Event', currencies: ['NOK'] },
+      tickets: [
+        {
+          id: 7,
+          name: 'Early Bird',
+          type: 'regular',
+          description: null,
+          price: [],
+          available: 10,
+          requiresInvitation: false,
+          visibleStartsAt: null,
+          visibleEndsAt: null,
+          position: 1,
+        },
+      ],
+    })
+
+    const markup = await html(TicketTypesAdminPage)
+    expect(markup).toContain('Early Bird')
+    expect(markup).not.toContain('Ticketing is not')
+  })
+
+  it('/admin/tickets/orders reports a REAL zero-sales empty state', async () => {
+    h.fetchEventTickets.mockResolvedValue([])
+    const markup = await html(OrdersAdminPage)
+    expect(markup).toContain('No orders found')
+    expect(markup).toContain('No tickets have been sold for this event yet.')
+    expect(markup).not.toContain('Ticketing is not')
+  })
+
+  it('/admin/tickets/discount renders the discount manager', async () => {
+    const markup = await html(DiscountCodesAdminPage)
+    expect(markup).not.toContain('Ticketing is not')
+    expect(markup).not.toContain('does not support this')
+  })
+})
+
+/**
+ * THE TITO FIX. The Checkin-hardcoded guard meant a Tito-bound conference was
+ * refused on every page for "missing Customer ID, Event ID" it does not use.
+ */
+describe('a Tito-bound conference', () => {
+  beforeEach(() => {
+    stubConference(PLATFORM_ORG_ID, TITO_BINDING)
+    mockGetOrganizationById.mockResolvedValue({
+      _id: PLATFORM_ORG_ID,
+      name: 'Platform',
+      slug: 'platform-org',
+    })
+  })
+
+  it('/admin/tickets/types opens and names Tito as the source', async () => {
+    h.fetchPublicTicketTypes.mockResolvedValue({
+      event: { id: 1, name: 'Event', currencies: ['NOK'] },
+      tickets: [
+        {
+          id: 7,
+          name: 'Conference Pass',
+          type: 'regular',
+          description: null,
+          price: [],
+          available: null,
+          requiresInvitation: false,
+          visibleStartsAt: null,
+          visibleEndsAt: null,
+          position: 1,
+        },
+      ],
+    })
+
+    const markup = await html(TicketTypesAdminPage)
+    expect(markup).toContain('Conference Pass')
+    expect(markup).toContain('Tito')
+    expect(markup).not.toContain('Customer ID')
+    // The provider-shaped ref, not a bare Checkin event id.
+    expect(h.fetchPublicTicketTypes).toHaveBeenCalledWith({
+      provider: 'tito',
+      accountSlug: 'cndn',
+      eventSlug: '2026',
+    })
+  })
+
+  it('/admin/tickets/orders opens and fetches through the Tito event ref', async () => {
+    const markup = await html(OrdersAdminPage)
+    expect(markup).not.toContain('Configuration Error')
+    expect(h.fetchEventTickets).toHaveBeenCalledWith({
+      provider: 'tito',
+      accountSlug: 'cndn',
+      eventSlug: '2026',
+    })
+  })
+
+  it('/admin/tickets and /admin/tickets/companies open too', async () => {
+    for (const page of [AdminTickets, CompaniesAdminPage]) {
+      const markup = await html(page)
+      expect(markup).not.toContain('Configuration Error')
+      expect(markup).not.toContain('Ticketing is not')
+    }
+  })
+
+  /** Discount codes are a Checkin-only API — say so, do not fail. */
+  it('/admin/tickets/discount says discounts are managed in the vendor', async () => {
+    const markup = await html(DiscountCodesAdminPage)
+    expect(markup).toContain('Tito does not support this')
+    expect(markup).not.toContain('Configuration Error')
+  })
+})

--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -4,8 +4,7 @@ import { getAuthSession } from '@/lib/auth'
 import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { isConferenceUnlisted } from '@/lib/conference/visibility'
-import { isWorkshopsEnabledForConference } from '@/lib/features/workshops'
-import type { FeatureId } from '@/lib/features/registry'
+import { resolveEnabledFeaturesForConference } from '@/lib/features/enabled'
 
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
@@ -43,13 +42,11 @@ export default async function AdminRootLayout({
 
   // Feature-gated admin destinations (#689): the registry hides any nav entry
   // / ⌘K destination tagged with a feature the current org is not entitled to.
-  // `workshops` is the only gated destination today; the pages themselves
+  // Resolved from the REAL entitlement resolution for the conference's owning
+  // tenant — every registry feature, not a hardcoded `['workshops']` — so
+  // tagging a destination is all it takes to gate it. The pages themselves
   // re-check server-side, so this is presentation, not security.
-  const enabledFeatures: FeatureId[] = (await isWorkshopsEnabledForConference(
-    conference,
-  ))
-    ? ['workshops']
-    : []
+  const enabledFeatures = await resolveEnabledFeaturesForConference(conference)
 
   return (
     <AdminLayout

--- a/src/app/(admin)/admin/speakers/badge/page.tsx
+++ b/src/app/(admin)/admin/speakers/badge/page.tsx
@@ -13,26 +13,19 @@ import type { Speaker } from '@/lib/speaker/types'
 export default async function AdminBadgePage() {
   const { conference, error } = await getConferenceForCurrentDomain({})
 
-  // FEATURE GATE: badge issuance signs with ONE global key pair and REFUSES any
-  // non-platform org (the Phase 0 tripwire, RunKonf/platform#46). Without this
-  // gate the page rendered in full for every tenant and surfaced that refusal —
-  // which names an internal issue tracker — once per speaker. The nav entry and
-  // the ⌘K destination are hidden (see the `badges` tag in
-  // `@/lib/admin/registry`) and the page itself 404s. Fail-closed: it runs
-  // BEFORE any conference/speaker read, so an unresolvable tenant 404s too.
-  if (!(await isBadgesEnabledForConference(conference))) {
-    notFound()
-  }
-
+  // FAILURE FIRST, THEN THE GATE. `getConferenceForCurrentDomain` returns a
+  // TRUTHY `{} as Conference` alongside its error, so an entitlement check
+  // placed above these would turn a transient Sanity failure — and an unknown
+  // host — into a bare 404. Both fail closed either way; the point is that they
+  // fail closed HONESTLY, saying which of the two happened.
   if (error) {
     return (
       <ErrorDisplay title="Error Loading Conference" message={error.message} />
     )
   }
 
-  // `getConferenceForDomain` returns a TRUTHY `{} as Conference` on an unknown
-  // host, so a bare `!conference` never fires and every query below would run
-  // with `conferenceId: undefined`. Use the canonical guard.
+  // A bare `!conference` never fires against that truthy `{}`, and every query
+  // below would then run with `conferenceId: undefined`. Use the canonical guard.
   if (isUnknownHost({ conference })) {
     return (
       <ErrorDisplay
@@ -40,6 +33,17 @@ export default async function AdminBadgePage() {
         message="No conference configuration found for the current domain."
       />
     )
+  }
+
+  // FEATURE GATE: badge issuance signs with ONE global key pair and REFUSES any
+  // non-platform org (the Phase 0 tripwire, RunKonf/platform#46). Without this
+  // gate the page rendered in full for every tenant and surfaced that refusal —
+  // which names an internal issue tracker — once per speaker. The nav entry and
+  // the ⌘K destination are hidden (see the `badges` tag in
+  // `@/lib/admin/registry`) and the page itself 404s. Fail-closed: it still runs
+  // BEFORE any badge/speaker read, so an unentitled tenant reads nothing.
+  if (!(await isBadgesEnabledForConference(conference))) {
+    notFound()
   }
 
   // Fetch all data on server to prevent loading states

--- a/src/app/(admin)/admin/speakers/badge/page.tsx
+++ b/src/app/(admin)/admin/speakers/badge/page.tsx
@@ -1,5 +1,7 @@
+import { notFound } from 'next/navigation'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { isUnknownHost } from '@/lib/conference/guard'
+import { isBadgesEnabledForConference } from '@/lib/features/badges'
 import { ErrorDisplay, AdminPageHeader } from '@/components/admin'
 import { BadgeManagementClient } from '@/components/admin/BadgeManagementClient'
 import { AcademicCapIcon } from '@heroicons/react/24/outline'
@@ -10,6 +12,17 @@ import type { Speaker } from '@/lib/speaker/types'
 
 export default async function AdminBadgePage() {
   const { conference, error } = await getConferenceForCurrentDomain({})
+
+  // FEATURE GATE: badge issuance signs with ONE global key pair and REFUSES any
+  // non-platform org (the Phase 0 tripwire, RunKonf/platform#46). Without this
+  // gate the page rendered in full for every tenant and surfaced that refusal —
+  // which names an internal issue tracker — once per speaker. The nav entry and
+  // the ⌘K destination are hidden (see the `badges` tag in
+  // `@/lib/admin/registry`) and the page itself 404s. Fail-closed: it runs
+  // BEFORE any conference/speaker read, so an unresolvable tenant 404s too.
+  if (!(await isBadgesEnabledForConference(conference))) {
+    notFound()
+  }
 
   if (error) {
     return (

--- a/src/app/(admin)/admin/speakers/page.tsx
+++ b/src/app/(admin)/admin/speakers/page.tsx
@@ -3,6 +3,7 @@ import SpeakersPageClient from '@/components/admin/SpeakersPageClient'
 import { Speaker, Flags } from '@/lib/speaker/types'
 import { ProposalExisting } from '@/lib/proposal/types'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { isBadgesEnabledForConference } from '@/lib/features/badges'
 import { getSpeakersWithAcceptedTalks } from '@/lib/speaker/sanity'
 import { hasPreviousAcceptedTalks } from '@/lib/speaker/utils'
 import { unstable_noStore as noStore } from 'next/cache'
@@ -104,6 +105,7 @@ export default async function AdminSpeakers() {
         }}
         confirmedSpeakersCount={confirmedSpeakers.length}
         conferenceEmail={`${conference.organizer || PLATFORM_NAME} <${conference.contactEmail}>`}
+        badgesEnabled={await isBadgesEnabledForConference(conference)}
       />
     )
   } catch (error) {

--- a/src/app/(admin)/admin/tickets/companies/page.tsx
+++ b/src/app/(admin)/admin/tickets/companies/page.tsx
@@ -1,11 +1,16 @@
 import { groupTicketsByOrder } from '@/lib/tickets/api'
 import {
-  getTicketingProvider,
-  resolveTicketingCredentials,
-} from '@/lib/tickets/provider'
+  resolveTicketingAdminAccess,
+  ticketingProviderLabel,
+  type TicketingAdminAccess,
+} from '@/lib/tickets/admin-access'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import type { EventTicket, GroupedOrder } from '@/lib/tickets/types'
-import { ErrorDisplay, AdminPageHeader } from '@/components/admin'
+import {
+  ErrorDisplay,
+  AdminPageHeader,
+  TicketingStateNotice,
+} from '@/components/admin'
 import {
   BuildingOfficeIcon,
   TicketIcon,
@@ -17,23 +22,18 @@ import { EmptyState } from '@/components/EmptyState'
 import { CompanyBreakdownTable } from './CompanyBreakdownTable'
 
 /**
- * Credentials come from the per-org seam, keyed on the conference's owning
- * organization — never straight off the platform env. A tenant the seam has no
- * credentials for renders the same empty state as an unbound conference.
+ * Fetches through the RESOLVED provider (Checkin or Tito). The "no credentials"
+ * case is a STATE handled before this runs, not an empty ticket list — see
+ * `resolveTicketingAdminAccess`.
  */
 async function getTicketData(
-  orgId: string | undefined,
-  customerId: number,
-  eventId: number,
+  access: Extract<TicketingAdminAccess, { state: 'ready' }>,
 ): Promise<EventTicket[]> {
-  const credentials = await resolveTicketingCredentials(orgId, 'checkin')
-  if (!credentials) return []
   try {
-    const provider = getTicketingProvider('checkin', credentials)
-    return await provider.fetchEventTickets({ customerId, eventId })
+    return await access.provider.fetchEventTickets(access.eventRef)
   } catch (error) {
     throw new Error(
-      `Failed to fetch event tickets from Checkin.no API: ${(error as Error).message}`,
+      `Failed to fetch event tickets: ${(error as Error).message}`,
     )
   }
 }
@@ -234,25 +234,35 @@ export default async function CompaniesAdminPage() {
   const { conference, error: conferenceError } =
     await getConferenceForCurrentDomain({})
 
-  if (
-    conferenceError ||
-    !conference.checkinCustomerId ||
-    !conference.checkinEventId
-  ) {
-    const missingFields = []
-    if (!conference.checkinCustomerId) missingFields.push('Customer ID')
-    if (!conference.checkinEventId) missingFields.push('Event ID')
-
+  if (conferenceError) {
     return (
       <ErrorDisplay
-        title="Checkin.no Configuration Error"
-        message={
-          conferenceError
-            ? `Failed to load conference data: ${conferenceError.message}`
-            : `Missing required Checkin.no configuration: ${missingFields.join(', ')}. Please configure these values in the conference settings to enable company breakdown.`
-        }
+        title="Error Loading Conference"
+        message={`Failed to load conference data: ${conferenceError.message}`}
         backLink={{ href: '/admin/tickets', label: 'Back to Tickets' }}
       />
+    )
+  }
+
+  const access = await resolveTicketingAdminAccess(conference)
+  const providerLabel = ticketingProviderLabel(access.providerType)
+
+  if (access.state !== 'ready') {
+    return (
+      <div className="space-y-6">
+        <AdminPageHeader
+          icon={<BuildingOfficeIcon />}
+          title="Company Breakdown"
+          description="Overview of attending companies for"
+          contextHighlight={conference.title}
+          backLink={{ href: '/admin/tickets', label: 'Back to Tickets' }}
+        />
+        <TicketingStateNotice
+          state={access.state}
+          providerLabel={providerLabel}
+          surface="attending companies"
+        />
+      </div>
     )
   }
 
@@ -260,11 +270,7 @@ export default async function CompaniesAdminPage() {
   let error: string | null = null
 
   try {
-    allTickets = await getTicketData(
-      conference.organization?._ref,
-      conference.checkinCustomerId,
-      conference.checkinEventId,
-    )
+    allTickets = await getTicketData(access)
   } catch (err) {
     error = (err as Error).message
   }
@@ -273,7 +279,7 @@ export default async function CompaniesAdminPage() {
     return (
       <ErrorDisplay
         title="Failed to Load Data"
-        message={`Unable to fetch tickets from Checkin.no: ${error}. Please check your API credentials and event configuration.`}
+        message={`Unable to fetch tickets from ${providerLabel}: ${error}. Please check your API credentials and event configuration.`}
         backLink={{ href: '/admin/tickets', label: 'Back to Tickets' }}
       />
     )

--- a/src/app/(admin)/admin/tickets/discount/page.tsx
+++ b/src/app/(admin)/admin/tickets/discount/page.tsx
@@ -1,6 +1,15 @@
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { SPONSOR_TIER_TICKET_ALLOCATION } from '@/lib/tickets/processor'
-import { ErrorDisplay, AdminPageHeader } from '@/components/admin'
+import {
+  resolveTicketingAdminAccess,
+  ticketingProviderLabel,
+} from '@/lib/tickets/admin-access'
+import {
+  ErrorDisplay,
+  AdminPageHeader,
+  TicketingStateNotice,
+  type TicketingNoticeState,
+} from '@/components/admin'
 import { DiscountCodeManager } from '@/components/admin/DiscountCodeManager'
 import {
   TicketIcon,
@@ -31,25 +40,51 @@ export default async function DiscountCodesAdminPage() {
     sponsors: true,
   })
 
-  if (
-    conferenceError ||
-    !conference.checkinCustomerId ||
-    !conference.checkinEventId
-  ) {
-    const missingFields = []
-    if (!conference.checkinCustomerId) missingFields.push('Customer ID')
-    if (!conference.checkinEventId) missingFields.push('Event ID')
-
+  if (conferenceError) {
     return (
       <ErrorDisplay
-        title="Checkin.no Configuration Error"
-        message={
-          conferenceError
-            ? `Failed to load conference data: ${conferenceError.message}`
-            : `Missing required Checkin.no configuration: ${missingFields.join(', ')}. Please configure these values in the conference settings to enable discount code management.`
-        }
+        title="Error Loading Conference"
+        message={`Failed to load conference data: ${conferenceError.message}`}
         backLink={{ href: '/admin/tickets', label: 'Back to Tickets' }}
       />
+    )
+  }
+
+  const access = await resolveTicketingAdminAccess(conference)
+  const providerLabel = ticketingProviderLabel(access.providerType)
+
+  // Discount codes are a CHECKIN-ONLY API end to end — the manager, the tRPC
+  // procedures and the provider interface all key on a numeric Checkin event id,
+  // and the Tito provider raises `ProviderUnsupportedError` for them. So a Tito
+  // conference gets an honest "not supported by this vendor" state rather than a
+  // manager whose every call fails.
+  const noticeState: TicketingNoticeState | null =
+    access.state !== 'ready' ? access.state : null
+
+  // A `ready` Checkin conference always has both ids (the resolver requires
+  // them), so this is only absent for Tito — and it narrows the id for the
+  // Checkin-shaped manager below.
+  const checkinEventId =
+    access.state === 'ready' && access.providerType === 'checkin'
+      ? conference.checkinEventId
+      : undefined
+
+  if (noticeState || !checkinEventId) {
+    return (
+      <div className="space-y-6">
+        <AdminPageHeader
+          icon={<TicketIcon />}
+          title="Discount Code Management"
+          description="Create and manage sponsor discount codes based on tier entitlements"
+          contextHighlight={conference.title}
+          backLink={{ href: '/admin/tickets', label: 'Back to Tickets' }}
+        />
+        <TicketingStateNotice
+          state={noticeState ?? 'unsupported'}
+          providerLabel={providerLabel}
+          surface="discount codes"
+        />
+      </div>
     )
   }
 
@@ -86,7 +121,7 @@ export default async function DiscountCodesAdminPage() {
       <div>
         <DiscountCodeManager
           sponsors={sponsorsWithTierInfo}
-          eventId={conference.checkinEventId}
+          eventId={checkinEventId}
           conference={{
             title: conference.title,
             city: conference.city,

--- a/src/app/(admin)/admin/tickets/orders/page.tsx
+++ b/src/app/(admin)/admin/tickets/orders/page.tsx
@@ -1,11 +1,16 @@
 import { groupTicketsByOrder } from '@/lib/tickets/api'
 import {
-  getTicketingProvider,
-  resolveTicketingCredentials,
-} from '@/lib/tickets/provider'
+  resolveTicketingAdminAccess,
+  ticketingProviderLabel,
+  type TicketingAdminAccess,
+} from '@/lib/tickets/admin-access'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import type { EventTicket } from '@/lib/tickets/types'
-import { ErrorDisplay, AdminPageHeader } from '@/components/admin'
+import {
+  ErrorDisplay,
+  AdminPageHeader,
+  TicketingStateNotice,
+} from '@/components/admin'
 import { OrdersTableWithSearch } from '@/components/admin/OrdersTableWithSearch'
 import {
   TicketIcon,
@@ -18,20 +23,17 @@ import Link from 'next/link'
 import { EmptyState } from '@/components/EmptyState'
 
 /**
- * Credentials come from the per-org seam, keyed on the conference's owning
- * organization — never straight off the platform env. A tenant the seam has no
- * credentials for renders the same empty state as an unbound conference.
+ * Fetches through the RESOLVED provider, so a Tito-bound conference reads its
+ * own event rather than being refused for missing Checkin ids. The "no
+ * credentials" case never reaches here — it is a state, not an empty result
+ * (see `resolveTicketingAdminAccess`), which is what used to make an
+ * unconfigured org read as "No tickets have been sold".
  */
 async function getTicketData(
-  orgId: string | undefined,
-  customerId: number,
-  eventId: number,
+  access: Extract<TicketingAdminAccess, { state: 'ready' }>,
 ): Promise<EventTicket[]> {
-  const credentials = await resolveTicketingCredentials(orgId, 'checkin')
-  if (!credentials) return []
   try {
-    const provider = getTicketingProvider('checkin', credentials)
-    return await provider.fetchEventTickets({ customerId, eventId })
+    return await access.provider.fetchEventTickets(access.eventRef)
   } catch (error) {
     throw new Error(`Unable to fetch tickets: ${(error as Error).message}`)
   }
@@ -41,25 +43,35 @@ export default async function OrdersAdminPage() {
   const { conference, error: conferenceError } =
     await getConferenceForCurrentDomain({})
 
-  if (
-    conferenceError ||
-    !conference.checkinCustomerId ||
-    !conference.checkinEventId
-  ) {
-    const missingFields = []
-    if (!conference.checkinCustomerId) missingFields.push('Customer ID')
-    if (!conference.checkinEventId) missingFields.push('Event ID')
-
+  if (conferenceError) {
     return (
       <ErrorDisplay
-        title="Checkin.no Configuration Error"
-        message={
-          conferenceError
-            ? `Failed to load conference data: ${conferenceError.message}`
-            : `Missing required Checkin.no configuration: ${missingFields.join(', ')}. Please configure these values in the conference settings to enable order management.`
-        }
+        title="Error Loading Conference"
+        message={`Failed to load conference data: ${conferenceError.message}`}
         backLink={{ href: '/admin/tickets', label: 'Back to Tickets' }}
       />
+    )
+  }
+
+  const access = await resolveTicketingAdminAccess(conference)
+  const providerLabel = ticketingProviderLabel(access.providerType)
+
+  if (access.state !== 'ready') {
+    return (
+      <div className="space-y-6">
+        <AdminPageHeader
+          icon={<ShoppingBagIcon />}
+          title="Order Management"
+          description="View and manage ticket orders for"
+          contextHighlight={conference.title}
+          backLink={{ href: '/admin/tickets', label: 'Back to Tickets' }}
+        />
+        <TicketingStateNotice
+          state={access.state}
+          providerLabel={providerLabel}
+          surface="orders"
+        />
+      </div>
     )
   }
 
@@ -67,11 +79,7 @@ export default async function OrdersAdminPage() {
   let error: string | null = null
 
   try {
-    allTickets = await getTicketData(
-      conference.organization?._ref,
-      conference.checkinCustomerId,
-      conference.checkinEventId,
-    )
+    allTickets = await getTicketData(access)
   } catch (err) {
     error = (err as Error).message
   }
@@ -80,7 +88,7 @@ export default async function OrdersAdminPage() {
     return (
       <ErrorDisplay
         title="Failed to Load Order Data"
-        message={`Unable to fetch orders from Checkin.no: ${error}. Please check your API credentials and event configuration.`}
+        message={`Unable to fetch orders from ${providerLabel}: ${error}. Please check your API credentials and event configuration.`}
         backLink={{ href: '/admin/tickets', label: 'Back to Tickets' }}
       />
     )
@@ -106,6 +114,8 @@ export default async function OrdersAdminPage() {
         </div>
 
         {orders.length === 0 ? (
+          /* Only reachable in the `ready` state, so this is a REAL zero-sales
+             fact about a connected event — never an unconfigured provider. */
           <EmptyState
             icon={ShoppingBagIcon}
             title="No orders found"
@@ -113,6 +123,8 @@ export default async function OrdersAdminPage() {
             className="py-12"
           />
         ) : (
+          /* Checkin-only deep-link ids; absent on a Tito event, where the table
+             renders the order without the vendor link. */
           <OrdersTableWithSearch
             orders={orders}
             customerId={conference.checkinCustomerId}

--- a/src/app/(admin)/admin/tickets/page.tsx
+++ b/src/app/(admin)/admin/tickets/page.tsx
@@ -1,4 +1,8 @@
-import { resolveTicketingProvider } from '@/lib/tickets/provider'
+import {
+  resolveTicketingAdminAccess,
+  ticketingProviderLabel,
+  type TicketingAdminAccess,
+} from '@/lib/tickets/admin-access'
 import { TicketSalesProcessor } from '@/lib/tickets/processor'
 import type { ProcessTicketSalesInput, EventTicket } from '@/lib/tickets/types'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
@@ -7,6 +11,7 @@ import {
   ErrorDisplay,
   AdminPageHeader,
   TicketAnalysisClient,
+  TicketingStateNotice,
 } from '@/components/admin'
 import { CollapsibleSection } from '@/components/admin/CollapsibleSection'
 import {
@@ -40,14 +45,11 @@ import { getSpeakers, getOrganizerCount } from '@/lib/speaker/sanity'
 import { Status } from '@/lib/proposal/types'
 import Link from 'next/link'
 
-async function getTicketData(conference: Conference) {
-  const ticketing = await resolveTicketingProvider(conference)
-  if (!ticketing.configured) {
-    throw new Error('Missing checkin configuration')
-  }
-
+async function getTicketData(
+  access: Extract<TicketingAdminAccess, { state: 'ready' }>,
+) {
   try {
-    return await ticketing.provider.fetchEventTickets(ticketing.eventRef)
+    return await access.provider.fetchEventTickets(access.eventRef)
   } catch (error) {
     throw new Error(`Unable to fetch tickets: ${(error as Error).message}`)
   }
@@ -95,25 +97,42 @@ export default async function AdminTickets() {
       sponsors: true,
     })
 
-  if (
-    conferenceError ||
-    !conference.checkinCustomerId ||
-    !conference.checkinEventId
-  ) {
-    const missingFields = []
-    if (!conference.checkinCustomerId) missingFields.push('Customer ID')
-    if (!conference.checkinEventId) missingFields.push('Event ID')
-
+  // A failed conference read is the ONLY error case here. "Not bound to an
+  // event" and "no ticketing integration" are states, not errors — see
+  // `resolveTicketingAdminAccess`.
+  if (conferenceError) {
     return (
       <ErrorDisplay
-        title="Checkin.no Configuration Error"
-        message={
-          conferenceError
-            ? `Failed to load conference data: ${conferenceError.message}`
-            : `Missing required Checkin.no configuration: ${missingFields.join(', ')}`
-        }
+        title="Error Loading Conference"
+        message={`Failed to load conference data: ${conferenceError.message}`}
         backLink={{ href: '/admin', label: 'Back to Admin Dashboard' }}
       />
+    )
+  }
+
+  const access = await resolveTicketingAdminAccess(conference)
+  if (access.state !== 'ready') {
+    return (
+      <div className="space-y-6">
+        <AdminPageHeader
+          icon={<TicketIcon />}
+          title="Ticket Management"
+          description="Manage sold tickets and attendee information for"
+          contextHighlight={conference.title}
+          actionItems={[
+            {
+              label: 'Page Content',
+              href: '/admin/tickets/content',
+              icon: <DocumentTextIcon className="h-4 w-4" />,
+            },
+          ]}
+        />
+        <TicketingStateNotice
+          state={access.state}
+          providerLabel={ticketingProviderLabel(access.providerType)}
+          surface="ticket sales"
+        />
+      </div>
     )
   }
 
@@ -121,7 +140,7 @@ export default async function AdminTickets() {
   let error: string | null = null
 
   try {
-    allTickets = await getTicketData(conference)
+    allTickets = await getTicketData(access)
   } catch (err) {
     error = (err as Error).message
   }

--- a/src/app/(admin)/admin/tickets/types/page.tsx
+++ b/src/app/(admin)/admin/tickets/types/page.tsx
@@ -7,10 +7,14 @@ import {
   type PublicTicketType,
 } from '@/lib/tickets/public'
 import {
-  getTicketingProvider,
-  resolveTicketingCredentials,
-} from '@/lib/tickets/provider'
-import { ErrorDisplay, AdminPageHeader } from '@/components/admin'
+  resolveTicketingAdminAccess,
+  ticketingProviderLabel,
+} from '@/lib/tickets/admin-access'
+import {
+  ErrorDisplay,
+  AdminPageHeader,
+  TicketingStateNotice,
+} from '@/components/admin'
 import { TicketIcon } from '@heroicons/react/24/outline'
 import { EmptyState } from '@/components/EmptyState'
 import {
@@ -44,25 +48,40 @@ export default async function TicketTypesAdminPage() {
   const { conference, error: conferenceError } =
     await getConferenceForCurrentDomain({})
 
-  if (
-    conferenceError ||
-    !conference.checkinCustomerId ||
-    !conference.checkinEventId
-  ) {
-    const missingFields = []
-    if (!conference.checkinCustomerId) missingFields.push('Customer ID')
-    if (!conference.checkinEventId) missingFields.push('Event ID')
-
+  if (conferenceError) {
     return (
       <ErrorDisplay
-        title="Checkin.no Configuration Error"
-        message={
-          conferenceError
-            ? `Failed to load conference data: ${conferenceError.message}`
-            : `Missing required Checkin.no configuration: ${missingFields.join(', ')}. Please configure these in the conference settings.`
-        }
+        title="Error Loading Conference"
+        message={`Failed to load conference data: ${conferenceError.message}`}
         backLink={{ href: '/admin/tickets', label: 'Back to Tickets' }}
       />
+    )
+  }
+
+  // Provider-aware: the resolver reads whichever binding this conference's
+  // vendor uses, so a Tito-bound conference lists ITS ticket types instead of
+  // being refused for missing Checkin ids. It also replaces the silent empty
+  // render that a credential-less org used to get — an unresolvable provider is
+  // not "this event has no ticket types".
+  const access = await resolveTicketingAdminAccess(conference)
+  const providerLabel = ticketingProviderLabel(access.providerType)
+
+  if (access.state !== 'ready') {
+    return (
+      <div className="space-y-6">
+        <AdminPageHeader
+          icon={<TicketIcon />}
+          title="Ticket Types"
+          description="Ticket types for"
+          contextHighlight={conference.title}
+          backLink={{ href: '/admin/tickets', label: 'Back to Tickets' }}
+        />
+        <TicketingStateNotice
+          state={access.state}
+          providerLabel={providerLabel}
+          surface="ticket types"
+        />
+      </div>
     )
   }
 
@@ -70,19 +89,10 @@ export default async function TicketTypesAdminPage() {
   let error: string | null = null
 
   try {
-    // Credentials come from the per-org seam, keyed on the conference's owning
-    // organization — never straight off the platform env.
-    const credentials = await resolveTicketingCredentials(
-      conference.organization?._ref,
-      'checkin',
-    )
-    if (credentials) {
-      const provider = getTicketingProvider('checkin', credentials)
-      const data = await provider.fetchPublicTicketTypes(
-        conference.checkinEventId,
-      )
-      tickets = data.tickets.sort((a, b) => a.position - b.position)
-    }
+    // The provider-shaped eventRef (not a bare Checkin event id), so Tito routes
+    // to its account/event slugs.
+    const data = await access.provider.fetchPublicTicketTypes(access.eventRef)
+    tickets = data.tickets.sort((a, b) => a.position - b.position)
   } catch (err) {
     error = (err as Error).message
   }
@@ -102,7 +112,7 @@ export default async function TicketTypesAdminPage() {
       <AdminPageHeader
         icon={<TicketIcon />}
         title="Ticket Types"
-        description="All ticket types configured in Checkin.no for"
+        description={`All ticket types configured in ${providerLabel} for`}
         contextHighlight={conference.title}
         backLink={{ href: '/admin/tickets', label: 'Back to Tickets' }}
       />
@@ -230,7 +240,7 @@ export default async function TicketTypesAdminPage() {
           <EmptyState
             icon={TicketIcon}
             title="No ticket types found"
-            description="No ticket types are configured in Checkin.no for this event."
+            description={`No ticket types are configured in ${providerLabel} for this event.`}
             className="rounded-lg bg-white p-12 shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:ring-gray-700"
           />
         )}

--- a/src/components/admin/SpeakersPageClient.tsx
+++ b/src/components/admin/SpeakersPageClient.tsx
@@ -39,6 +39,14 @@ interface SpeakersPageClientProps {
   }
   confirmedSpeakersCount: number
   conferenceEmail: string
+  /**
+   * Whether this organization may manage speaker badges. `/admin/speakers/badge`
+   * 404s without the entitlement (badge issuance refuses any non-platform org —
+   * RunKonf/platform#46), so the shortcut to it must disappear with it. Defaults
+   * to `false`: a caller that forgets to pass it hides a link rather than
+   * offering a dead one.
+   */
+  badgesEnabled?: boolean
 }
 
 export default function SpeakersPageClient({
@@ -48,6 +56,7 @@ export default function SpeakersPageClient({
   stats,
   confirmedSpeakersCount,
   conferenceEmail,
+  badgesEnabled = false,
 }: SpeakersPageClientProps) {
   const router = useRouter()
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
@@ -231,12 +240,17 @@ export default function SpeakersPageClient({
               onClick: handleCreateClick,
               icon: <PlusIcon className="h-4 w-4" />,
             },
-            {
-              label: 'Manage Badges',
-              href: '/admin/speakers/badge',
-              icon: <AcademicCapIcon className="h-4 w-4" />,
-              variant: 'secondary',
-            },
+            // Hidden without the entitlement — the page it points at 404s.
+            ...(badgesEnabled
+              ? [
+                  {
+                    label: 'Manage Badges',
+                    href: '/admin/speakers/badge',
+                    icon: <AcademicCapIcon className="h-4 w-4" />,
+                    variant: 'secondary' as const,
+                  },
+                ]
+              : []),
             {
               label: 'Travel Support',
               href: '/admin/speakers/travel-support',

--- a/src/components/admin/TicketingStateNotice.stories.tsx
+++ b/src/components/admin/TicketingStateNotice.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { TicketingStateNotice } from './TicketingStateNotice'
+
+const meta = {
+  title: 'Components/Feedback/TicketingStateNotice',
+  component: TicketingStateNotice,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The three honest ticketing empty states an organizer can land on: not connected yet (actionable), not available for the organization (nothing to do), and not supported by the conference’s vendor. None of them is an error frame.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof TicketingStateNotice>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Entitled org, conference not bound to an event yet. */
+export const Unconfigured: Story = {
+  args: {
+    state: 'unconfigured',
+    providerLabel: 'Checkin.no',
+    surface: 'ticket sales',
+  },
+}
+
+/** Same state on a Tito-bound conference — the copy follows the vendor. */
+export const UnconfiguredTito: Story = {
+  args: {
+    state: 'unconfigured',
+    providerLabel: 'Tito',
+    surface: 'ticket types',
+  },
+}
+
+/** A brand-new tenant with no ticketing integration at all. */
+export const Unavailable: Story = {
+  args: {
+    state: 'unavailable',
+    providerLabel: 'Checkin.no',
+    surface: 'orders',
+  },
+}
+
+/** Discount codes are a Checkin-only API; a Tito conference gets this. */
+export const Unsupported: Story = {
+  args: {
+    state: 'unsupported',
+    providerLabel: 'Tito',
+    surface: 'discount codes',
+  },
+}

--- a/src/components/admin/TicketingStateNotice.tsx
+++ b/src/components/admin/TicketingStateNotice.tsx
@@ -39,6 +39,11 @@ interface TicketingStateNoticeProps {
 
 const SETTINGS_HREF = '/admin/settings#tickets-registration'
 
+/** Sentence-cases a `surface` noun phrase for use at the start of a title. */
+function capitalize(surface: string): string {
+  return surface.charAt(0).toUpperCase() + surface.slice(1)
+}
+
 export function TicketingStateNotice({
   state,
   providerLabel,
@@ -52,8 +57,13 @@ export function TicketingStateNotice({
         }
       : state === 'unsupported'
         ? {
-            title: `${providerLabel} does not support this`,
-            description: `${surface.charAt(0).toUpperCase()}${surface.slice(1)} are managed in Checkin.no. This conference sells tickets through ${providerLabel}, so manage them in ${providerLabel} instead.`,
+            // NAMES ONLY THIS CONFERENCE'S OWN VENDOR. An earlier draft said the
+            // surface was "managed in Checkin.no", which is exactly backwards:
+            // this state fires when the CURRENT provider is the one our
+            // integration cannot drive, so pointing a Tito organizer at
+            // Checkin.no sends them somewhere they have no account.
+            title: `${capitalize(surface)} are not available for ${providerLabel}`,
+            description: `${PLATFORM_NAME} cannot manage ${surface} for ${providerLabel} events. Create and manage them in your ${providerLabel} dashboard instead — ticket sales here are unaffected.`,
           }
         : {
             title: 'Ticketing is not available for your organization',

--- a/src/components/admin/TicketingStateNotice.tsx
+++ b/src/components/admin/TicketingStateNotice.tsx
@@ -1,0 +1,81 @@
+import Link from 'next/link'
+import { TicketIcon } from '@heroicons/react/24/outline'
+import { EmptyState } from '@/components/EmptyState'
+import { PLATFORM_NAME } from '@/lib/branding/platform'
+
+/**
+ * The organizer-facing empty states for the ticketing surfaces — the honest
+ * alternative to the red `ErrorDisplay "Checkin.no Configuration Error"` every
+ * ticket page used to render whenever the provider did not resolve.
+ *
+ * Three states, matching {@link import('@/lib/tickets/admin-access')}'s
+ * resolution (and the budget page's empty ≠ error ≠ unavailable rule):
+ *
+ * - `unconfigured` — the org MAY use ticketing but this conference is not bound
+ *   to an event yet. Actionable: it links straight to the ticketing settings.
+ * - `unavailable` — the org has no ticketing integration at all. There is
+ *   nothing to configure, so there is no settings link to offer; saying so
+ *   plainly beats sending an organizer to a form that cannot help.
+ * - `unsupported` — the surface exists but this conference's vendor has no
+ *   equivalent (discount codes are a Checkin-only API).
+ *
+ * NONE of these is an error: no red frame, no exclamation mark, and the page
+ * keeps its own header so the organizer stays oriented.
+ */
+export type TicketingNoticeState =
+  'unconfigured' | 'unavailable' | 'unsupported'
+
+interface TicketingStateNoticeProps {
+  state: TicketingNoticeState
+  /** Vendor label for the copy, e.g. `Checkin.no` or `Tito`. */
+  providerLabel: string
+  /**
+   * What this page would have shown, as a plural noun phrase — "ticket sales",
+   * "orders", "ticket types". Keeps the copy specific to the page an organizer
+   * is actually standing on.
+   */
+  surface: string
+}
+
+const SETTINGS_HREF = '/admin/settings#tickets-registration'
+
+export function TicketingStateNotice({
+  state,
+  providerLabel,
+  surface,
+}: TicketingStateNoticeProps) {
+  const copy: { title: string; description: string } =
+    state === 'unconfigured'
+      ? {
+          title: 'Ticketing is not connected yet',
+          description: `Connect this conference to its ${providerLabel} event in the ticket settings and ${surface} will show up here.`,
+        }
+      : state === 'unsupported'
+        ? {
+            title: `${providerLabel} does not support this`,
+            description: `${surface.charAt(0).toUpperCase()}${surface.slice(1)} are managed in Checkin.no. This conference sells tickets through ${providerLabel}, so manage them in ${providerLabel} instead.`,
+          }
+        : {
+            title: 'Ticketing is not available for your organization',
+            description: `Your organization does not have ${PLATFORM_NAME}'s ticketing integration enabled, so there are no ${surface} to show. Everything else in the admin area works as usual.`,
+          }
+
+  return (
+    <EmptyState
+      icon={TicketIcon}
+      title={copy.title}
+      description={copy.description}
+      className="rounded-lg bg-white p-12 shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:ring-gray-700"
+      action={
+        state === 'unconfigured' ? (
+          <Link
+            href={SETTINGS_HREF}
+            className="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-400"
+          >
+            Open ticket settings
+          </Link>
+        ) : undefined
+      }
+    />
+  )
+}

--- a/src/components/admin/dashboard/widgets/TicketSalesDashboardWidget.tsx
+++ b/src/components/admin/dashboard/widgets/TicketSalesDashboardWidget.tsx
@@ -204,8 +204,10 @@ export function TicketSalesDashboardWidget({
     )
   }
 
-  // Planning & Execution phases: the conference genuinely lacks checkin
-  // customer/event IDs (result.status === 'unconfigured')
+  // Planning & Execution phases: the conference is not bound to a ticketing
+  // event (`result.status === 'unconfigured'`). Kept VENDOR-NEUTRAL — the
+  // binding is Checkin ids OR Tito slugs depending on `ticketingProvider`, so
+  // naming Checkin here would mislead a Tito tenant.
   if (!data) {
     return (
       <div className="flex h-full flex-col">
@@ -220,8 +222,8 @@ export function TicketSalesDashboardWidget({
               Ticket integration not configured
             </p>
             <p className="text-xs text-gray-500 dark:text-gray-400">
-              Set up Check-in customer &amp; event IDs in conference settings to
-              enable ticket tracking.
+              Connect this conference to its ticketing provider in the ticket
+              settings to enable sales tracking.
             </p>
           </div>
         </div>

--- a/src/components/admin/index.ts
+++ b/src/components/admin/index.ts
@@ -63,6 +63,8 @@ export {
 } from './gallery'
 
 export { ErrorDisplay } from './ErrorDisplay'
+export { TicketingStateNotice } from './TicketingStateNotice'
+export type { TicketingNoticeState } from './TicketingStateNotice'
 export * from './LoadingSkeleton'
 export * from './PageLoadingSkeleton'
 

--- a/src/lib/admin/registry.test.ts
+++ b/src/lib/admin/registry.test.ts
@@ -9,6 +9,7 @@ import {
 } from './registry'
 import { SETTINGS_GROUPS, SETTINGS_TIERS } from '@/lib/settings/groups'
 import { APPEARANCE_SECTIONS } from '@/lib/settings/appearance'
+import { FEATURE_IDS, type FeatureId } from '@/lib/features/registry'
 
 describe('admin destination registry', () => {
   it('has globally unique destination ids', () => {
@@ -103,7 +104,66 @@ describe('feature-gated destinations', () => {
     const gated = visibleNavSections([]).flatMap((s) => s.items)
     const all = ADMIN_NAV_SECTIONS.flatMap((s) => s.items)
     const hidden = all.filter((item) => !gated.includes(item))
-    expect(hidden.map((item) => item.href)).toEqual(['/admin/workshops'])
+    // Exactly the tagged nav entries — nothing untagged may go missing.
+    expect(hidden.map((item) => item.href).sort()).toEqual([
+      '/admin/tickets',
+      '/admin/workshops',
+    ])
+  })
+
+  /**
+   * TICKETS (the demo-org audit): every provider-backed ticketing destination
+   * disappears for an org with no ticketing integration, so an organizer is
+   * never pointed at five pages that can only tell them they cannot use them.
+   */
+  it('hides the tickets nav entry and its provider-backed sub-pages', () => {
+    const items = visibleNavSections([]).flatMap((s) => s.items)
+    expect(items.map((item) => item.href)).not.toContain('/admin/tickets')
+
+    const hrefs = visibleDestinations([]).map((d) => d.href)
+    for (const href of [
+      '/admin/tickets',
+      '/admin/tickets/orders',
+      '/admin/tickets/types',
+      '/admin/tickets/discount',
+      '/admin/tickets/companies',
+    ]) {
+      expect(hrefs).not.toContain(href)
+    }
+  })
+
+  it('shows every ticketing destination once the org is entitled', () => {
+    const hrefs = visibleDestinations(['ticketing']).map((d) => d.href)
+    for (const href of [
+      '/admin/tickets',
+      '/admin/tickets/orders',
+      '/admin/tickets/types',
+      '/admin/tickets/discount',
+      '/admin/tickets/companies',
+    ]) {
+      expect(hrefs).toContain(href)
+    }
+  })
+
+  /**
+   * The ticket PAGE CONTENT editor is deliberately ungated: it edits the public
+   * /tickets page copy out of Sanity and touches no provider, so it must stay
+   * reachable for a tenant that has no ticketing integration.
+   */
+  it('keeps the tickets page-content editor available without ticketing', () => {
+    expect(visibleDestinations([]).map((d) => d.href)).toContain(
+      '/admin/tickets/content',
+    )
+  })
+
+  /** BADGES: issuance refuses any non-platform org (RunKonf/platform#46). */
+  it('hides the speaker badges destination without the badges feature', () => {
+    expect(visibleDestinations([]).map((d) => d.href)).not.toContain(
+      '/admin/speakers/badge',
+    )
+    expect(visibleDestinations(['badges']).map((d) => d.href)).toContain(
+      '/admin/speakers/badge',
+    )
   })
 
   it('drops the workshops destination from ⌘K search results', () => {
@@ -121,10 +181,26 @@ describe('feature-gated destinations', () => {
   })
 
   it('drops no ungated destination', () => {
-    expect(visibleDestinations([]).length).toBe(ADMIN_DESTINATIONS.length - 1)
-    expect(visibleDestinations(['workshops']).length).toBe(
+    const tagged = ADMIN_DESTINATIONS.filter((d) => d.feature)
+    // Every gated destination is dropped for an org with no features, and
+    // exactly those — the untagged majority is never touched.
+    expect(visibleDestinations([]).length).toBe(
+      ADMIN_DESTINATIONS.length - tagged.length,
+    )
+    const everyFeature = [
+      ...new Set(tagged.map((d) => d.feature!)),
+    ] as FeatureId[]
+    expect(visibleDestinations(everyFeature).length).toBe(
       ADMIN_DESTINATIONS.length,
     )
+  })
+
+  it('tags a destination only with a real registry feature id', () => {
+    for (const destination of ADMIN_DESTINATIONS) {
+      if (destination.feature) {
+        expect(FEATURE_IDS).toContain(destination.feature)
+      }
+    }
   })
 })
 

--- a/src/lib/admin/registry.ts
+++ b/src/lib/admin/registry.ts
@@ -153,7 +153,8 @@ export const ADMIN_NAV_SECTIONS: AdminNavSection[] = [
         name: 'Tickets',
         href: '/admin/tickets',
         icon: TicketIcon,
-        keywords: ['sales', 'registration', 'attendees', 'checkin'],
+        keywords: ['sales', 'registration', 'attendees', 'checkin', 'tito'],
+        feature: 'ticketing',
       },
       {
         name: 'Sponsors',
@@ -252,6 +253,10 @@ const ADMIN_SUB_PAGES: Omit<AdminDestination, 'kind'>[] = [
     group: 'People',
     keywords: ['badge', 'badges', 'print', 'qr'],
     icon: IdentificationIcon,
+    // Badge issuance signs with ONE global key pair and REFUSES any non-platform
+    // org (RunKonf/platform#46), so an unentitled tenant must not be pointed at
+    // a page whose every action fails — the page itself 404s.
+    feature: 'badges',
   },
   {
     id: 'speakers-travel-support',
@@ -261,6 +266,8 @@ const ADMIN_SUB_PAGES: Omit<AdminDestination, 'kind'>[] = [
     keywords: ['travel', 'funding', 'reimbursement', 'expenses'],
     icon: HeartIcon,
   },
+  // The provider-backed ticketing sub-pages: every one of them reads live data
+  // from Checkin/Tito, so they are gated with the section itself.
   {
     id: 'tickets-orders',
     title: 'Ticket Orders',
@@ -268,6 +275,7 @@ const ADMIN_SUB_PAGES: Omit<AdminDestination, 'kind'>[] = [
     group: 'Events & Content',
     keywords: ['orders', 'purchases', 'attendees', 'sales'],
     icon: TicketIcon,
+    feature: 'ticketing',
   },
   {
     id: 'tickets-types',
@@ -276,6 +284,7 @@ const ADMIN_SUB_PAGES: Omit<AdminDestination, 'kind'>[] = [
     group: 'Events & Content',
     keywords: ['types', 'categories', 'pricing'],
     icon: TicketIcon,
+    feature: 'ticketing',
   },
   {
     id: 'tickets-discount',
@@ -284,6 +293,7 @@ const ADMIN_SUB_PAGES: Omit<AdminDestination, 'kind'>[] = [
     group: 'Events & Content',
     keywords: ['discount', 'codes', 'coupons', 'promo', 'voucher'],
     icon: BanknotesIcon,
+    feature: 'ticketing',
   },
   {
     id: 'tickets-companies',
@@ -292,8 +302,13 @@ const ADMIN_SUB_PAGES: Omit<AdminDestination, 'kind'>[] = [
     group: 'Events & Content',
     keywords: ['companies', 'organizations', 'breakdown'],
     icon: BuildingOfficeIcon,
+    feature: 'ticketing',
   },
   {
+    // DELIBERATELY UNGATED. This edits the public /tickets page's own copy
+    // (inclusions, FAQ, headings) out of Sanity and touches no provider — that
+    // page still renders for a tenant with no ticketing integration, so the
+    // only way to edit it must not disappear with the integration.
     id: 'tickets-content',
     title: 'Tickets Page Content',
     href: '/admin/tickets/content',

--- a/src/lib/features/badges.test.ts
+++ b/src/lib/features/badges.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @vitest-environment node
+ *
+ * The BADGE feature gate — the front door in front of the badge issuance
+ * tripwire (RunKonf/platform#46). Without it `/admin/speakers/badge` rendered
+ * for every tenant and surfaced the tripwire's refusal, which names an internal
+ * issue tracker, once PER SPEAKER.
+ *
+ * One boundary carries the entitlement inputs (`@/lib/organization/sanity`, the
+ * cached org document); platform standing is pure env, so the
+ * `@/lib/sanity/client` mock is a TRIPWIRE — a reintroduced slug lookup would
+ * call it and trip the no-fetch guards.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Organization } from '@/lib/organization/types'
+
+const getOrganizationById = vi.fn()
+
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationById: (...args: unknown[]) => getOrganizationById(...args),
+  getOrganizationRefForCurrentConference: () => null,
+}))
+
+const h = vi.hoisted(() => ({
+  fetch: vi.fn<(query: string, params?: unknown) => Promise<unknown>>(),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: h.fetch },
+}))
+
+import { isBadgesEnabledForOrg, isBadgesEnabledForConference } from './badges'
+
+const PLATFORM_ORG_ID = 'org-platform'
+const PAST = '2020-01-01T00:00:00.000Z'
+const FUTURE = '2999-01-01T00:00:00.000Z'
+
+function org(overrides: Partial<Organization> = {}): Organization {
+  return { _id: 'org-A', name: 'Tenant A', slug: 'tenant-a', ...overrides }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubEnv('PLATFORM_ORG_ID', PLATFORM_ORG_ID)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('isBadgesEnabledForOrg — fail closed', () => {
+  it('is DISABLED and reads nothing when the org cannot be resolved', async () => {
+    await expect(isBadgesEnabledForOrg(null)).resolves.toBe(false)
+    await expect(isBadgesEnabledForOrg(undefined)).resolves.toBe(false)
+    await expect(isBadgesEnabledForOrg('')).resolves.toBe(false)
+    expect(getOrganizationById).not.toHaveBeenCalled()
+  })
+
+  it('is DISABLED for an unknown organization document', async () => {
+    getOrganizationById.mockResolvedValue(null)
+    await expect(isBadgesEnabledForOrg('org-missing')).resolves.toBe(false)
+  })
+
+  it('is DISABLED — not thrown — when the organization read REJECTS', async () => {
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {})
+    getOrganizationById.mockRejectedValue(new Error('sanity unavailable'))
+    await expect(isBadgesEnabledForOrg('org-A')).resolves.toBe(false)
+    expect(logged).toHaveBeenCalled()
+    logged.mockRestore()
+  })
+
+  it('is DISABLED for an ordinary tenant on EVERY plan — no tier sells badges', async () => {
+    for (const plan of ['community', 'pro', 'enterprise'] as const) {
+      getOrganizationById.mockResolvedValue(org({ plan }))
+      await expect(isBadgesEnabledForOrg('org-A')).resolves.toBe(false)
+    }
+  })
+})
+
+describe('isBadgesEnabledForOrg — overrides and the platform default', () => {
+  it('is ENABLED by an explicit grant, regardless of plan', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        plan: 'community',
+        featureOverrides: [{ feature: 'badges', enabled: true }],
+      }),
+    )
+    await expect(isBadgesEnabledForOrg('org-A')).resolves.toBe(true)
+  })
+
+  it('ignores an EXPIRED grant', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        featureOverrides: [
+          { feature: 'badges', enabled: true, expiresAt: PAST },
+        ],
+      }),
+    )
+    await expect(isBadgesEnabledForOrg('org-A')).resolves.toBe(false)
+  })
+
+  it('honours a grant that has not expired yet', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        featureOverrides: [
+          { feature: 'badges', enabled: true, expiresAt: FUTURE },
+        ],
+      }),
+    )
+    await expect(isBadgesEnabledForOrg('org-A')).resolves.toBe(true)
+  })
+
+  it('ignores an override for a different feature', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({ featureOverrides: [{ feature: 'workshops', enabled: true }] }),
+    )
+    await expect(isBadgesEnabledForOrg('org-A')).resolves.toBe(false)
+  })
+
+  it('is ENABLED for the org whose id is PLATFORM_ORG_ID, with no Sanity read for the identity', async () => {
+    getOrganizationById.mockResolvedValue(org({ _id: PLATFORM_ORG_ID }))
+    await expect(isBadgesEnabledForOrg(PLATFORM_ORG_ID)).resolves.toBe(true)
+    expect(h.fetch).not.toHaveBeenCalled()
+  })
+
+  it('lets an explicit DENY revoke it from the platform org', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        _id: PLATFORM_ORG_ID,
+        featureOverrides: [{ feature: 'badges', enabled: false }],
+      }),
+    )
+    await expect(isBadgesEnabledForOrg(PLATFORM_ORG_ID)).resolves.toBe(false)
+  })
+
+  it('DENIES an org whose slug merely LOOKS like the platform org', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({ _id: 'org-A', slug: 'platform-org' }),
+    )
+    await expect(isBadgesEnabledForOrg('org-A')).resolves.toBe(false)
+    expect(h.fetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('isBadgesEnabledForConference', () => {
+  it('keys on the conference OWNER, not the request host', async () => {
+    getOrganizationById.mockResolvedValue(org({ _id: PLATFORM_ORG_ID }))
+    await expect(
+      isBadgesEnabledForConference({
+        organization: { _ref: PLATFORM_ORG_ID, _type: 'reference' },
+      }),
+    ).resolves.toBe(true)
+    expect(getOrganizationById).toHaveBeenCalledWith(PLATFORM_ORG_ID)
+  })
+
+  it('is DISABLED for a conference with no organization (fail closed)', async () => {
+    await expect(isBadgesEnabledForConference({})).resolves.toBe(false)
+    await expect(isBadgesEnabledForConference(null)).resolves.toBe(false)
+    expect(getOrganizationById).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/features/badges.test.ts
+++ b/src/lib/features/badges.test.ts
@@ -77,18 +77,40 @@ describe('isBadgesEnabledForOrg — fail closed', () => {
   })
 })
 
-describe('isBadgesEnabledForOrg — overrides and the platform default', () => {
-  it('is ENABLED by an explicit grant, regardless of plan', async () => {
+/**
+ * THE GATE CANNOT BE LOOSER THAN THE CAPABILITY.
+ *
+ * Badge signing is ONE global key pair and `issueBadgeForSpeaker` refuses every
+ * non-platform org. A `badges` grant that opened the page anyway would hand an
+ * organizer the full management UI for something structurally broken — every
+ * Issue, Rebake and bulk run failing with the tripwire's message, which is the
+ * dead end this gate exists to remove, recreated by an operator's own override.
+ * So the override may REVOKE but never GRANT, until platform#46 ships per-tenant
+ * keys and the capability check relaxes with it.
+ */
+describe('isBadgesEnabledForOrg — a grant cannot open a broken surface', () => {
+  it('is DISABLED for a non-platform org even with an ACTIVE grant', async () => {
     getOrganizationById.mockResolvedValue(
       org({
         plan: 'community',
         featureOverrides: [{ feature: 'badges', enabled: true }],
       }),
     )
-    await expect(isBadgesEnabledForOrg('org-A')).resolves.toBe(true)
+    await expect(isBadgesEnabledForOrg('org-A')).resolves.toBe(false)
   })
 
-  it('ignores an EXPIRED grant', async () => {
+  it('is DISABLED for a non-platform org with an unexpired grant', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        featureOverrides: [
+          { feature: 'badges', enabled: true, expiresAt: FUTURE },
+        ],
+      }),
+    )
+    await expect(isBadgesEnabledForOrg('org-A')).resolves.toBe(false)
+  })
+
+  it('is DISABLED for a non-platform org with an EXPIRED grant', async () => {
     getOrganizationById.mockResolvedValue(
       org({
         featureOverrides: [
@@ -99,17 +121,17 @@ describe('isBadgesEnabledForOrg — overrides and the platform default', () => {
     await expect(isBadgesEnabledForOrg('org-A')).resolves.toBe(false)
   })
 
-  it('honours a grant that has not expired yet', async () => {
-    getOrganizationById.mockResolvedValue(
-      org({
-        featureOverrides: [
-          { feature: 'badges', enabled: true, expiresAt: FUTURE },
-        ],
-      }),
-    )
-    await expect(isBadgesEnabledForOrg('org-A')).resolves.toBe(true)
+  it('a grant does NOT reach past the capability on ANY plan', async () => {
+    for (const plan of ['community', 'pro', 'enterprise'] as const) {
+      getOrganizationById.mockResolvedValue(
+        org({ plan, featureOverrides: [{ feature: 'badges', enabled: true }] }),
+      )
+      await expect(isBadgesEnabledForOrg('org-A')).resolves.toBe(false)
+    }
   })
+})
 
+describe('isBadgesEnabledForOrg — the platform default and its revocation', () => {
   it('ignores an override for a different feature', async () => {
     getOrganizationById.mockResolvedValue(
       org({ featureOverrides: [{ feature: 'workshops', enabled: true }] }),
@@ -131,6 +153,18 @@ describe('isBadgesEnabledForOrg — overrides and the platform default', () => {
       }),
     )
     await expect(isBadgesEnabledForOrg(PLATFORM_ORG_ID)).resolves.toBe(false)
+  })
+
+  it('ignores an EXPIRED deny on the platform org', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        _id: PLATFORM_ORG_ID,
+        featureOverrides: [
+          { feature: 'badges', enabled: false, expiresAt: PAST },
+        ],
+      }),
+    )
+    await expect(isBadgesEnabledForOrg(PLATFORM_ORG_ID)).resolves.toBe(true)
   })
 
   it('DENIES an org whose slug merely LOOKS like the platform org', async () => {

--- a/src/lib/features/badges.ts
+++ b/src/lib/features/badges.ts
@@ -1,0 +1,57 @@
+import 'server-only'
+import {
+  conferenceOrgId,
+  isPlatformDefaultFeatureEnabledForOrg,
+  type ConferenceTenant,
+} from './platform-default'
+
+/**
+ * THE single gate for the speaker BADGE feature — the `/admin/speakers/badge`
+ * management surface and the "Manage Badges" entry that points at it.
+ *
+ * WHY IT IS GATED. Open Badge credentials are signed with ONE GLOBAL key pair
+ * shared by every tenant, and issued bytes verify PERMANENTLY on platforms we do
+ * not control (Credly, 1EdTech, LinkedIn) — a badge minted for a second tenant on
+ * the global keys could never be un-issued or re-signed. `issueBadgeForSpeaker`
+ * therefore REFUSES any non-platform org outright (the Phase 0 tripwire,
+ * RunKonf/platform#46). That refusal is correct but invisible until an organizer
+ * clicks Issue, at which point the raw refusal — which names an internal issue
+ * tracker — is rendered once PER SPEAKER.
+ *
+ * This gate moves the same decision to the front door, so a tenant that can
+ * never issue a badge never reaches a page whose every action fails: the nav
+ * entry and the ⌘K destination are hidden (see the `feature` tag in
+ * `@/lib/admin/registry`) and the page itself 404s. The issuance tripwire STAYS
+ * — it is the security boundary; this is presentation.
+ *
+ * The `badges` registry entry is `readiness: 'internal'` with NO `minPlan`: it
+ * is not sellable at any tier until per-tenant signing keys exist
+ * (platform#46), so an override is the only way to grant it, and granting it
+ * without those keys would surface a page whose issuance still refuses.
+ *
+ * Resolution order, caching and fail-closed posture: see `./platform-default`.
+ */
+
+/** The registry id this module gates. */
+const BADGES_FEATURE = 'badges' as const
+
+/**
+ * Whether the organization may manage speaker badges. A nullish org id is
+ * DISABLED (fail closed).
+ */
+export async function isBadgesEnabledForOrg(
+  orgId: string | null | undefined,
+): Promise<boolean> {
+  return isPlatformDefaultFeatureEnabledForOrg(orgId, BADGES_FEATURE)
+}
+
+/**
+ * Whether badges are enabled for the tenant that OWNS this conference — the
+ * same tenant key `issueBadgeForSpeaker` compares against the platform org, so
+ * the page gate and the issuance tripwire agree by construction.
+ */
+export async function isBadgesEnabledForConference(
+  conference: ConferenceTenant | null | undefined,
+): Promise<boolean> {
+  return isBadgesEnabledForOrg(conferenceOrgId(conference))
+}

--- a/src/lib/features/badges.ts
+++ b/src/lib/features/badges.ts
@@ -1,9 +1,10 @@
 import 'server-only'
 import {
   conferenceOrgId,
-  isPlatformDefaultFeatureEnabledForOrg,
+  resolveRegistryEntitlement,
   type ConferenceTenant,
 } from './platform-default'
+import { isPlatformOrganization } from './platform'
 
 /**
  * THE single gate for the speaker BADGE feature — the `/admin/speakers/badge`
@@ -24,25 +25,55 @@ import {
  * `@/lib/admin/registry`) and the page itself 404s. The issuance tripwire STAYS
  * — it is the security boundary; this is presentation.
  *
- * The `badges` registry entry is `readiness: 'internal'` with NO `minPlan`: it
- * is not sellable at any tier until per-tenant signing keys exist
- * (platform#46), so an override is the only way to grant it, and granting it
- * without those keys would surface a page whose issuance still refuses.
+ * ── THE GATE TRACKS THE CAPABILITY, IN BOTH DIRECTIONS ──────────────────────
  *
- * Resolution order, caching and fail-closed posture: see `./platform-default`.
+ * This is the MIRROR of the ticketing gate, and the asymmetry is deliberate.
+ * Ticketing resolves the provider FIRST so the gate is never STRICTER than the
+ * credentials — it must not hide a surface that works. Badges have the opposite
+ * hazard: the capability is a single global key pair that exists for exactly one
+ * org, so a gate that is LOOSER than issuance would hand an organizer the full
+ * management UI for something structurally broken — every Issue, every Rebake,
+ * every bulk run failing with the tripwire's message. That is the dead end this
+ * whole change exists to remove, re-created by an operator's own grant.
+ *
+ * So a `badges` override can REVOKE (a deny beats the platform default, like
+ * every other feature) but cannot GRANT: the final word is
+ * `isPlatformOrganization`, the same comparison `issueBadgeForSpeaker` makes. An
+ * `enabled: true` override on a non-platform org is therefore inert TODAY, by
+ * design — it is not a way to opt into a broken surface.
+ *
+ * WHEN platform#46 SHIPS per-tenant signing keys, this is the ONE line to
+ * change: replace `isPlatformOrganization` with "the org has resolvable signing
+ * keys" — the same relaxation the issuance tripwire's own comment promises — and
+ * the override becomes meaningful again for orgs that have them. Keep the two
+ * moving together; that is the invariant this module exists to hold.
+ *
+ * Caching and fail-closed posture: see `./platform-default`.
  */
 
 /** The registry id this module gates. */
 const BADGES_FEATURE = 'badges' as const
 
 /**
- * Whether the organization may manage speaker badges. A nullish org id is
- * DISABLED (fail closed).
+ * Whether the organization may manage speaker badges: an explicit deny wins,
+ * and otherwise the org must be the one that can actually ISSUE. A nullish or
+ * unresolvable org id is DISABLED (fail closed).
  */
 export async function isBadgesEnabledForOrg(
   orgId: string | null | undefined,
 ): Promise<boolean> {
-  return isPlatformDefaultFeatureEnabledForOrg(orgId, BADGES_FEATURE)
+  // Overrides still REVOKE — an operator must be able to take the surface away
+  // from the platform org — and an unresolvable org resolves to `denied` here,
+  // which keeps the fail-closed posture without a second null check.
+  if ((await resolveRegistryEntitlement(orgId, BADGES_FEATURE)) === 'denied') {
+    return false
+  }
+
+  // The capability itself. An `enabled: true` override does NOT reach past this:
+  // see the module doc — granting a page whose every action fails would recreate
+  // the dead end. ID comparison against the ONE uncached resolver, never the
+  // cached document's `slug`.
+  return isPlatformOrganization(orgId)
 }
 
 /**

--- a/src/lib/features/enabled.test.ts
+++ b/src/lib/features/enabled.test.ts
@@ -1,0 +1,154 @@
+/**
+ * @vitest-environment node
+ *
+ * The EFFECTIVE feature set the admin shell filters its nav and ⌘K destinations
+ * by. The admin layout used to hardcode `['workshops'] | []`, which is why no
+ * other feature could gate a destination however it was tagged; this composes
+ * the registry resolution with each platform-default gate's own answer.
+ *
+ * Real entitlement resolution runs — only the org document read and the per-org
+ * secret env are supplied.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Organization } from '@/lib/organization/types'
+
+const getOrganizationById = vi.fn()
+
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationById: (...args: unknown[]) => getOrganizationById(...args),
+  getOrganizationRefForCurrentConference: () => null,
+}))
+
+const h = vi.hoisted(() => ({
+  fetch: vi.fn<(query: string, params?: unknown) => Promise<unknown>>(),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: h.fetch },
+}))
+
+import {
+  resolveEnabledFeaturesForOrg,
+  resolveEnabledFeaturesForConference,
+} from './enabled'
+import { PLATFORM_DEFAULT_FEATURES } from './platform-default'
+import { FEATURES } from './registry'
+
+const PLATFORM_ORG_ID = 'org-platform'
+
+function org(overrides: Partial<Organization> = {}): Organization {
+  return { _id: 'org-A', name: 'Tenant A', slug: 'tenant-a', ...overrides }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubEnv('PLATFORM_ORG_ID', PLATFORM_ORG_ID)
+  vi.stubEnv('TENANT_SECRETS_JSON', '')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+/**
+ * NO PLAN TIER SELLS THESE YET. Which tier eventually sells ticketing, badges
+ * or workshops is an open owner decision; encoding a guess would hand a
+ * customer a surface that cannot work (one WorkOS client, one provider account,
+ * one badge signing key pair). This fails the moment someone adds a `minPlan`.
+ */
+describe('the platform-default features stay internal and tier-less', () => {
+  it.each(PLATFORM_DEFAULT_FEATURES)('%s', (id) => {
+    expect(FEATURES[id].readiness).toBe('internal')
+    expect(FEATURES[id].minPlan).toBeUndefined()
+  })
+})
+
+describe('resolveEnabledFeaturesForOrg', () => {
+  it('gives a brand-new community tenant NOTHING — the day-one demo org', async () => {
+    getOrganizationById.mockResolvedValue(org({ plan: 'community' }))
+    await expect(resolveEnabledFeaturesForOrg('org-A')).resolves.toEqual([])
+  })
+
+  it('gives the platform org every platform-default feature', async () => {
+    getOrganizationById.mockResolvedValue(org({ _id: PLATFORM_ORG_ID }))
+    await expect(
+      resolveEnabledFeaturesForOrg(PLATFORM_ORG_ID),
+    ).resolves.toEqual(['workshops', 'ticketing', 'badges'])
+  })
+
+  it('includes plan-granted ga features alongside the platform defaults', async () => {
+    // `dedicated-email` is the ga/minPlan-pro registry entry.
+    getOrganizationById.mockResolvedValue(org({ plan: 'pro' }))
+    await expect(resolveEnabledFeaturesForOrg('org-A')).resolves.toEqual([
+      'dedicated-email',
+    ])
+  })
+
+  it('honours a single override without granting its siblings', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({ featureOverrides: [{ feature: 'ticketing', enabled: true }] }),
+    )
+    await expect(resolveEnabledFeaturesForOrg('org-A')).resolves.toEqual([
+      'ticketing',
+    ])
+  })
+
+  it('lets a DENY override revoke a platform-default from the platform org', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        _id: PLATFORM_ORG_ID,
+        featureOverrides: [{ feature: 'badges', enabled: false }],
+      }),
+    )
+    await expect(
+      resolveEnabledFeaturesForOrg(PLATFORM_ORG_ID),
+    ).resolves.toEqual(['workshops', 'ticketing'])
+  })
+
+  it('is EMPTY for an unresolvable org, and reads nothing (fail closed)', async () => {
+    await expect(resolveEnabledFeaturesForOrg(null)).resolves.toEqual([])
+    await expect(resolveEnabledFeaturesForOrg(undefined)).resolves.toEqual([])
+    expect(getOrganizationById).not.toHaveBeenCalled()
+  })
+
+  it('is EMPTY — not thrown — when the org read REJECTS', async () => {
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {})
+    getOrganizationById.mockRejectedValue(new Error('sanity unavailable'))
+    await expect(resolveEnabledFeaturesForOrg('org-A')).resolves.toEqual([])
+    expect(logged).toHaveBeenCalled()
+    logged.mockRestore()
+  })
+
+  it('returns registry declaration order, whatever grants it', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        plan: 'pro',
+        featureOverrides: [
+          { feature: 'badges', enabled: true },
+          { feature: 'graphql-api', enabled: true },
+        ],
+      }),
+    )
+    await expect(resolveEnabledFeaturesForOrg('org-A')).resolves.toEqual([
+      'graphql-api',
+      'dedicated-email',
+      'badges',
+    ])
+  })
+})
+
+describe('resolveEnabledFeaturesForConference', () => {
+  it('keys on the conference OWNER', async () => {
+    getOrganizationById.mockResolvedValue(org({ _id: PLATFORM_ORG_ID }))
+    await expect(
+      resolveEnabledFeaturesForConference({
+        organization: { _ref: PLATFORM_ORG_ID, _type: 'reference' },
+      }),
+    ).resolves.toContain('ticketing')
+  })
+
+  it('is EMPTY for a conference with no organization', async () => {
+    await expect(resolveEnabledFeaturesForConference({})).resolves.toEqual([])
+    await expect(resolveEnabledFeaturesForConference(null)).resolves.toEqual([])
+  })
+})

--- a/src/lib/features/enabled.test.ts
+++ b/src/lib/features/enabled.test.ts
@@ -124,7 +124,7 @@ describe('resolveEnabledFeaturesForOrg', () => {
       org({
         plan: 'pro',
         featureOverrides: [
-          { feature: 'badges', enabled: true },
+          { feature: 'ticketing', enabled: true },
           { feature: 'graphql-api', enabled: true },
         ],
       }),
@@ -132,8 +132,20 @@ describe('resolveEnabledFeaturesForOrg', () => {
     await expect(resolveEnabledFeaturesForOrg('org-A')).resolves.toEqual([
       'graphql-api',
       'dedicated-email',
-      'badges',
+      'ticketing',
     ])
+  })
+
+  /**
+   * The badge gate is the one that cannot be opened by an override — its
+   * capability is a single global key pair. The composed set must honour that,
+   * or the nav would offer a page the gate itself 404s.
+   */
+  it('does not grant badges to a non-platform org by override', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({ featureOverrides: [{ feature: 'badges', enabled: true }] }),
+    )
+    await expect(resolveEnabledFeaturesForOrg('org-A')).resolves.toEqual([])
   })
 })
 

--- a/src/lib/features/enabled.ts
+++ b/src/lib/features/enabled.ts
@@ -1,0 +1,80 @@
+import 'server-only'
+import { getEntitlementsForOrganization } from './entitlements'
+import {
+  conferenceOrgId,
+  PLATFORM_DEFAULT_FEATURES,
+  type ConferenceTenant,
+  type PlatformDefaultFeature,
+} from './platform-default'
+import { isBadgesEnabledForOrg } from './badges'
+import { isTicketingEnabledForOrg } from './ticketing'
+import { isWorkshopsEnabledForOrg } from './workshops'
+import { FEATURE_IDS, type FeatureId } from './registry'
+
+/**
+ * The org's EFFECTIVE feature set — what the admin shell filters its nav and ⌘K
+ * destinations by (`visibleNavSections` / `visibleDestinations`).
+ *
+ * WHY THIS EXISTS. `computeEntitlements` alone is not the whole truth: the
+ * platform-default features (`workshops`, `ticketing`, `badges`) carry implicit
+ * grants their own resolvers own — the platform org, and for `ticketing` an org
+ * with its own provider credentials. The admin layout used to hardcode
+ * `['workshops']`, which meant no other feature could ever gate a destination.
+ * This composes the registry resolution with each gate's own answer, so a
+ * destination tagged with ANY feature id is filtered by the same decision the
+ * page itself re-checks server-side.
+ *
+ * Each gate reads the org document through the cached, `organizationTag`-tagged
+ * `getOrganizationById`, so the calls below share one underlying read per
+ * request rather than fanning out to Sanity.
+ *
+ * PRESENTATION, NOT SECURITY: hiding a destination only removes the pointer.
+ * Every gated page re-checks its own gate (`notFound()` for badges and
+ * workshops, an explicit unavailable state for ticketing).
+ */
+export async function resolveEnabledFeaturesForOrg(
+  orgId: string | null | undefined,
+): Promise<FeatureId[]> {
+  if (!orgId) return []
+
+  const [entitled, workshops, ticketing, badges] = await Promise.all([
+    // Resolves the plan/override baseline for the features that have no
+    // resolver of their own (`graphql-api`, `dedicated-email`, `slack-mirror`).
+    getEntitlementsForOrganization(orgId).catch((error: unknown) => {
+      console.error(
+        `[features] entitlement resolution failed for ${orgId}; treating every feature as DISABLED`,
+        error,
+      )
+      return new Set<FeatureId>()
+    }),
+    isWorkshopsEnabledForOrg(orgId),
+    isTicketingEnabledForOrg(orgId),
+    isBadgesEnabledForOrg(orgId),
+  ])
+
+  const enabled = new Set(entitled)
+  // Each gate is AUTHORITATIVE for its own feature, in both directions: it adds
+  // the platform-default grant the registry alone cannot express, and an
+  // explicit deny it honours must not be re-added by the baseline above. The
+  // record is keyed by the union, so adding a platform-default feature without
+  // wiring its resolver here is a COMPILE error, not a silently missing gate.
+  const gated: Record<PlatformDefaultFeature, boolean> = {
+    workshops,
+    ticketing,
+    badges,
+  }
+  for (const feature of PLATFORM_DEFAULT_FEATURES) {
+    if (gated[feature]) enabled.add(feature)
+    else enabled.delete(feature)
+  }
+
+  // Registry declaration order, so the list is stable for tests and snapshots.
+  return FEATURE_IDS.filter((id) => enabled.has(id))
+}
+
+/** {@link resolveEnabledFeaturesForOrg} for the tenant that OWNS a conference. */
+export async function resolveEnabledFeaturesForConference(
+  conference: ConferenceTenant | null | undefined,
+): Promise<FeatureId[]> {
+  return resolveEnabledFeaturesForOrg(conferenceOrgId(conference))
+}

--- a/src/lib/features/platform-default.ts
+++ b/src/lib/features/platform-default.ts
@@ -1,0 +1,123 @@
+import 'server-only'
+import { getOrganizationById } from '@/lib/organization/sanity'
+import { computeEntitlements, hasActiveOverride } from './entitlements'
+import { isPlatformOrganization } from './platform'
+import type { FeatureId } from './registry'
+
+/**
+ * The shared resolution shape behind every PLATFORM-DEFAULT feature — the
+ * features that are `readiness: 'internal'` in the registry AND carry an
+ * implicit grant to the organization configured as `PLATFORM_ORG_ID`.
+ *
+ * WHY THE SHAPE EXISTS. `workshops` (#689), `ticketing` (#820) and `badges`
+ * (RunKonf/platform#46) each depend on ONE global credential the platform
+ * deployment owns — one WorkOS client, one provider account, one badge signing
+ * key pair. None of them works for a second tenant today, and none has a plan
+ * tier yet. So the honest default for all three is "the platform org, and
+ * whoever an operator explicitly grants", which is exactly what
+ * `./workshops.ts` worked out first; this module is that logic, factored out so
+ * the three gates cannot drift.
+ *
+ * RESOLUTION ORDER — fail-CLOSED at every step:
+ *
+ *  1. No resolvable org (unknown domain, missing org document, or a REJECTED
+ *     org read) → DENIED. An unresolvable tenant must never degrade into "serve
+ *     it anyway"; this mirrors the org-scoped authz waist's posture.
+ *  2. An ACTIVE `featureOverrides` entry wins, in BOTH directions —
+ *     `enabled: true` grants it to a pilot org, `enabled: false` revokes it even
+ *     from the platform org (rule 3).
+ *  3. Otherwise the decision is UNSET and the caller applies its own default.
+ *     {@link isPlatformDefaultFeatureEnabledForOrg} applies the shared one: the
+ *     org whose id is `PLATFORM_ORG_ID` keeps the feature. `./ticketing.ts`
+ *     layers one extra grant on top (an org with its OWN provider credentials).
+ *
+ * ONE READ ONLY: `plan` and `featureOverrides` come from `getOrganizationById`,
+ * cached and tagged `organizationTag(orgId)`, so an override flip takes effect
+ * by INVALIDATION. Platform standing comes from `isPlatformOrganization`, a pure
+ * id comparison against the configured `PLATFORM_ORG_ID` — no Sanity read, no
+ * cache, no staleness window, and never the document's customer-writable `slug`.
+ * Override expiry is evaluated per call against a fresh `now`.
+ */
+
+/** The features that default to the platform organization (see the module doc). */
+export const PLATFORM_DEFAULT_FEATURES = [
+  'workshops',
+  'ticketing',
+  'badges',
+] as const satisfies readonly FeatureId[]
+
+export type PlatformDefaultFeature = (typeof PLATFORM_DEFAULT_FEATURES)[number]
+
+/**
+ * What the REGISTRY (plan + overrides) decides for a feature. `'unset'` means
+ * neither granted nor explicitly denied — the caller's implicit default applies.
+ */
+export type RegistryDecision = 'granted' | 'denied' | 'unset'
+
+/**
+ * The registry's decision for `feature` on `orgId`. A nullish org, an unknown
+ * organization document, and a rejected read all resolve to `'denied'` (fail
+ * closed) rather than `'unset'` — an unresolvable tenant must not inherit a
+ * default grant.
+ */
+export async function resolveRegistryEntitlement(
+  orgId: string | null | undefined,
+  feature: FeatureId,
+): Promise<RegistryDecision> {
+  if (!orgId) return 'denied'
+
+  // A REJECTED read (transient Sanity failure) must resolve to DENIED like any
+  // other unresolvable org — never propagate, or one flaky read would 500 the
+  // whole admin dashboard through the nav's entitlement lookup.
+  let org
+  try {
+    org = await getOrganizationById(orgId)
+  } catch (error) {
+    console.error(
+      `[features] organization read failed for ${orgId}; treating "${feature}" as DISABLED`,
+      error,
+    )
+    return 'denied'
+  }
+  if (!org) return 'denied'
+
+  const now = new Date()
+  if (computeEntitlements(org.plan, org.featureOverrides, now).has(feature)) {
+    return 'granted'
+  }
+
+  // Not entitled by plan/override. An ACTIVE override at this point can only be
+  // an explicit `enabled: false`, which must beat any caller-side default.
+  if (hasActiveOverride(org.featureOverrides, feature, now)) return 'denied'
+
+  return 'unset'
+}
+
+/**
+ * Whether a platform-default feature is enabled for `orgId`: the registry
+ * decision, falling back to "is this the platform org?" when it is unset.
+ */
+export async function isPlatformDefaultFeatureEnabledForOrg(
+  orgId: string | null | undefined,
+  feature: PlatformDefaultFeature,
+): Promise<boolean> {
+  const decision = await resolveRegistryEntitlement(orgId, feature)
+  if (decision !== 'unset') return decision === 'granted'
+  // ID comparison against the ONE uncached resolver, never the cached document's
+  // `slug` — see `./platform`. This is a grant, and this deployment has an org
+  // that is both the platform org and a tenant, so a slug edit that revokes it
+  // must revoke it NOW rather than whenever the cached document expires.
+  return isPlatformOrganization(orgId)
+}
+
+/** The minimum conference shape these gates read — its owning tenant. */
+export interface ConferenceTenant {
+  organization?: { _ref: string; _type?: 'reference' }
+}
+
+/** The owning tenant of a conference, or `null` (fail closed). */
+export function conferenceOrgId(
+  conference: ConferenceTenant | null | undefined,
+): string | null {
+  return conference?.organization?._ref ?? null
+}

--- a/src/lib/features/registry.ts
+++ b/src/lib/features/registry.ts
@@ -33,11 +33,20 @@ import {
  *
  * The set is intentionally SMALL and truthful. `graphql-api` and
  * `dedicated-email` are still foundation-only (not enforced anywhere).
- * `workshops` and `slack-mirror` ARE enforced — see `./workshops.ts` and
- * `./slack.ts` for the single resolver each of their surfaces goes through
- * (`slack-mirror` gates the PLATFORM's shared Slack bot token, consumed at the
- * one chokepoint `resolveConferenceSlackToken`). Enforcement is wired
- * per-feature via that pattern or the `requireFeature` tRPC middleware.
+ * `workshops`, `slack-mirror`, `ticketing` and `badges` ARE enforced — see
+ * `./workshops.ts`, `./slack.ts`, `./ticketing.ts` and `./badges.ts` for the
+ * single resolver each of their surfaces goes through (`slack-mirror` gates the
+ * PLATFORM's shared Slack bot token, consumed at the one chokepoint
+ * `resolveConferenceSlackToken`). Enforcement is wired per-feature via that
+ * pattern or the `requireFeature` tRPC middleware.
+ *
+ * `workshops`, `ticketing` and `badges` share the PLATFORM-DEFAULT shape
+ * (`./platform-default.ts`): `internal` readiness plus an implicit grant to the
+ * organization configured as `PLATFORM_ORG_ID`, because each depends on a single
+ * global credential the platform deployment owns (one WorkOS client, one
+ * provider account, one badge signing key pair). NO plan tier maps to them yet —
+ * which tier eventually sells ticketing or badges is an open owner decision, and
+ * encoding a guess here would grant a customer a surface that cannot work.
  */
 
 export const FEATURE_IDS = [
@@ -45,6 +54,8 @@ export const FEATURE_IDS = [
   'dedicated-email',
   'slack-mirror',
   'workshops',
+  'ticketing',
+  'badges',
 ] as const
 
 export type FeatureId = (typeof FEATURE_IDS)[number]
@@ -94,6 +105,20 @@ export const FEATURES: Record<FeatureId, FeatureDefinition> = {
     title: 'Workshop portal',
     description:
       'Attendee workshop sign-up portal, organizer workshop management, and the automatic workshop instructions email sent on every workshop ticket sale.',
+    readiness: 'internal',
+  },
+  ticketing: {
+    id: 'ticketing',
+    title: 'Ticketing integration',
+    description:
+      'Organizer ticket sales, orders, ticket types, discount codes and company breakdown, read live from the conference’s ticketing provider (Checkin.no or Tito).',
+    readiness: 'internal',
+  },
+  badges: {
+    id: 'badges',
+    title: 'Speaker badges',
+    description:
+      'Issuing and emailing OpenBadges v3.0 credentials to speakers and organizers.',
     readiness: 'internal',
   },
 }

--- a/src/lib/features/registry.ts
+++ b/src/lib/features/registry.ts
@@ -117,8 +117,12 @@ export const FEATURES: Record<FeatureId, FeatureDefinition> = {
   badges: {
     id: 'badges',
     title: 'Speaker badges',
+    // The override editor renders this description, so it says out loud that a
+    // GRANT here does nothing: issuance signs with one global key pair and
+    // refuses every non-platform org, so `./badges.ts` will not open a surface
+    // whose every action fails. Revoking still works.
     description:
-      'Issuing and emailing OpenBadges v3.0 credentials to speakers and organizers.',
+      'Issuing and emailing OpenBadges v3.0 credentials to speakers and organizers. Platform organization only until per-tenant signing keys exist (platform#46) — an override can revoke this, but cannot grant it.',
     readiness: 'internal',
   },
 }

--- a/src/lib/features/ticketing.test.ts
+++ b/src/lib/features/ticketing.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @vitest-environment node
+ *
+ * The TICKETING feature gate. Two boundaries carry its inputs and both are real
+ * env/document reads, not network:
+ *
+ *  - `@/lib/organization/sanity` — the cached org document (plan + overrides).
+ *  - `TENANT_SECRETS_JSON` — the per-org secret store, read through the REAL
+ *    `perOrgSecretsStore` so the gate and `resolveTicketingCredentials` cannot
+ *    disagree about what "has credentials" means.
+ *
+ * The `@/lib/sanity/client` mock is a TRIPWIRE: platform standing is a pure id
+ * comparison and must read nothing.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Organization } from '@/lib/organization/types'
+
+const getOrganizationById = vi.fn()
+
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationById: (...args: unknown[]) => getOrganizationById(...args),
+  getOrganizationRefForCurrentConference: () => null,
+}))
+
+const h = vi.hoisted(() => ({
+  fetch: vi.fn<(query: string, params?: unknown) => Promise<unknown>>(),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: h.fetch },
+}))
+
+import {
+  isTicketingEnabledForOrg,
+  isTicketingEnabledForConference,
+} from './ticketing'
+
+const PLATFORM_ORG_ID = 'org-platform'
+
+function org(overrides: Partial<Organization> = {}): Organization {
+  return { _id: 'org-A', name: 'Tenant A', slug: 'tenant-a', ...overrides }
+}
+
+/** A tenant with its OWN Checkin account in the per-org secret store. */
+function stubOwnTicketingSecret(orgId: string) {
+  vi.stubEnv(
+    'TENANT_SECRETS_JSON',
+    JSON.stringify({ [orgId]: { ticketing: { apiKey: 'tenant-key' } } }),
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubEnv('PLATFORM_ORG_ID', PLATFORM_ORG_ID)
+  vi.stubEnv('TENANT_SECRETS_JSON', '')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('isTicketingEnabledForOrg — fail closed', () => {
+  it('is DISABLED and reads nothing when the org cannot be resolved', async () => {
+    await expect(isTicketingEnabledForOrg(null)).resolves.toBe(false)
+    await expect(isTicketingEnabledForOrg(undefined)).resolves.toBe(false)
+    await expect(isTicketingEnabledForOrg('')).resolves.toBe(false)
+    expect(getOrganizationById).not.toHaveBeenCalled()
+  })
+
+  it('is DISABLED for an unknown organization document', async () => {
+    getOrganizationById.mockResolvedValue(null)
+    await expect(isTicketingEnabledForOrg('org-missing')).resolves.toBe(false)
+  })
+
+  it('is DISABLED — not thrown — when the organization read REJECTS', async () => {
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {})
+    getOrganizationById.mockRejectedValue(new Error('sanity unavailable'))
+    await expect(isTicketingEnabledForOrg('org-A')).resolves.toBe(false)
+    expect(logged).toHaveBeenCalled()
+    logged.mockRestore()
+  })
+
+  /** THE DEMO-ORG CASE: a brand-new tenant, any plan, no credentials. */
+  it('is DISABLED for an ordinary tenant with no credentials, on every plan', async () => {
+    for (const plan of ['community', 'pro', 'enterprise'] as const) {
+      getOrganizationById.mockResolvedValue(org({ plan }))
+      await expect(isTicketingEnabledForOrg('org-A')).resolves.toBe(false)
+    }
+  })
+})
+
+describe('isTicketingEnabledForOrg — grants', () => {
+  it('is ENABLED for the platform org (it owns the env provider account)', async () => {
+    getOrganizationById.mockResolvedValue(org({ _id: PLATFORM_ORG_ID }))
+    await expect(isTicketingEnabledForOrg(PLATFORM_ORG_ID)).resolves.toBe(true)
+    expect(h.fetch).not.toHaveBeenCalled()
+  })
+
+  it('is ENABLED by an explicit override grant, regardless of plan', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        plan: 'community',
+        featureOverrides: [{ feature: 'ticketing', enabled: true }],
+      }),
+    )
+    await expect(isTicketingEnabledForOrg('org-A')).resolves.toBe(true)
+  })
+
+  /**
+   * THE NEVER-HIDE-WHAT-WORKS RULE: an org the secret seam can serve has a
+   * working integration, so the gate must not be stricter than
+   * `resolveTicketingCredentials`.
+   */
+  it('is ENABLED for a tenant with its OWN per-org ticketing credentials', async () => {
+    stubOwnTicketingSecret('org-A')
+    getOrganizationById.mockResolvedValue(org({ plan: 'community' }))
+    await expect(isTicketingEnabledForOrg('org-A')).resolves.toBe(true)
+  })
+
+  it('does not lend one tenant’s credentials to another', async () => {
+    stubOwnTicketingSecret('org-B')
+    getOrganizationById.mockResolvedValue(org())
+    await expect(isTicketingEnabledForOrg('org-A')).resolves.toBe(false)
+  })
+
+  it('lets an explicit DENY revoke it from the platform org AND from a credentialed tenant', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        _id: PLATFORM_ORG_ID,
+        featureOverrides: [{ feature: 'ticketing', enabled: false }],
+      }),
+    )
+    await expect(isTicketingEnabledForOrg(PLATFORM_ORG_ID)).resolves.toBe(false)
+
+    stubOwnTicketingSecret('org-A')
+    getOrganizationById.mockResolvedValue(
+      org({ featureOverrides: [{ feature: 'ticketing', enabled: false }] }),
+    )
+    await expect(isTicketingEnabledForOrg('org-A')).resolves.toBe(false)
+  })
+
+  it('ignores a malformed per-org secret entry (never a silent grant)', async () => {
+    vi.stubEnv('TENANT_SECRETS_JSON', '{not json')
+    getOrganizationById.mockResolvedValue(org())
+    await expect(isTicketingEnabledForOrg('org-A')).resolves.toBe(false)
+  })
+})
+
+describe('isTicketingEnabledForConference', () => {
+  it('keys on the conference OWNER, not the request host', async () => {
+    getOrganizationById.mockResolvedValue(org({ _id: PLATFORM_ORG_ID }))
+    await expect(
+      isTicketingEnabledForConference({
+        organization: { _ref: PLATFORM_ORG_ID, _type: 'reference' },
+      }),
+    ).resolves.toBe(true)
+    expect(getOrganizationById).toHaveBeenCalledWith(PLATFORM_ORG_ID)
+  })
+
+  it('is DISABLED for a conference with no organization (fail closed)', async () => {
+    await expect(isTicketingEnabledForConference({})).resolves.toBe(false)
+    await expect(isTicketingEnabledForConference(null)).resolves.toBe(false)
+    expect(getOrganizationById).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/features/ticketing.ts
+++ b/src/lib/features/ticketing.ts
@@ -33,12 +33,29 @@ import { isPlatformOrganization } from './platform'
  *     than the credential resolver it fronts.
  *  3. Otherwise DISABLED — including every unresolvable org (fail closed).
  *
- * NOT A SECURITY BOUNDARY. Credential isolation is enforced in
- * `resolveTicketingCredentials` and the tRPC tenancy guards; this decides what
- * an organizer is SHOWN. The `ticketing` registry entry is `readiness:
- * 'internal'` with NO `minPlan` — which plan tier eventually sells ticketing is
- * an open owner decision, so nothing but an explicit grant (or owning
- * credentials) turns it on.
+ * NOT A SECURITY BOUNDARY, AND A DENY IS NOT A KILL SWITCH. Credential
+ * isolation is enforced in `resolveTicketingCredentials` and the tRPC tenancy
+ * guards; this decides what an organizer is SHOWN. One consequence is worth
+ * stating outright, because it looks like a bug and is not: because the ticket
+ * pages resolve the PROVIDER first (`resolveTicketingAdminAccess`), an explicit
+ * `enabled: false` override on an org that HAS working credentials hides the nav
+ * entry and the ⌘K destination but does not blank a deep link — that conference
+ * still renders its real sales data. That is the deliberate price of "never hide
+ * a surface that works", and it is safe precisely because this is presentation:
+ * revoking actual ACCESS means removing the org's credentials (or its binding),
+ * which the seam above already governs. If a nav-level deny should ever become a
+ * hard kill switch, that is a design change to make on purpose, not a comment to
+ * quietly reinterpret here.
+ *
+ * The `ticketing` registry entry is `readiness: 'internal'` with NO `minPlan` —
+ * which plan tier eventually sells ticketing is an open owner decision, so
+ * nothing but an explicit grant (or owning credentials) turns it on.
+ *
+ * CONTRAST WITH `./badges.ts`, whose gate is the MIRROR of this one: badges'
+ * capability exists for exactly one org, so there a grant cannot reach past the
+ * capability. Ticketing is never stricter than its credentials; badges are never
+ * looser than theirs. Both rules say the same thing — the gate tracks what the
+ * surface can actually do.
  */
 
 /** The registry id this module gates. */

--- a/src/lib/features/ticketing.ts
+++ b/src/lib/features/ticketing.ts
@@ -1,0 +1,88 @@
+import 'server-only'
+import { perOrgSecretsStore } from '@/lib/secrets/store'
+import {
+  conferenceOrgId,
+  resolveRegistryEntitlement,
+  type ConferenceTenant,
+} from './platform-default'
+import { isPlatformOrganization } from './platform'
+
+/**
+ * THE single gate for the organizer TICKETING surfaces (`/admin/tickets` and
+ * its sub-pages).
+ *
+ * WHY IT IS GATED. Ticketing credentials are org-scoped since #820: a per-org
+ * secret is the tenant's own provider account, and the platform env credentials
+ * (`CHECKIN_*` / `TITO_*`) are handed to the PLATFORM ORG ONLY, because they are
+ * one vendor ACCOUNT whose event ids no Sanity guard can see. A brand-new tenant
+ * therefore resolves to NO credentials, and every ticketing page rendered a red
+ * "Checkin.no Configuration Error" — an error frame for "this was never yours to
+ * configure". This gate lets the nav hide the section and lets the pages say so
+ * honestly instead.
+ *
+ * WHAT COUNTS AS ENABLED (in order):
+ *
+ *  1. The registry decision (plan + `featureOverrides`) when it is not unset —
+ *     an operator grant enables it, an explicit deny revokes it even from the
+ *     platform org. See `./platform-default`.
+ *  2. Otherwise: the platform org (it owns the env account), OR any org that has
+ *     its OWN ticketing credentials in the per-org secret store. Rule 2's second
+ *     half deliberately MIRRORS `resolveTicketingCredentials`: an org the secret
+ *     seam can serve has a working ticketing integration, so hiding the surface
+ *     from it would hide something that works. The gate must never be stricter
+ *     than the credential resolver it fronts.
+ *  3. Otherwise DISABLED — including every unresolvable org (fail closed).
+ *
+ * NOT A SECURITY BOUNDARY. Credential isolation is enforced in
+ * `resolveTicketingCredentials` and the tRPC tenancy guards; this decides what
+ * an organizer is SHOWN. The `ticketing` registry entry is `readiness:
+ * 'internal'` with NO `minPlan` — which plan tier eventually sells ticketing is
+ * an open owner decision, so nothing but an explicit grant (or owning
+ * credentials) turns it on.
+ */
+
+/** The registry id this module gates. */
+const TICKETING_FEATURE = 'ticketing' as const
+
+/**
+ * Whether the organization has ITS OWN ticketing credentials in the per-org
+ * secret store — the same store `resolveTicketingCredentials` consults first,
+ * and provider-agnostic (a Tito or a Checkin bag both count).
+ */
+async function hasOwnTicketingCredentials(orgId: string): Promise<boolean> {
+  try {
+    return (await perOrgSecretsStore.get(orgId, 'ticketing')) !== null
+  } catch (error) {
+    // The store contract says a miss is `null` and never a throw; treat a
+    // violation as "no credentials" rather than 500-ing the admin nav.
+    console.error(
+      `[features] per-org ticketing secret lookup failed for ${orgId}; treating "ticketing" as DISABLED`,
+      error,
+    )
+    return false
+  }
+}
+
+/**
+ * Whether the organization may use the ticketing surfaces. See the module doc
+ * for the exact order; a nullish org id is DISABLED (fail closed).
+ */
+export async function isTicketingEnabledForOrg(
+  orgId: string | null | undefined,
+): Promise<boolean> {
+  const decision = await resolveRegistryEntitlement(orgId, TICKETING_FEATURE)
+  if (decision !== 'unset') return decision === 'granted'
+  if (!orgId) return false
+  if (await isPlatformOrganization(orgId)) return true
+  return hasOwnTicketingCredentials(orgId)
+}
+
+/**
+ * Whether ticketing is enabled for the tenant that OWNS this conference — the
+ * same tenant key `resolveTicketingCredentials` resolves credentials against.
+ */
+export async function isTicketingEnabledForConference(
+  conference: ConferenceTenant | null | undefined,
+): Promise<boolean> {
+  return isTicketingEnabledForOrg(conferenceOrgId(conference))
+}

--- a/src/lib/features/workshops.ts
+++ b/src/lib/features/workshops.ts
@@ -1,8 +1,10 @@
 import 'server-only'
-import { getOrganizationById } from '@/lib/organization/sanity'
 import { resolveCurrentOrgId } from '@/lib/authz/organizer'
-import { computeEntitlements, hasActiveOverride } from './entitlements'
-import { isPlatformOrganization } from './platform'
+import {
+  conferenceOrgId,
+  isPlatformDefaultFeatureEnabledForOrg,
+  type ConferenceTenant,
+} from './platform-default'
 
 /**
  * THE single gate for the workshop feature (#689) — the portal, the organizer
@@ -19,7 +21,9 @@ import { isPlatformOrganization } from './platform'
  * silence, so the feature is `readiness: 'internal'` (override-only, never
  * offered in upsell surfaces) and OFF for everyone it does not work for.
  *
- * RESOLUTION ORDER — fail-CLOSED at every step:
+ * RESOLUTION ORDER — the shared PLATFORM-DEFAULT shape (`./platform-default.ts`,
+ * which also carries the caching and fail-closed notes), fail-CLOSED at every
+ * step:
  *
  *  1. No resolvable org (unknown domain, missing org document, or a REJECTED
  *     org read) → DISABLED. An unresolvable tenant must never degrade into
@@ -70,50 +74,7 @@ const WORKSHOPS_FEATURE = 'workshops' as const
 export async function isWorkshopsEnabledForOrg(
   orgId: string | null | undefined,
 ): Promise<boolean> {
-  if (!orgId) return false
-
-  // A REJECTED read (transient Sanity failure) must resolve to DISABLED like
-  // any other unresolvable org — never propagate, or one flaky read would 500
-  // the whole admin dashboard through the nav's entitlement lookup and turn a
-  // deliberately suppressed webhook delivery into a retried 500.
-  let org
-  try {
-    org = await getOrganizationById(orgId)
-  } catch (error) {
-    console.error(
-      `[workshops] organization read failed for ${orgId}; treating workshops as DISABLED`,
-      error,
-    )
-    return false
-  }
-  if (!org) return false
-
-  const now = new Date()
-  if (
-    computeEntitlements(org.plan, org.featureOverrides, now).has(
-      WORKSHOPS_FEATURE,
-    )
-  ) {
-    return true
-  }
-
-  // Not entitled by plan/override. An ACTIVE override at this point can only be
-  // an explicit `enabled: false`, which must beat the platform default below.
-  if (hasActiveOverride(org.featureOverrides, WORKSHOPS_FEATURE, now)) {
-    return false
-  }
-
-  // ID comparison against the ONE uncached resolver, never `org.slug` off the
-  // cached read above — see `./platform`. This is a grant, and this deployment
-  // has an org that is both the platform org and a tenant, so a slug edit that
-  // revokes it must revoke it NOW rather than whenever the cached document
-  // happens to expire.
-  return isPlatformOrganization(orgId)
-}
-
-/** The minimum conference shape this gate reads — its owning tenant. */
-interface ConferenceTenant {
-  organization?: { _ref: string; _type?: 'reference' }
+  return isPlatformDefaultFeatureEnabledForOrg(orgId, WORKSHOPS_FEATURE)
 }
 
 /**
@@ -125,7 +86,7 @@ interface ConferenceTenant {
 export async function isWorkshopsEnabledForConference(
   conference: ConferenceTenant | null | undefined,
 ): Promise<boolean> {
-  return isWorkshopsEnabledForOrg(conference?.organization?._ref)
+  return isWorkshopsEnabledForOrg(conferenceOrgId(conference))
 }
 
 /**

--- a/src/lib/tickets/admin-access.test.ts
+++ b/src/lib/tickets/admin-access.test.ts
@@ -1,0 +1,192 @@
+/**
+ * @vitest-environment node
+ *
+ * The three-way ticketing state the admin pages render — empty ≠ error ≠
+ * unavailable. Everything the app owns runs for real: the provider resolver
+ * (including its Tito branch), the credential seam and the feature gate. Only
+ * the org document read is supplied; no network is involved because the state
+ * is decided before any provider call.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Organization } from '@/lib/organization/types'
+
+const getOrganizationById = vi.fn()
+
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationById: (...args: unknown[]) => getOrganizationById(...args),
+  getOrganizationRefForCurrentConference: () => null,
+}))
+
+const h = vi.hoisted(() => ({
+  fetch: vi.fn<(query: string, params?: unknown) => Promise<unknown>>(),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: h.fetch },
+}))
+
+import {
+  resolveTicketingAdminAccess,
+  ticketingProviderLabel,
+} from './admin-access'
+
+const PLATFORM_ORG_ID = 'org-platform'
+const TENANT_ORG_ID = 'org-A'
+
+function org(overrides: Partial<Organization> = {}): Organization {
+  return {
+    _id: TENANT_ORG_ID,
+    name: 'Tenant A',
+    slug: 'tenant-a',
+    ...overrides,
+  }
+}
+
+const checkinBound = (orgId: string) => ({
+  checkinCustomerId: 42,
+  checkinEventId: 4242,
+  organization: { _ref: orgId },
+})
+
+const titoBound = (orgId: string) => ({
+  ticketingProvider: 'tito' as const,
+  titoAccountSlug: 'cndn',
+  titoEventSlug: '2026',
+  organization: { _ref: orgId },
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubEnv('PLATFORM_ORG_ID', PLATFORM_ORG_ID)
+  vi.stubEnv('TENANT_SECRETS_JSON', '')
+  vi.stubEnv('CHECKIN_API_KEY', 'platform-checkin-key')
+  vi.stubEnv('CHECKIN_API_SECRET', 'platform-checkin-secret')
+  vi.stubEnv('TITO_API_KEY', 'platform-tito-key')
+  getOrganizationById.mockResolvedValue(org())
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('resolveTicketingAdminAccess — ready', () => {
+  it('is READY for the platform org’s fully bound Checkin conference', async () => {
+    const access = await resolveTicketingAdminAccess(
+      checkinBound(PLATFORM_ORG_ID),
+    )
+    expect(access.state).toBe('ready')
+    expect(access.providerType).toBe('checkin')
+    if (access.state !== 'ready') throw new Error('unreachable')
+    expect(access.eventRef).toEqual({ customerId: 42, eventId: 4242 })
+  })
+
+  /**
+   * THE TITO FIX. Every ticket page hardcoded the Checkin field check, so a
+   * Tito-bound conference could never open one however complete its binding —
+   * even though `resolveTicketingProvider` has supported Tito all along.
+   */
+  it('is READY for a fully bound TITO conference, with a Tito event ref', async () => {
+    const access = await resolveTicketingAdminAccess(titoBound(PLATFORM_ORG_ID))
+    expect(access.state).toBe('ready')
+    expect(access.providerType).toBe('tito')
+    if (access.state !== 'ready') throw new Error('unreachable')
+    expect(access.eventRef).toEqual({
+      provider: 'tito',
+      accountSlug: 'cndn',
+      eventSlug: '2026',
+    })
+  })
+
+  it('is READY for a tenant with its OWN credentials — the gate never hides what works', async () => {
+    vi.stubEnv(
+      'TENANT_SECRETS_JSON',
+      JSON.stringify({
+        [TENANT_ORG_ID]: { ticketing: { apiKey: 'tenant-key' } },
+      }),
+    )
+    const access = await resolveTicketingAdminAccess(
+      checkinBound(TENANT_ORG_ID),
+    )
+    expect(access.state).toBe('ready')
+  })
+})
+
+describe('resolveTicketingAdminAccess — unconfigured (entitled, not bound)', () => {
+  it('is UNCONFIGURED for the platform org with no event binding', async () => {
+    getOrganizationById.mockResolvedValue(org({ _id: PLATFORM_ORG_ID }))
+    const access = await resolveTicketingAdminAccess({
+      organization: { _ref: PLATFORM_ORG_ID },
+    })
+    expect(access).toEqual({ state: 'unconfigured', providerType: 'checkin' })
+  })
+
+  it('is UNCONFIGURED for a Tito conference missing one of its two slugs', async () => {
+    getOrganizationById.mockResolvedValue(org({ _id: PLATFORM_ORG_ID }))
+    const access = await resolveTicketingAdminAccess({
+      ticketingProvider: 'tito',
+      titoAccountSlug: 'cndn',
+      organization: { _ref: PLATFORM_ORG_ID },
+    })
+    expect(access).toEqual({ state: 'unconfigured', providerType: 'tito' })
+  })
+
+  it('is UNCONFIGURED for an org granted ticketing by override but not yet bound', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({ featureOverrides: [{ feature: 'ticketing', enabled: true }] }),
+    )
+    const access = await resolveTicketingAdminAccess({
+      organization: { _ref: TENANT_ORG_ID },
+    })
+    expect(access.state).toBe('unconfigured')
+  })
+})
+
+describe('resolveTicketingAdminAccess — unavailable (not entitled)', () => {
+  /** THE DEMO-ORG CASE: the state that replaces the red configuration error. */
+  it('is UNAVAILABLE for a brand-new tenant with nothing configured', async () => {
+    const access = await resolveTicketingAdminAccess({
+      organization: { _ref: TENANT_ORG_ID },
+    })
+    expect(access).toEqual({ state: 'unavailable', providerType: 'checkin' })
+  })
+
+  /**
+   * #820: filling in the ids is NOT enough for a tenant without credentials.
+   * That combination used to reach the fetch and surface a raw error; it is an
+   * unavailable state, never an error.
+   */
+  it('is UNAVAILABLE for a tenant that filled in event ids but has no credentials', async () => {
+    const access = await resolveTicketingAdminAccess(
+      checkinBound(TENANT_ORG_ID),
+    )
+    expect(access.state).toBe('unavailable')
+  })
+
+  it('is UNAVAILABLE for a conference with no owning organization (fail closed)', async () => {
+    const access = await resolveTicketingAdminAccess({
+      checkinCustomerId: 42,
+      checkinEventId: 4242,
+    })
+    expect(access.state).toBe('unavailable')
+  })
+
+  it('is UNAVAILABLE when an explicit DENY revokes ticketing from the platform org', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        _id: PLATFORM_ORG_ID,
+        featureOverrides: [{ feature: 'ticketing', enabled: false }],
+      }),
+    )
+    const access = await resolveTicketingAdminAccess({
+      organization: { _ref: PLATFORM_ORG_ID },
+    })
+    expect(access.state).toBe('unavailable')
+  })
+})
+
+describe('ticketingProviderLabel', () => {
+  it('names the vendor the organizer actually uses', () => {
+    expect(ticketingProviderLabel('checkin')).toBe('Checkin.no')
+    expect(ticketingProviderLabel('tito')).toBe('Tito')
+  })
+})

--- a/src/lib/tickets/admin-access.ts
+++ b/src/lib/tickets/admin-access.ts
@@ -1,0 +1,80 @@
+import 'server-only'
+import { isTicketingEnabledForOrg } from '@/lib/features/ticketing'
+import {
+  conferenceProviderType,
+  resolveTicketingProvider,
+  type ConferenceTicketingBinding,
+  type EventRef,
+  type TicketingProvider,
+  type TicketingProviderType,
+} from './provider'
+
+/**
+ * ONE resolution for what an organizer's ticketing pages should show — the
+ * three-way distinction the budget page already treats as correct
+ * (`src/app/(admin)/admin/budget/page.tsx`): EMPTY ≠ ERROR ≠ UNAVAILABLE.
+ *
+ * WHAT IT REPLACES. All five provider-backed ticket pages hardcoded
+ * `!conference.checkinCustomerId || !conference.checkinEventId` and rendered a
+ * red `ErrorDisplay "Checkin.no Configuration Error"`. That was wrong three
+ * ways:
+ *
+ *  1. VENDOR-BLIND. `resolveTicketingProvider` has supported Tito since the
+ *     adapter generalized, but the guard only knew Checkin's fields — so a
+ *     Tito-bound conference could never open ANY ticket page, however complete
+ *     its binding. The state below keys on the resolver, which reads whichever
+ *     binding the conference's `ticketingProvider` selects.
+ *  2. AN ERROR FRAME FOR "NOT SET UP YET". A tenant that never configured
+ *     ticketing has done nothing wrong; #820 additionally means an org with no
+ *     credentials resolves to unconfigured no matter what ids it fills in.
+ *  3. NO HONEST "NOT YOURS". An org without the `ticketing` entitlement cannot
+ *     make those pages work at all, and pointing it at conference settings was
+ *     a dead end.
+ *
+ * ORDER MATTERS. The provider is resolved FIRST, so a conference that is
+ * genuinely configured renders its data regardless of what the entitlement says
+ * — the gate must never hide a surface that works. Only when nothing resolves
+ * does the entitlement decide WHICH honest empty state to show.
+ */
+export type TicketingAdminAccess =
+  /** Bound, credentialed and ready — the caller may fetch. */
+  | {
+      state: 'ready'
+      provider: TicketingProvider
+      eventRef: EventRef
+      providerType: TicketingProviderType
+    }
+  /** Entitled, but the conference is not bound to an event yet (or the org's
+   * credentials are missing) — an empty state with a link to settings. */
+  | { state: 'unconfigured'; providerType: TicketingProviderType }
+  /** Not entitled: ticketing is not available to this organization at all. */
+  | { state: 'unavailable'; providerType: TicketingProviderType }
+
+export async function resolveTicketingAdminAccess(
+  conference: ConferenceTicketingBinding,
+): Promise<TicketingAdminAccess> {
+  const providerType = conferenceProviderType(conference)
+  const ticketing = await resolveTicketingProvider(conference)
+
+  if (ticketing.configured) {
+    return {
+      state: 'ready',
+      provider: ticketing.provider,
+      eventRef: ticketing.eventRef,
+      providerType,
+    }
+  }
+
+  if (await isTicketingEnabledForOrg(conference.organization?._ref)) {
+    return { state: 'unconfigured', providerType }
+  }
+
+  return { state: 'unavailable', providerType }
+}
+
+/** Vendor label for organizer-facing copy. */
+export function ticketingProviderLabel(
+  providerType: TicketingProviderType,
+): string {
+  return providerType === 'tito' ? 'Tito' : 'Checkin.no'
+}


### PR DESCRIPTION
## Why

An audit of a brand-new tenant's day one found the two worst admin surfaces, both about to be shown to sales prospects in a demo organization (`RunKonf/platform#47`):

1. **Badge admin had no gate at all.** `issueBadgeForSpeaker` refuses every non-platform org (the Phase 0 tripwire, `RunKonf/platform#46`), but `/admin/speakers/badge` rendered in full for every tenant and `BadgeManagementClient` surfaced the raw refusal **per speaker** — a message naming our internal issue tracker.
2. **All five provider-backed ticket routes rendered a red `ErrorDisplay "Checkin.no Configuration Error"`** when the binding was absent: an error frame for "not set up yet", with no link to settings. Plus two aggravations — the guard hardcoded the **Checkin** fields even though `resolveTicketingProvider` fully supports **Tito** (so a Tito-bound conference could never open *any* ticket page), and after #820 an org that fills in the ids but has no credentials still failed: raw `"Missing checkin configuration"` on the overview, a false *"No tickets have been sold"* on orders, and a silently empty list on types.

The structural cause: the nav/⌘K filtering machinery existed but could only gate one feature. `src/lib/features/registry.ts` knew `graphql-api | dedicated-email | slack-mirror | workshops`, and the admin layout computed `enabledFeatures` as literally `['workshops']` or `[]`.

## The structural enabler

- **`ticketing` and `badges` added to `FEATURE_IDS`**, both `readiness: 'internal'` with **no `minPlan`** — matching today's reality (both are platform-org-gated in code already) and deliberately **not** guessing a plan tier. A test fails the moment someone adds one.
- **`src/lib/features/platform-default.ts`** factors out the resolution `workshops` worked out first (registry decision → overrides win both ways → platform-org default, fail-closed at every step). `workshops.ts` now delegates to it, byte-identical behaviour.
- **`ticketing.ts`** layers one extra grant: an org with its **own** provider credentials in the per-org secret store. The gate must never be stricter than `resolveTicketingCredentials`, or it would hide a surface that works.
- **`enabled.ts`** composes the registry resolution with each gate, and the layout now calls it instead of the hardcoded array. Tagging a destination is now all it takes to gate it.
- Registry tags: the **Tickets** nav entry + orders / types / discount / companies, and **Speaker Badges**. `/admin/tickets/content` stays **ungated** — it edits the public page's Sanity copy, needs no provider, and that page still renders for a tenant with no ticketing.

## What each of the six pages shows now

| Page | Entitled + configured | Entitled, not bound | Not entitled |
|---|---|---|---|
| `/admin/tickets` | unchanged analytics | header + "Ticketing is not connected yet" + **Open ticket settings** | header + "Ticketing is not available for your organization" |
| `/admin/tickets/types` | ticket types, vendor named in the header | same notice | same notice (no more silent empty list) |
| `/admin/tickets/orders` | orders, or a **real** zero-sales empty state | same notice | same notice (no more false "No tickets have been sold") |
| `/admin/tickets/discount` | discount manager | same notice | same notice |
| `/admin/tickets/companies` | company breakdown | same notice | same notice |
| `/admin/speakers/badge` | unchanged | — | **404**, nav entry and "Manage Badges" shortcut hidden |

None of the notices is an error: neutral card, no red frame, no exclamation mark, and the page keeps its own header so the organizer stays oriented. The unavailable state offers **no** settings link — there is nothing to configure, and sending someone to a form that cannot help is the dead end this PR removes.

## The Tito fix

`resolveTicketingAdminAccess` keys on `resolveTicketingProvider`, which reads whichever binding the conference's `ticketingProvider` selects. A Tito conference now opens every ticket page and fetches through its Tito event ref (`{ provider, accountSlug, eventSlug }`) instead of a bare Checkin event id. Discount codes are a Checkin-only API end to end (manager, tRPC procedures and the provider interface all take a numeric Checkin event id), so Tito gets an honest "managed in Checkin.no, manage them in Tito instead" state rather than a manager whose every call fails.

## Sabotage results

Each guard removed by exact string; the matching suite must fail; restored; green.

| Guard removed | Result |
|---|---|
| badge page `notFound()` gate | 2 failed / 4 |
| ticketing entitlement branch in `admin-access` | 6 failed / 21 |
| layout entitlement resolution → hardcoded `['workshops']` | 4 failed / 4 |
| registry `feature: 'ticketing'` on the Tickets nav entry | 2 failed / 24 |
| Tito-aware ticket-types fetch → old bare Checkin id | 1 failed / 21 |
| **restored** | **157 passed** |

## Numbers

| | baseline (`origin/main`) | this branch |
|---|---|---|
| `pnpm test` | 487 files / 7008 tests | **494 files / 7091 tests** |
| `pnpm typecheck` | clean | clean |
| `npx prettier --check .` | clean | clean |
| `npx eslint .` | 0 errors, 216 warnings | 0 errors, 216 warnings |
| `pnpm knip` | 1 pre-existing config hint | same hint |

## Visual inspection

`TicketingStateNotice` has a Storybook story per state; all three captured with `pnpm shoot` at 393×852 and viewed — neutral card, no viewport overflow, `PLATFORM_NAME` resolving correctly in the unavailable copy.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces centralized feature resolution for ticketing and badges, adds provider-aware ticket administration states, and hides unavailable destinations from admin navigation.

- Adds platform-default feature gates with override and per-organization credential handling.
- Routes Checkin and Tito admin pages through a shared ready/unconfigured/unavailable resolver.
- Adds neutral ticketing state notices and gates badge navigation and direct page access.
- Preserves the ungated ticket-page content editor.

<h3>Confidence Score: 4/5</h3>

The badge override path must be fixed before merging because it exposes non-platform tenants to a management page whose issuance operations always fail and reveal an internal tracker reference.

Ticketing state handling is consistently centralized, but the new badge gate grants non-platform organizations through overrides without changing the platform-only issuance boundary, leaving the enabled surface unusable.

**Files Needing Attention:** src/lib/features/badges.ts; src/app/(admin)/admin/speakers/badge/page.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/features/platform-default.ts | Centralizes platform-default entitlement resolution, including explicit override precedence and fail-closed organization lookup. |
| src/lib/features/enabled.ts | Composes registry entitlements with feature-specific gates for admin navigation filtering. |
| src/lib/features/ticketing.ts | Enables ticketing for registry grants, the platform organization, or tenants with their own provider credentials. |
| src/lib/features/badges.ts | Adds the badge entitlement resolver, but permits non-platform override grants that the existing issuance path cannot honor. |
| src/lib/tickets/admin-access.ts | Introduces shared provider-aware ready, unconfigured, and unavailable states for ticket administration. |
| src/app/(admin)/admin/speakers/badge/page.tsx | Adds a direct badge-page gate whose override-enabled path can still lead to categorical issuance failures. |
| src/components/admin/TicketingStateNotice.tsx | Adds neutral, state-specific ticketing notices with a settings action only when configuration is actionable. |
| src/app/(admin)/admin/tickets/types/page.tsx | Uses provider-shaped event references so both Checkin and Tito ticket types can be fetched correctly. |
| src/app/(admin)/admin/tickets/orders/page.tsx | Distinguishes unavailable integrations from genuine zero-order events and fetches through the resolved provider. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  C[Conference and owning organization] --> F[Resolve enabled features]
  F --> N[Filter admin navigation and command menu]
  C --> T[Resolve ticketing provider]
  T -->|Configured| R[Ready: fetch provider data]
  T -->|Not configured| E{Ticketing entitled?}
  E -->|Yes| U[Show configuration notice]
  E -->|No| A[Show unavailable notice]
  C --> B{Badges enabled?}
  B -->|No| NF[Return 404]
  B -->|Yes| BP[Render badge management]
  BP --> I[Badge issuance]
  I --> P{Platform organization?}
  P -->|No| X[Issuance refusal]
  P -->|Yes| S[Sign and issue badge]
```

<sub>Reviews (1): Last reviewed commit: ["feat(admin): gate ticketing and badges i..."](https://github.com/cloudnativebergen/website/commit/266ad24e9d454e75b3d3ae27a4deda428e8b11a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50463049)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Ticketing and contract e-signature](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/ticketing-signing.md)

<!-- /greptile_comment -->