### PR TITLE
fix(public): stop a brand-new tenant's public site from lying on day one

### DIFF
--- a/__tests__/app/day-one/fresh-tenant-public-pages.test.tsx
+++ b/__tests__/app/day-one/fresh-tenant-public-pages.test.tsx
@@ -1,0 +1,264 @@
+/**
+ * @vitest-environment node
+ *
+ * DAY ONE, PUBLIC SIDE. `@/lib/onboarding/create.ts` provisions a tenant with a
+ * title, an org reference, a city/country, contact addresses and nothing else:
+ * no tagline, no dates, no venue, no schedule, no speakers. Two public pages
+ * used to fill that silence with copy of their own —
+ *
+ *   - `/speaker` headed an empty grid with "Meet our 0 speakers" over a
+ *     paragraph about "these industry experts" (reachable from the `/tickets`
+ *     coming-soon card, which links "View Speakers" straight here);
+ *   - `/info` asserted a date ("held on TBD", from `formatDate('')`), a
+ *     registration time, a start and end time, catering and an afterparty
+ *     starting at 6 PM.
+ *
+ * None of it came from the organizer. This suite builds the conference document
+ * with the REAL `buildOnboardingDocuments`, pushes it through the real
+ * `getConferenceForDomain` boundary and walks both pages — so if provisioning
+ * ever starts seeding these fields, the premise guards below fail loudly rather
+ * than the coverage quietly evaporating.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactElement } from 'react'
+
+const conferenceFetchMock = vi.fn()
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: { fetch: (...args: unknown[]) => conferenceFetchMock(...args) },
+  clientReadUncached: {
+    fetch: (...args: unknown[]) => conferenceFetchMock(...args),
+  },
+}))
+
+vi.mock('next/cache', () => ({
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
+}))
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn(async () => new Headers({ host: FRESH_HOST })),
+}))
+
+vi.mock('@/lib/gallery/sanity', () => ({
+  getGalleryImages: vi.fn(async () => []),
+  getFeaturedGalleryImages: vi.fn(async () => []),
+}))
+
+vi.mock('@/lib/sponsor-crm/sanity', () => ({
+  getPublicSponsorsForConference: vi.fn(async () => []),
+}))
+
+const getSpeakersMock = vi.fn()
+vi.mock('@/lib/speaker/sanity', () => ({
+  getSpeakers: (...args: unknown[]) => getSpeakersMock(...args),
+}))
+
+import { buildOnboardingDocuments } from '@/lib/onboarding/create'
+import SpeakerPage from '@/app/(main)/speaker/page'
+import InfoPage from '@/app/(main)/info/page'
+
+const FRESH_HOST = 'brand-new.konf.run'
+
+/** The conference document a concierge provisioning run actually writes. */
+function provisionedConferenceDocument() {
+  let key = 0
+  const { conference } = buildOnboardingDocuments(
+    {
+      organization: {
+        name: 'Brand New Events',
+        slug: 'brand-new-events',
+        contactEmail: 'hello@brand-new.example',
+      },
+      conference: {
+        title: 'Brand New Conf',
+        city: 'Bergen',
+        country: 'Norway',
+      },
+      organizer: { name: 'Ada Organizer', email: 'ada@brand-new.example' },
+      domains: [FRESH_HOST],
+    },
+    {
+      organizationId: 'org-fresh',
+      conferenceId: 'conf-fresh',
+      speakerId: 'speaker-fresh',
+      mintKey: () => `key-${++key}`,
+    },
+    null,
+  )
+  return conference
+}
+
+/**
+ * Both pages are server components wrapping ONE async child that reads the
+ * conference. Awaiting the page yields that child's element; awaiting the child
+ * gives a tree of ordinary components `renderToStaticMarkup` can finish.
+ */
+async function renderPage(page: () => Promise<ReactElement>): Promise<string> {
+  const pageElement = (await page()) as ReactElement<{ domain: string }>
+  const inner = await (
+    pageElement.type as (props: {
+      domain: string
+    }) => Promise<ReactElement | null>
+  )(pageElement.props)
+  return inner === null ? '' : renderToStaticMarkup(inner)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getSpeakersMock.mockResolvedValue({ speakers: [], err: null })
+  conferenceFetchMock.mockResolvedValue(provisionedConferenceDocument())
+})
+
+describe('what provisioning actually writes', () => {
+  it('omits the tagline, the dates, the venue and the schedule', () => {
+    // Guards the premise: if this fails, everything below is testing a
+    // scenario that no longer exists and should be rewritten, not updated.
+    const doc = provisionedConferenceDocument()
+    expect(doc.tagline).toBeUndefined()
+    expect(doc.startDate).toBeUndefined()
+    expect(doc.endDate).toBeUndefined()
+    expect(doc.venueName).toBeUndefined()
+    expect(doc.venueAddress).toBeUndefined()
+    expect(doc.schedules).toBeUndefined()
+    // ...but it does write a title and a contact address, which is what the
+    // day-one copy leans on.
+    expect(doc.title).toBe('Brand New Conf')
+    expect(doc.contactEmail).toBe('hello@brand-new.example')
+  })
+})
+
+describe('/speaker before the first speaker is announced', () => {
+  it('does not count an empty grid', async () => {
+    const html = await renderPage(SpeakerPage)
+
+    expect(html).not.toContain('Meet our 0 speakers')
+    expect(html).not.toContain('These industry experts')
+  })
+
+  it('says so, and offers the organizers instead', async () => {
+    const html = await renderPage(SpeakerPage)
+
+    expect(html).toContain('Speakers have not been announced yet')
+    expect(html).toContain('hello@brand-new.example')
+  })
+
+  it('does not push a CFP that cannot accept a proposal', async () => {
+    // The CFP window is closed AND no format is configured — a "submit a talk"
+    // link here would land on a form with an empty format dropdown (#824).
+    const html = await renderPage(SpeakerPage)
+
+    expect(html).not.toContain('call for presentations')
+  })
+})
+
+describe('/speaker once speakers exist', () => {
+  it('still counts them and renders the grid', async () => {
+    getSpeakersMock.mockResolvedValue({
+      speakers: [
+        {
+          _id: 'spk-1',
+          name: 'Grace Hopper',
+          slug: 'grace-hopper',
+          title: 'Rear Admiral',
+          proposals: [],
+        },
+      ],
+      err: null,
+    })
+
+    const html = await renderPage(SpeakerPage)
+
+    expect(html).toContain('Meet our 1 speakers')
+    expect(html).toContain('Grace Hopper')
+    expect(html).not.toContain('Speakers have not been announced yet')
+  })
+})
+
+describe('/info asserts nothing the organizer did not configure', () => {
+  it('never renders the "TBD" date placeholder as prose', async () => {
+    const html = await renderPage(InfoPage)
+
+    expect(html).not.toContain('TBD')
+    expect(html).not.toContain('will be held on')
+  })
+
+  it('invents no registration, start or end times', async () => {
+    const html = await renderPage(InfoPage)
+
+    expect(html).not.toContain('Registration opens at')
+    expect(html).not.toContain('Doors open for registration')
+    // The badge answer is nothing BUT a registration time, so it goes too.
+    expect(html).not.toContain('When and where can I pick up my badge?')
+    expect(html).not.toContain('08:00')
+    expect(html).not.toContain('09:00')
+    expect(html).not.toContain('17:00')
+  })
+
+  it('promises no food and no afterparty', async () => {
+    const html = await renderPage(InfoPage)
+
+    expect(html).not.toContain('We will serve food and drinks')
+    expect(html).not.toContain('afterparty')
+  })
+
+  it('claims nothing about a venue that has not been booked', async () => {
+    const html = await renderPage(InfoPage)
+
+    expect(html).not.toContain('take place at the venue')
+    expect(html).not.toContain('the venue is accessible')
+    // The city IS configured, so that much is still answered.
+    expect(html).toContain('Bergen, Norway')
+  })
+
+  it('keeps the answers that are true for every conference', async () => {
+    const html = await renderPage(InfoPage)
+
+    expect(html).toContain('What is the code of conduct?')
+    expect(html).toContain('allergies or dietary restrictions')
+  })
+})
+
+describe('/info for a conference that HAS configured its event', () => {
+  it('answers the date and the running times again', async () => {
+    conferenceFetchMock.mockResolvedValue({
+      ...provisionedConferenceDocument(),
+      startDate: '2026-10-27',
+      venueName: 'Grieghallen',
+      schedules: [
+        {
+          _id: 'sched-1',
+          date: '2026-10-27',
+          tracks: [
+            {
+              trackTitle: 'Main track',
+              trackDescription: '',
+              talks: [
+                {
+                  placeholder: 'Registration',
+                  startTime: '07:30',
+                  endTime: '08:45',
+                },
+                {
+                  placeholder: 'Closing',
+                  startTime: '16:00',
+                  endTime: '16:45',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+
+    const html = await renderPage(InfoPage)
+
+    expect(html).toContain('The conference will be held on')
+    expect(html).toContain('07:30')
+    expect(html).toContain('16:45')
+    expect(html).toContain('Grieghallen')
+    expect(html).toContain('When will the doors open?')
+    expect(html).toContain('When and where can I pick up my badge?')
+    expect(html).toContain('Is this venue accessible?')
+  })
+})

--- a/__tests__/app/day-one/fresh-tenant-public-pages.test.tsx
+++ b/__tests__/app/day-one/fresh-tenant-public-pages.test.tsx
@@ -55,6 +55,8 @@ vi.mock('@/lib/speaker/sanity', () => ({
 }))
 
 import { buildOnboardingDocuments } from '@/lib/onboarding/create'
+import { getScheduleDayInfo } from '@/lib/conference/info-faq'
+import type { ConferenceSchedule } from '@/lib/conference/types'
 import SpeakerPage from '@/app/(main)/speaker/page'
 import InfoPage from '@/app/(main)/info/page'
 
@@ -153,25 +155,38 @@ describe('/speaker before the first speaker is announced', () => {
 })
 
 describe('/speaker once speakers exist', () => {
-  it('still counts them and renders the grid', async () => {
+  function speaker(id: string, name: string) {
+    return { _id: id, name, slug: id, title: 'Speaker', proposals: [] }
+  }
+
+  it('counts the first speaker in the singular', async () => {
+    getSpeakersMock.mockResolvedValue({
+      speakers: [speaker('spk-1', 'Grace Hopper')],
+      err: null,
+    })
+
+    const html = await renderPage(SpeakerPage)
+
+    expect(html).toContain('Meet our 1 speaker<')
+    expect(html).not.toContain('Meet our 1 speakers')
+    expect(html).toContain('Grace Hopper')
+    expect(html).not.toContain('Speakers have not been announced yet')
+  })
+
+  it('counts the rest in the plural, and renders the grid', async () => {
     getSpeakersMock.mockResolvedValue({
       speakers: [
-        {
-          _id: 'spk-1',
-          name: 'Grace Hopper',
-          slug: 'grace-hopper',
-          title: 'Rear Admiral',
-          proposals: [],
-        },
+        speaker('spk-1', 'Grace Hopper'),
+        speaker('spk-2', 'Barbara Liskov'),
       ],
       err: null,
     })
 
     const html = await renderPage(SpeakerPage)
 
-    expect(html).toContain('Meet our 1 speakers')
+    expect(html).toContain('Meet our 2 speakers')
     expect(html).toContain('Grace Hopper')
-    expect(html).not.toContain('Speakers have not been announced yet')
+    expect(html).toContain('Barbara Liskov')
   })
 })
 
@@ -260,5 +275,106 @@ describe('/info for a conference that HAS configured its event', () => {
     expect(html).toContain('When will the doors open?')
     expect(html).toContain('When and where can I pick up my badge?')
     expect(html).toContain('Is this venue accessible?')
+  })
+})
+
+/**
+ * THE SECOND ROUTE TO THE SAME LIE. Creating the schedule day is an early
+ * setup step — earlier than filling it in — so "a schedule document with
+ * nothing in it" is a likelier state than "no schedule document". For such a
+ * day `getScheduleDayInfo` still hands back `08:00 / 09:00 / 17:00`, which is
+ * why the answers gate on `hasRealTimes` and not on the day's existence.
+ */
+describe('/info for a conference whose schedule day is EMPTY', () => {
+  function emptyScheduleDocument(overrides: Record<string, unknown> = {}) {
+    return {
+      _id: 'sched-empty',
+      date: '2026-10-27',
+      tracks: [{ trackTitle: 'Main track', trackDescription: '', talks: [] }],
+      ...overrides,
+    }
+  }
+
+  it('getScheduleDayInfo really does invent times for it', () => {
+    // Guards the premise: the gate exists because of exactly these values.
+    const info = getScheduleDayInfo([
+      emptyScheduleDocument() as unknown as ConferenceSchedule,
+    ])
+
+    expect(info.days).toHaveLength(1)
+    expect(info.conferenceDay?.registrationTime).toBe('08:00')
+    expect(info.conferenceDay?.startTime).toBe('09:00')
+    expect(info.conferenceDay?.endTime).toBe('17:00')
+    expect(info.conferenceDay?.hasRealTimes).toBe(false)
+  })
+
+  it('publishes none of those invented times', async () => {
+    conferenceFetchMock.mockResolvedValue({
+      ...provisionedConferenceDocument(),
+      startDate: '2026-10-27',
+      schedules: [emptyScheduleDocument()],
+    })
+
+    const html = await renderPage(InfoPage)
+
+    expect(html).not.toContain('08:00')
+    expect(html).not.toContain('09:00')
+    expect(html).not.toContain('17:00')
+    expect(html).not.toContain('Registration opens at')
+    expect(html).not.toContain('When will the doors open?')
+    expect(html).not.toContain('When and where can I pick up my badge?')
+    // The date is real, so it survives on its own.
+    expect(html).toContain('The conference will be held on')
+  })
+
+  it('survives a schedule document with no tracks at all', async () => {
+    // `tracks` is typed non-optional; a half-created document does not have it,
+    // and `/info` has no error boundary above it.
+    conferenceFetchMock.mockResolvedValue({
+      ...provisionedConferenceDocument(),
+      schedules: [{ _id: 'sched-bare', date: '2026-10-27' }],
+    })
+
+    const html = await renderPage(InfoPage)
+
+    expect(html).toContain('For Attendees')
+    expect(html).not.toContain('08:00')
+  })
+
+  it('drops the two-day answers when only ONE of the days is filled in', async () => {
+    conferenceFetchMock.mockResolvedValue({
+      ...provisionedConferenceDocument(),
+      startDate: '2026-10-27',
+      endDate: '2026-10-28',
+      schedules: [
+        {
+          _id: 'sched-1',
+          date: '2026-10-27',
+          tracks: [
+            {
+              trackTitle: 'Workshops',
+              trackDescription: '',
+              talks: [
+                {
+                  placeholder: 'Registration',
+                  startTime: '07:30',
+                  endTime: '08:45',
+                },
+              ],
+            },
+          ],
+        },
+        emptyScheduleDocument({ _id: 'sched-2', date: '2026-10-28' }),
+      ],
+    })
+
+    const html = await renderPage(InfoPage)
+
+    // The empty second day is the "conference day", so nothing timed is safe.
+    expect(html).not.toContain('08:00')
+    expect(html).not.toContain('Day 1 (')
+    expect(html).not.toContain('When will the doors open?')
+    // The span between the two configured dates is still true.
+    expect(html).toContain('This is a multi-day event running from')
   })
 })

--- a/src/app/(main)/speaker/page.tsx
+++ b/src/app/(main)/speaker/page.tsx
@@ -77,7 +77,9 @@ async function CachedSpeakersContent({ domain }: { domain: string }) {
             <div className="mx-auto max-w-2xl lg:mx-0">
               <h1 className="font-jetbrains text-4xl font-bold tracking-tighter text-brand-cloud-blue sm:text-6xl dark:text-blue-400">
                 {hasSpeakers
-                  ? `Meet our ${speakersWithTalks.length} speakers`
+                  ? `Meet our ${speakersWithTalks.length} ${
+                      speakersWithTalks.length === 1 ? 'speaker' : 'speakers'
+                    }`
                   : 'Speakers'}
               </h1>
               {hasSpeakers && (

--- a/src/app/(main)/speaker/page.tsx
+++ b/src/app/(main)/speaker/page.tsx
@@ -1,9 +1,11 @@
 import { BackgroundImage } from '@/components/BackgroundImage'
 import { Container } from '@/components/Container'
 import { SpeakerPromotionCard } from '@/components/SpeakerPromotionCard'
+import { SpeakersNotAnnouncedNotice } from '@/components/speaker/SpeakersNotAnnouncedNotice'
 import { getSpeakers } from '@/lib/speaker/sanity'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
 import { isUnknownHost } from '@/lib/conference/guard'
+import { hasSubmittableFormats, isCfpOpen } from '@/lib/conference/state'
 import { SpeakerWithTalks } from '@/lib/speaker/types'
 import { cacheLife, cacheTag } from 'next/cache'
 import { conferenceTag } from '@/lib/cache/tags'
@@ -50,6 +52,13 @@ async function CachedSpeakersContent({ domain }: { domain: string }) {
     talks: speaker.proposals || [],
   }))
 
+  // "Meet our 0 speakers" over an empty grid is what every conference shows
+  // before its first acceptance — including every freshly provisioned tenant,
+  // and including anyone who follows "View Speakers" from the /tickets
+  // coming-soon card.
+  const hasSpeakers = speakersWithTalks.length > 0
+  const canSubmit = isCfpOpen(conference) && hasSubmittableFormats(conference)
+
   return (
     <>
       <BreadcrumbJsonLd
@@ -67,25 +76,38 @@ async function CachedSpeakersContent({ domain }: { domain: string }) {
           <div className="mx-auto max-w-7xl px-6 lg:px-8">
             <div className="mx-auto max-w-2xl lg:mx-0">
               <h1 className="font-jetbrains text-4xl font-bold tracking-tighter text-brand-cloud-blue sm:text-6xl dark:text-blue-400">
-                Meet our {speakersWithTalks.length} speakers
+                {hasSpeakers
+                  ? `Meet our ${speakersWithTalks.length} speakers`
+                  : 'Speakers'}
               </h1>
-              <p className="font-inter mt-6 text-xl leading-8 tracking-tight text-brand-slate-gray dark:text-gray-300">
-                These industry experts will share their insights and
-                experiences. Get ready to be inspired and learn from the best in
-                the field.
-              </p>
+              {hasSpeakers && (
+                <p className="font-inter mt-6 text-xl leading-8 tracking-tight text-brand-slate-gray dark:text-gray-300">
+                  These industry experts will share their insights and
+                  experiences. Get ready to be inspired and learn from the best
+                  in the field.
+                </p>
+              )}
             </div>
 
-            <div className="mx-auto mt-20 grid max-w-2xl auto-rows-fr grid-cols-1 gap-6 md:grid-cols-2 lg:mx-0 lg:max-w-none lg:grid-cols-3">
-              {speakersWithTalks.map((speaker) => (
-                <SpeakerPromotionCard
-                  key={speaker._id}
-                  speaker={speaker}
-                  variant="compact"
-                  ctaText="View Profile"
+            {hasSpeakers ? (
+              <div className="mx-auto mt-20 grid max-w-2xl auto-rows-fr grid-cols-1 gap-6 md:grid-cols-2 lg:mx-0 lg:max-w-none lg:grid-cols-3">
+                {speakersWithTalks.map((speaker) => (
+                  <SpeakerPromotionCard
+                    key={speaker._id}
+                    speaker={speaker}
+                    variant="compact"
+                    ctaText="View Profile"
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="mx-auto max-w-2xl lg:mx-0">
+                <SpeakersNotAnnouncedNotice
+                  contactEmail={conference.contactEmail}
+                  cfpOpen={canSubmit}
                 />
-              ))}
-            </div>
+              </div>
+            )}
           </div>
         </Container>
       </div>

--- a/src/components/Hero.stories.tsx
+++ b/src/components/Hero.stories.tsx
@@ -187,6 +187,20 @@ export const DayOneNoTagline: Story = {
   },
 }
 
+/**
+ * The same day-one conference in the `emblem` variant, where the title normally
+ * sits as an eyebrow ABOVE the tagline. With no tagline the title has become
+ * the headline, so the eyebrow drops rather than printing the name twice,
+ * stacked.
+ */
+export const DayOneNoTaglineEmblem: Story = {
+  name: 'Day one (no tagline) — emblem',
+  args: {
+    conference: (DayOneNoTagline.args as { conference: Conference }).conference,
+    variant: 'emblem',
+  },
+}
+
 /* -------------------------------------------------------------------------- */
 /* Variants                                                                    */
 /*                                                                             */

--- a/src/components/Hero.stories.tsx
+++ b/src/components/Hero.stories.tsx
@@ -151,6 +151,42 @@ export const MinimalConference: Story = {
   },
 }
 
+/**
+ * DAY ONE — exactly what `@/lib/onboarding/create.ts` provisions: a title, a
+ * city, contact addresses, and nothing else. No tagline, so the headline falls
+ * back to the conference NAME; the title is deliberately long, because a long
+ * name is what the classic hero's fixed heading height would have clipped.
+ */
+export const DayOneNoTagline: Story = {
+  name: 'Day one (no tagline)',
+  args: {
+    conference: {
+      ...baseConference,
+      title: 'Cloud Native Days Norway 2026',
+      tagline: undefined,
+      description: undefined,
+      startDate: undefined,
+      endDate: undefined,
+      venueName: undefined,
+      venueAddress: undefined,
+      vanityMetrics: undefined,
+      registrationEnabled: false,
+      registrationLink: undefined,
+      programDate: undefined,
+      cfpStartDate: undefined,
+      cfpEndDate: undefined,
+    } as unknown as Conference,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A freshly provisioned tenant. The `<h1>` used to render EMPTY here — the tagline is the visible heading and a new conference has none — leaving a blank fixed-height block as the largest element on the homepage, with the name only in an `sr-only` span. The headline now falls back to the conference title, and the `sr-only` copy of it drops so the name is announced once.',
+      },
+    },
+  },
+}
+
 /* -------------------------------------------------------------------------- */
 /* Variants                                                                    */
 /*                                                                             */

--- a/src/components/Hero.test.tsx
+++ b/src/components/Hero.test.tsx
@@ -27,6 +27,7 @@ vi.mock('@/components/CollapsibleDescription', () => ({
 }))
 
 import { Hero } from './Hero'
+import { buildOnboardingDocuments } from '@/lib/onboarding/create'
 import type { Conference } from '@/lib/conference/types'
 
 function makeConference(overrides: Partial<Conference> = {}): Conference {
@@ -283,5 +284,115 @@ describe('Hero — emblem variant', () => {
   it('keeps the phase CTA row', () => {
     render(<Hero conference={conference} variant="emblem" />)
     expect(screen.getByText(/Tickets/i)).toBeTruthy()
+  })
+})
+
+/**
+ * DAY ONE. `tagline` is optional on a real conference document and
+ * `@/lib/onboarding/create.ts` provisions a tenant WITHOUT one, so the hero's
+ * `<h1>` — the largest thing on the homepage — used to render empty, with the
+ * conference name available only to screen readers.
+ *
+ * The fixture is built by the REAL provisioning builder so it cannot drift away
+ * from what a new tenant actually gets.
+ */
+describe('Hero — a conference with no tagline', () => {
+  function provisionedConference(): Conference {
+    let key = 0
+    const { conference } = buildOnboardingDocuments(
+      {
+        organization: {
+          name: 'Brand New Events',
+          slug: 'brand-new-events',
+          contactEmail: 'hello@brand-new.example',
+        },
+        conference: {
+          title: 'Brand New Conf',
+          city: 'Bergen',
+          country: 'Norway',
+        },
+        organizer: { name: 'Ada Organizer', email: 'ada@brand-new.example' },
+        domains: ['brand-new.konf.run'],
+      },
+      {
+        organizationId: 'org-fresh',
+        conferenceId: 'conf-fresh',
+        speakerId: 'speaker-fresh',
+        mintKey: () => `key-${++key}`,
+      },
+      null,
+    )
+    return conference as unknown as Conference
+  }
+
+  it('provisioning really does omit the tagline', () => {
+    // Premise guard: if provisioning starts seeding a tagline, these tests are
+    // about a state that no longer exists.
+    expect(provisionedConference().tagline).toBeUndefined()
+  })
+
+  it.each(['classic', 'minimal', 'emblem'] as const)(
+    'names the conference in the visible heading (%s)',
+    (variant) => {
+      const { container } = render(
+        <Hero conference={provisionedConference()} variant={variant} />,
+      )
+      const h1 = container.querySelector('h1')
+      expect(h1?.textContent).toBe('Brand New Conf')
+      // Not merely non-empty: the heading must not be a blank block with the
+      // name hidden in an `sr-only` span beside it.
+      expect(h1?.querySelector('.sr-only')).toBeNull()
+    },
+  )
+
+  it.each(['classic', 'minimal', 'emblem'] as const)(
+    'says the name once, not twice (%s)',
+    (variant) => {
+      const { container } = render(
+        <Hero conference={provisionedConference()} variant={variant} />,
+      )
+      const occurrences = (container.textContent ?? '').split(
+        'Brand New Conf',
+      ).length
+      expect(occurrences - 1).toBe(1)
+    },
+  )
+
+  it('lets the title-as-headline size itself instead of clipping', () => {
+    const { container } = render(<Hero conference={provisionedConference()} />)
+    // The classic hero clamps its heading height to stop the typewriter from
+    // jolting the page. A static title has no animation to reserve room for,
+    // and a long conference name is exactly what the clamp would cut in half.
+    expect(container.querySelector('h1')?.className).not.toContain('h-[5.5rem]')
+  })
+
+  it('keeps the sr-only name beside a REAL tagline', () => {
+    const conference = provisionedConference()
+    conference.tagline = 'Systems that hold at scale'
+    const { container } = render(<Hero conference={conference} />)
+    const h1 = container.querySelector('h1')
+    expect(h1?.querySelector('.sr-only')?.textContent).toBe('Brand New Conf - ')
+    expect(h1?.textContent).toContain('Systems that hold at scale')
+    expect(h1?.className).toContain('h-[5.5rem]')
+  })
+
+  it('treats a whitespace-only tagline as no tagline', () => {
+    const conference = provisionedConference()
+    conference.tagline = '   '
+    const { container } = render(<Hero conference={conference} />)
+    expect(container.querySelector('h1')?.textContent).toBe('Brand New Conf')
+  })
+
+  it('still lets a stored headline override win', () => {
+    const { container } = render(
+      <Hero
+        conference={provisionedConference()}
+        headlineOverride="Tickets are live"
+      />,
+    )
+    const h1 = container.querySelector('h1')
+    expect(h1?.textContent).toContain('Tickets are live')
+    // The override is not the title, so the name still needs its own mention.
+    expect(h1?.querySelector('.sr-only')?.textContent).toBe('Brand New Conf - ')
   })
 })

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -347,19 +347,49 @@ function HeroAnnouncement({ conference }: { conference: Conference }) {
 }
 
 /**
- * The headline TEXT only — the `<h1>` wrapper belongs to the variant, because
- * the type treatment is most of what makes the variants different. Override
- * precedence (override → typewriter tagline → plain tagline) is shared.
+ * What the hero's `<h1>` says, and where it came from.
+ *
+ * `tagline` is OPTIONAL on a real conference document — `@/lib/onboarding/create.ts`
+ * provisions a brand-new tenant without one — and the headline used to render
+ * the tagline unconditionally. A fresh tenant therefore shipped an EMPTY `<h1>`
+ * (a blank fixed-height block in `classic`) as the most prominent element on
+ * its homepage, with the conference name reachable only by screen readers.
+ * Falling back to the title means the page always names the event.
+ *
+ * `source` is what the variants key their surrounding chrome on: both the
+ * `sr-only` prefix in `classic`/`minimal` and the eyebrow in `emblem` exist to
+ * add the title BESIDE the tagline, so they must disappear when the title has
+ * become the headline itself — otherwise the page says the name twice.
  */
-function HeroHeadlineText({
-  conference,
-  headlineOverride,
-}: {
-  conference: Conference
-  headlineOverride?: string
-}) {
-  if (headlineOverride) return <>{headlineOverride}</>
-  if (conference.tagline?.startsWith('Real ')) {
+type HeroHeadlineSource = 'override' | 'tagline' | 'title'
+
+interface HeroHeadline {
+  text: string
+  source: HeroHeadlineSource
+}
+
+function resolveHeroHeadline(
+  conference: Conference,
+  headlineOverride?: string,
+): HeroHeadline {
+  // Trimmed only for the emptiness TEST — a stored "  " is as absent as an
+  // unset field, but the value itself is rendered as the organizer wrote it.
+  if (headlineOverride?.trim())
+    return { text: headlineOverride, source: 'override' }
+  if (conference.tagline?.trim())
+    return { text: conference.tagline, source: 'tagline' }
+  return { text: conference.title ?? '', source: 'title' }
+}
+
+/**
+ * The headline TEXT only — the `<h1>` wrapper belongs to the variant, because
+ * the type treatment is most of what makes the variants different. Precedence
+ * (override → typewriter tagline → plain tagline → title) is shared.
+ */
+function HeroHeadlineText({ headline }: { headline: HeroHeadline }) {
+  // The typewriter is a TAGLINE treatment: an override that happens to start
+  // with "Real " stays plain text, as it always has.
+  if (headline.source === 'tagline' && headline.text.startsWith('Real ')) {
     return (
       <TypewriterEffect
         prefix="Real "
@@ -371,7 +401,7 @@ function HeroHeadlineText({
       />
     )
   }
-  return <>{conference.tagline}</>
+  return <>{headline.text}</>
 }
 
 /** The description column, with the same override precedence as the headline. */
@@ -457,18 +487,33 @@ function ClassicHero({
   subheadlineOverride,
   ctaOverrides,
 }: HeroVariantProps) {
+  const headline = resolveHeroHeadline(conference, headlineOverride)
+
   return (
     <div className="relative py-10 sm:pt-36 sm:pb-24">
       <BackgroundImage className="-top-36 -bottom-14" />
       <Container className="relative">
         <div className="mx-auto max-w-2xl lg:max-w-4xl lg:px-12">
           <HeroAnnouncement conference={conference} />
-          <h1 className="font-jetbrains h-[5.5rem] overflow-hidden text-4xl font-bold tracking-tighter text-brand-cloud-blue sm:h-[8.5rem] sm:text-6xl lg:h-auto lg:overflow-visible">
-            <span className="sr-only">{conference.title} - </span>
-            <HeroHeadlineText
-              conference={conference}
-              headlineOverride={headlineOverride}
-            />
+          {/*
+            The fixed height reserves room for the typewriter so the page does
+            not jump as it types — a TAGLINE concern. A title headline is
+            static, and a long conference name is exactly what the clamp would
+            cut in half, so that path lets the heading size itself.
+          */}
+          <h1
+            className={
+              headline.source === 'title'
+                ? 'font-jetbrains text-4xl font-bold tracking-tighter text-brand-cloud-blue sm:text-6xl'
+                : // Spelled out rather than composed: this exact string is what
+                  // the back-compat snapshots pin for every existing edition.
+                  'font-jetbrains h-[5.5rem] overflow-hidden text-4xl font-bold tracking-tighter text-brand-cloud-blue sm:h-[8.5rem] sm:text-6xl lg:h-auto lg:overflow-visible'
+            }
+          >
+            {headline.source !== 'title' && (
+              <span className="sr-only">{conference.title} - </span>
+            )}
+            <HeroHeadlineText headline={headline} />
           </h1>
           <HeroDescription
             conference={conference}
@@ -559,6 +604,7 @@ function MinimalHero({
   ctaOverrides,
 }: HeroVariantProps) {
   const meta = heroMetaLine(conference)
+  const headline = resolveHeroHeadline(conference, headlineOverride)
 
   return (
     <div className="relative border-b border-brand-slate-gray/10 py-14 sm:py-20 dark:border-white/10">
@@ -585,11 +631,10 @@ function MinimalHero({
           )}
 
           <h1 className="font-space-grotesk mt-4 text-4xl font-bold tracking-tight text-balance text-brand-slate-gray sm:mt-6 sm:text-5xl lg:text-6xl dark:text-white">
-            <span className="sr-only">{conference.title} - </span>
-            <HeroHeadlineText
-              conference={conference}
-              headlineOverride={headlineOverride}
-            />
+            {headline.source !== 'title' && (
+              <span className="sr-only">{conference.title} - </span>
+            )}
+            <HeroHeadlineText headline={headline} />
           </h1>
 
           <div className="max-w-2xl [&_p]:sm:text-xl">
@@ -646,6 +691,7 @@ function EmblemHero({
 }: HeroVariantProps) {
   const meta = heroMetaLine(conference)
   const metrics = conference.vanityMetrics?.slice(0, 4) ?? []
+  const headline = resolveHeroHeadline(conference, headlineOverride)
 
   return (
     <div className="relative py-12 sm:py-20 lg:py-28">
@@ -672,15 +718,19 @@ function EmblemHero({
           </div>
 
           <div className="text-center lg:text-left">
-            <p className="font-jetbrains text-xs font-semibold tracking-[0.25em] text-brand-cloud-blue uppercase sm:text-sm">
-              {conference.title}
-            </p>
+            {/*
+              The eyebrow names the event ABOVE the tagline. When the tagline
+              is missing the title has become the headline, so the eyebrow
+              would just print the same words twice, stacked.
+            */}
+            {headline.source !== 'title' && (
+              <p className="font-jetbrains text-xs font-semibold tracking-[0.25em] text-brand-cloud-blue uppercase sm:text-sm">
+                {conference.title}
+              </p>
+            )}
 
             <h1 className="font-space-grotesk mt-3 text-3xl font-bold tracking-tight text-balance text-brand-slate-gray sm:text-5xl lg:text-6xl dark:text-white">
-              <HeroHeadlineText
-                conference={conference}
-                headlineOverride={headlineOverride}
-              />
+              <HeroHeadlineText headline={headline} />
             </h1>
 
             {meta.length > 0 && (

--- a/src/components/info/InfoContent.stories.tsx
+++ b/src/components/info/InfoContent.stories.tsx
@@ -75,6 +75,30 @@ export const FreshTenant: Story = {
   },
 }
 
+/**
+ * HALF SET UP: the organizer has a date and has CREATED the schedule day, but
+ * has not put anything in it. `getScheduleDayInfo` fills such a day with
+ * 08:00 / 09:00 / 17:00, so this is the state that would publish invented
+ * times if the answers gated on the day existing rather than on it carrying
+ * real ones. Expect the date answer alone — no doors, no badge desk.
+ */
+export const ScheduleCreatedButEmpty: Story = {
+  args: {
+    faqs: buildInfoFaqs(
+      { ...freshConference(), startDate: '2026-10-27' } as Conference,
+      getScheduleDayInfo([
+        {
+          _id: 'sched-empty',
+          date: '2026-10-27',
+          tracks: [
+            { trackTitle: 'Main track', trackDescription: '', talks: [] },
+          ],
+        } as unknown as ConferenceSchedule,
+      ]),
+    ),
+  },
+}
+
 /** The same page once dates, a venue and a schedule exist. */
 export const ConfiguredConference: Story = {
   args: {

--- a/src/components/info/InfoContent.stories.tsx
+++ b/src/components/info/InfoContent.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { InfoContent } from './InfoContent'
+import { buildInfoFaqs, getScheduleDayInfo } from '@/lib/conference/info-faq'
+import { buildOnboardingDocuments } from '@/lib/onboarding/create'
+import type { Conference, ConferenceSchedule } from '@/lib/conference/types'
+
+/**
+ * The `/info` FAQ. Every answer is built by `buildInfoFaqs`, so these stories
+ * are the review surface for WHICH QUESTIONS EXIST at a given level of
+ * configuration — the point of the day-one work is that a conference which has
+ * said nothing has fewer questions, not wrong answers.
+ */
+const meta = {
+  title: 'Systems/Info/InfoContent',
+  component: InfoContent,
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof InfoContent>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Built by the REAL provisioning builder, so the story cannot drift. */
+function freshConference(): Conference {
+  let key = 0
+  const { conference } = buildOnboardingDocuments(
+    {
+      organization: {
+        name: 'Brand New Events',
+        slug: 'brand-new-events',
+        contactEmail: 'hello@brand-new.example',
+      },
+      conference: {
+        title: 'Brand New Conf',
+        city: 'Bergen',
+        country: 'Norway',
+      },
+      organizer: { name: 'Ada Organizer', email: 'ada@brand-new.example' },
+      domains: ['brand-new.konf.run'],
+    },
+    {
+      organizationId: 'org-fresh',
+      conferenceId: 'conf-fresh',
+      speakerId: 'speaker-fresh',
+      mintKey: () => `key-${++key}`,
+    },
+    null,
+  )
+  return conference as unknown as Conference
+}
+
+const schedule: ConferenceSchedule = {
+  _id: 'sched-1',
+  date: '2026-10-27',
+  tracks: [
+    {
+      trackTitle: 'Main track',
+      trackDescription: '',
+      talks: [
+        { placeholder: 'Registration', startTime: '07:30', endTime: '08:45' },
+        { placeholder: 'Closing', startTime: '16:00', endTime: '16:45' },
+      ],
+    },
+  ],
+} as unknown as ConferenceSchedule
+
+/**
+ * DAY ONE. No dates, no venue, no schedule. The page used to answer "The
+ * conference will be held on TBD. Registration opens at 08:00…", promise food
+ * and drinks, and describe an afterparty starting at 6 PM — none of which the
+ * organizer had configured. Those questions are now simply not asked.
+ */
+export const FreshTenant: Story = {
+  args: {
+    faqs: buildInfoFaqs(freshConference(), getScheduleDayInfo(undefined)),
+  },
+}
+
+/** The same page once dates, a venue and a schedule exist. */
+export const ConfiguredConference: Story = {
+  args: {
+    faqs: buildInfoFaqs(
+      {
+        ...freshConference(),
+        startDate: '2026-10-27',
+        endDate: '2026-10-27',
+        venueName: 'Grieghallen',
+        venueAddress: 'Edvard Griegs plass 1, 5015 Bergen',
+      } as Conference,
+      getScheduleDayInfo([schedule]),
+    ),
+  },
+}

--- a/src/components/speaker/SpeakersNotAnnouncedNotice.stories.tsx
+++ b/src/components/speaker/SpeakersNotAnnouncedNotice.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { SpeakersNotAnnouncedNotice } from './SpeakersNotAnnouncedNotice'
+
+/**
+ * Replaces the speaker grid on the public `/speaker` page while no speaker has
+ * been announced — the state every freshly provisioned tenant starts in, and
+ * the one the `/tickets` coming-soon card links straight into. The page used
+ * to say "Meet our 0 speakers" above an empty grid.
+ */
+const meta = {
+  title: 'Systems/Speakers/SpeakersNotAnnouncedNotice',
+  component: SpeakersNotAnnouncedNotice,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SpeakersNotAnnouncedNotice>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Day one: a contact address (provisioning always sets one), no open CFP. */
+export const FreshTenant: Story = {
+  args: { contactEmail: 'hello@brand-new.example' },
+}
+
+/** The CFP window is open and formats exist — speakers can still get in. */
+export const WithOpenCfp: Story = {
+  args: { contactEmail: 'hello@brand-new.example', cfpOpen: true },
+}
+
+/** No contact address configured — the offer to email is simply dropped. */
+export const WithoutContactEmail: Story = {
+  args: {},
+}

--- a/src/components/speaker/SpeakersNotAnnouncedNotice.tsx
+++ b/src/components/speaker/SpeakersNotAnnouncedNotice.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link'
+
+/**
+ * Shown on the public `/speaker` page IN PLACE OF the speaker grid when the
+ * conference has no accepted speakers yet.
+ *
+ * The page used to head an empty grid with "Meet our 0 speakers" over a
+ * paragraph promising "these industry experts" — which is what every freshly
+ * provisioned tenant showed (see `@/lib/onboarding/create.ts`), and what the
+ * "View Speakers" button on the `/tickets` coming-soon card linked to. A
+ * counted heading only makes sense once there is something to count.
+ *
+ * The submit link appears only when a proposal could actually be submitted —
+ * the CFP window is open AND the conference offers at least one format — so
+ * this never sends a speaker to a form they cannot complete.
+ */
+export function SpeakersNotAnnouncedNotice({
+  contactEmail,
+  cfpOpen = false,
+}: {
+  /** General contact address; omitted → the offer to email is dropped. */
+  contactEmail?: string
+  /** CFP window open AND at least one submittable format configured. */
+  cfpOpen?: boolean
+}) {
+  return (
+    <div
+      role="status"
+      className="mt-10 rounded-lg border border-brand-cloud-blue/20 bg-brand-sky-mist p-6 dark:border-blue-800 dark:bg-blue-900/20"
+    >
+      <h2 className="font-space-grotesk text-lg font-semibold text-brand-cloud-blue dark:text-blue-300">
+        Speakers have not been announced yet
+      </h2>
+      <p className="font-inter mt-2 text-base text-brand-slate-gray dark:text-gray-300">
+        The programme is still being put together. Speaker profiles will appear
+        here as soon as the first talks are confirmed. Check back soon
+        {contactEmail ? (
+          <>
+            , or reach out to{' '}
+            <Link
+              href={`mailto:${contactEmail}`}
+              className="underline hover:no-underline"
+            >
+              {contactEmail}
+            </Link>{' '}
+            if you have questions
+          </>
+        ) : null}
+        .
+      </p>
+      {cfpOpen && (
+        <p className="font-inter mt-4 text-base text-brand-slate-gray dark:text-gray-300">
+          Want to be one of them? The{' '}
+          <Link href="/cfp" className="underline hover:no-underline">
+            call for presentations
+          </Link>{' '}
+          is open.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/lib/conference/info-faq.ts
+++ b/src/lib/conference/info-faq.ts
@@ -36,6 +36,22 @@ export interface ScheduleDayInfo {
   registrationTime: string
   startTime: string
   endTime: string
+  /**
+   * Whether the three times above were READ OFF this day's talks, or invented.
+   *
+   * A schedule DOCUMENT is not a schedule: creating the day is an early setup
+   * step, so "day exists, nothing in it" is a common — arguably the most
+   * common — intermediate state, and for it the fields above are `08:00`,
+   * `09:00` and `17:00`, which no organizer ever typed. Consumers that publish
+   * these times to visitors must gate on this flag, not on the day's
+   * existence.
+   *
+   * Deliberately ALL-OR-NOTHING and fail-closed: a half-filled first talk
+   * (start but no end) leaves at least one published time invented, and no
+   * caller wants to reason about which. A day with talks that carry real times
+   * — every real conference schedule — is unaffected.
+   */
+  hasRealTimes: boolean
   isWorkshopDay: boolean
   schedule: ConferenceSchedule
 }
@@ -66,7 +82,11 @@ export function getScheduleDayInfo(
   const hasMultipleDays = sortedSchedules.length > 1
 
   const days = sortedSchedules.map((schedule) => {
-    const allTalks = schedule.tracks.flatMap((track) => track.talks)
+    // `tracks` (and `talks`) are typed non-optional but a half-created schedule
+    // document carries neither — and this runs on a public page with no error
+    // boundary above it, so an absent array is an empty one, not a 500.
+    const tracks = schedule.tracks ?? []
+    const allTalks = tracks.flatMap((track) => track.talks ?? [])
 
     // First item is registration
     const registrationTalk = allTalks.length > 0 ? allTalks[0] : null
@@ -80,7 +100,7 @@ export function getScheduleDayInfo(
     const latestEnd =
       endTimes.length > 0 ? endTimes.sort().reverse()[0] : '17:00'
 
-    const isWorkshopDay = schedule.tracks.some((track) =>
+    const isWorkshopDay = tracks.some((track) =>
       track.trackTitle?.toLowerCase().includes('workshop'),
     )
 
@@ -89,6 +109,14 @@ export function getScheduleDayInfo(
       registrationTime,
       startTime: firstProgramTime,
       endTime: latestEnd,
+      // Every `|| fallback` above fired off the SAME source, so one test covers
+      // all three: a first talk carrying both of its own times, and at least
+      // one end time anywhere on the day.
+      hasRealTimes: Boolean(
+        registrationTalk?.startTime &&
+        registrationTalk?.endTime &&
+        endTimes.length > 0,
+      ),
       isWorkshopDay,
       schedule,
     }
@@ -129,19 +157,28 @@ export function buildInfoFaqs(
   const day = (value: string) => escapeHtml(formatDate(value))
 
   /**
-   * Whether the organizers have published a schedule at all. Every clock time
-   * on this page is derived from one (`getScheduleDayInfo`), so with no
-   * schedule the `08:00 / 09:00 / 17:00` fallbacks are not defaults — they are
-   * the page inventing the running order of someone else's conference.
+   * The day whose times this page may publish, or `null`.
+   *
+   * Gating on the day's EXISTENCE is not enough: `getScheduleDayInfo` builds a
+   * day for an empty schedule document too, filled with `08:00 / 09:00 / 17:00`
+   * — so a tenant who created their schedule and has not filled it in (an early
+   * setup step, and therefore a likelier state than having no schedule at all)
+   * would publish invented times through this gate. `hasRealTimes` is the
+   * question that actually matters.
    */
-  const hasSchedule = scheduleInfo.days.length > 0
+  const timedDay = (day: ScheduleDayInfo | null): ScheduleDayInfo | null =>
+    day?.hasRealTimes ? day : null
+
+  const conferenceDay = timedDay(scheduleInfo.conferenceDay)
+  const workshopDay = timedDay(scheduleInfo.workshopDay)
+  /** Both days real: the only state in which the two-day answers are true. */
+  const bothDays =
+    scheduleInfo.hasMultipleDays && workshopDay && conferenceDay
+      ? { workshopDay, conferenceDay }
+      : null
 
   const dateAnswer = (() => {
-    if (
-      scheduleInfo.hasMultipleDays &&
-      scheduleInfo.workshopDay &&
-      scheduleInfo.conferenceDay
-    ) {
+    if (bothDays) {
       // The span sentence is dropped when the conference itself carries no
       // dates: the per-day breakdown below comes from the schedule and is true
       // regardless.
@@ -152,23 +189,33 @@ export function buildInfoFaqs(
 `
           : ''
 
-      return `${span}Day 1 (${day(scheduleInfo.workshopDay.date)}) - Workshop Day: Registration opens at ${escapeHtml(scheduleInfo.workshopDay.registrationTime)}. Workshops run from ${escapeHtml(scheduleInfo.workshopDay.startTime)} to ${escapeHtml(scheduleInfo.workshopDay.endTime)}.
+      return `${span}Day 1 (${day(bothDays.workshopDay.date)}) - Workshop Day: Registration opens at ${escapeHtml(bothDays.workshopDay.registrationTime)}. Workshops run from ${escapeHtml(bothDays.workshopDay.startTime)} to ${escapeHtml(bothDays.workshopDay.endTime)}.
 
-Day 2 (${day(scheduleInfo.conferenceDay.date)}) - Main Conference: Registration opens at ${escapeHtml(scheduleInfo.conferenceDay.registrationTime)}. Talks are scheduled from ${escapeHtml(scheduleInfo.conferenceDay.startTime)} to ${escapeHtml(scheduleInfo.conferenceDay.endTime)}.
+Day 2 (${day(bothDays.conferenceDay.date)}) - Main Conference: Registration opens at ${escapeHtml(bothDays.conferenceDay.registrationTime)}. Talks are scheduled from ${escapeHtml(bothDays.conferenceDay.startTime)} to ${escapeHtml(bothDays.conferenceDay.endTime)}.
 
 Important: Please check your ticket type. Workshop tickets (&quot;Workshop + Conference&quot;) grant access to both days, while conference-only tickets grant access to the main conference day only.`
     }
 
-    // Two independent facts, each kept only if it is one: the date, and the
-    // running times. A tenant with a date but no schedule gets the date alone;
-    // a tenant with neither gets no question at all (see below), because an
-    // answer that says nothing is worse than a question that is not asked yet.
+    // Two independent facts, each kept only if it is one: the dates, and the
+    // running times. A tenant with dates but no usable schedule gets the dates
+    // alone; a tenant with neither gets no question at all (see below), because
+    // an answer that says nothing is worse than a question that is not asked
+    // yet.
+    const dates =
+      conference.startDate &&
+      conference.endDate &&
+      conference.endDate !== conference.startDate
+        ? // Reached by a multi-day conference whose schedule is not filled in:
+          // the span is known even when the running order is not.
+          `This is a multi-day event running from ${day(conference.startDate)} to ${day(conference.endDate)}.`
+        : conference.startDate
+          ? `The conference will be held on ${day(conference.startDate)}.`
+          : null
+
     const sentences = [
-      conference.startDate
-        ? `The conference will be held on ${day(conference.startDate)}.`
-        : null,
-      scheduleInfo.conferenceDay
-        ? `Registration opens at ${time(scheduleInfo.conferenceDay.registrationTime, '08:00')}. The talks are scheduled to start at ${time(scheduleInfo.conferenceDay.startTime, '09:00')} and to end at ${time(scheduleInfo.conferenceDay.endTime, '17:00')}.`
+      dates,
+      conferenceDay
+        ? `Registration opens at ${time(conferenceDay.registrationTime, '08:00')}. The talks are scheduled to start at ${time(conferenceDay.startTime, '09:00')} and to end at ${time(conferenceDay.endTime, '17:00')}.`
         : null,
     ].filter(Boolean)
 
@@ -290,27 +337,26 @@ Important: Please check your ticket type. Workshop tickets (&quot;Workshop + Con
         // off the schedule. Without one this said "Registration opens at 08:00"
         // — and describing a desk "at the venue" two answers below "The venue
         // has not been announced yet" is its own small absurdity.
-        ...(scheduleInfo.conferenceDay
+        ...(conferenceDay
           ? [
               {
                 question: 'When and where can I pick up my badge?',
-                answer:
-                  scheduleInfo.hasMultipleDays && scheduleInfo.workshopDay
-                    ? `You can pick up your badge at the registration desk at the venue. Registration opens at ${escapeHtml(scheduleInfo.workshopDay.registrationTime)} on ${day(scheduleInfo.workshopDay.date)} (workshop day) and at ${escapeHtml(scheduleInfo.conferenceDay.registrationTime)} on ${day(scheduleInfo.conferenceDay.date)} (conference day). If you&apos;re attending both days, we recommend picking up your badge on the first day.`
-                    : `You can pick up your badge at the registration desk at the venue. Registration opens at ${time(scheduleInfo.conferenceDay.registrationTime, '08:00')}. We recommend arriving early to get your badge and find a good seat.`,
+                answer: bothDays
+                  ? `You can pick up your badge at the registration desk at the venue. Registration opens at ${escapeHtml(bothDays.workshopDay.registrationTime)} on ${day(bothDays.workshopDay.date)} (workshop day) and at ${escapeHtml(bothDays.conferenceDay.registrationTime)} on ${day(bothDays.conferenceDay.date)} (conference day). If you&apos;re attending both days, we recommend picking up your badge on the first day.`
+                  : `You can pick up your badge at the registration desk at the venue. Registration opens at ${time(conferenceDay.registrationTime, '08:00')}. We recommend arriving early to get your badge and find a good seat.`,
               },
             ]
           : []),
         // Every word of this answer is a clock time read off the schedule, so
         // without one there is nothing left to say — and "Doors open at 08:00"
         // was the invention a reader was most likely to plan a train around.
-        ...(hasSchedule
+        ...(conferenceDay
           ? [
               {
                 question: 'When will the doors open?',
-                answer: scheduleInfo.hasMultipleDays
-                  ? `Doors open for registration at ${time(scheduleInfo.workshopDay?.registrationTime, '08:00')} on the workshop day and at ${time(scheduleInfo.conferenceDay?.registrationTime, '08:00')} on the conference day. The first workshop starts at ${time(scheduleInfo.workshopDay?.startTime, '09:00')} and the first talk starts at ${time(scheduleInfo.conferenceDay?.startTime, '09:00')}. We suggest arriving at registration time to pick up your badge, enjoy coffee, and find a good seat.`
-                  : `Doors open for registration at ${time(scheduleInfo.conferenceDay?.registrationTime, '08:00')}. The first talk starts at ${time(scheduleInfo.conferenceDay?.startTime, '09:00')}. We suggest arriving early to pick up your badge and find a good seat.`,
+                answer: bothDays
+                  ? `Doors open for registration at ${time(bothDays.workshopDay.registrationTime, '08:00')} on the workshop day and at ${time(bothDays.conferenceDay.registrationTime, '08:00')} on the conference day. The first workshop starts at ${time(bothDays.workshopDay.startTime, '09:00')} and the first talk starts at ${time(bothDays.conferenceDay.startTime, '09:00')}. We suggest arriving at registration time to pick up your badge, enjoy coffee, and find a good seat.`
+                  : `Doors open for registration at ${time(conferenceDay.registrationTime, '08:00')}. The first talk starts at ${time(conferenceDay.startTime, '09:00')}. We suggest arriving early to pick up your badge and find a good seat.`,
               },
             ]
           : []),

--- a/src/lib/conference/info-faq.ts
+++ b/src/lib/conference/info-faq.ts
@@ -119,7 +119,22 @@ export function buildInfoFaqs(
   // `formatDate` output is Intl-generated (or the literal "TBD"/"Invalid Date")
   // and cannot carry markup, but it is escaped anyway so that no reader has to
   // re-derive that argument to know the interpolation is safe.
+  //
+  // NOTE `formatDate('')` returns the literal "TBD". That is a fine placeholder
+  // in an admin table but a falsehood in prose — "The conference will be held
+  // on TBD" is what a brand-new tenant's `/info` page said, because
+  // `@/lib/onboarding/create.ts` provisions no dates. Every `day(...)` call
+  // below is therefore GATED on the value being present, rather than changing
+  // the shared helper that ~30 other call sites depend on.
   const day = (value: string) => escapeHtml(formatDate(value))
+
+  /**
+   * Whether the organizers have published a schedule at all. Every clock time
+   * on this page is derived from one (`getScheduleDayInfo`), so with no
+   * schedule the `08:00 / 09:00 / 17:00` fallbacks are not defaults — they are
+   * the page inventing the running order of someone else's conference.
+   */
+  const hasSchedule = scheduleInfo.days.length > 0
 
   const dateAnswer = (() => {
     if (
@@ -127,22 +142,65 @@ export function buildInfoFaqs(
       scheduleInfo.workshopDay &&
       scheduleInfo.conferenceDay
     ) {
-      return `This is a multi-day event running from ${day(conference.startDate)} to ${day(conference.endDate)}.
+      // The span sentence is dropped when the conference itself carries no
+      // dates: the per-day breakdown below comes from the schedule and is true
+      // regardless.
+      const span =
+        conference.startDate && conference.endDate
+          ? `This is a multi-day event running from ${day(conference.startDate)} to ${day(conference.endDate)}.
 
-Day 1 (${day(scheduleInfo.workshopDay.date)}) - Workshop Day: Registration opens at ${escapeHtml(scheduleInfo.workshopDay.registrationTime)}. Workshops run from ${escapeHtml(scheduleInfo.workshopDay.startTime)} to ${escapeHtml(scheduleInfo.workshopDay.endTime)}.
+`
+          : ''
+
+      return `${span}Day 1 (${day(scheduleInfo.workshopDay.date)}) - Workshop Day: Registration opens at ${escapeHtml(scheduleInfo.workshopDay.registrationTime)}. Workshops run from ${escapeHtml(scheduleInfo.workshopDay.startTime)} to ${escapeHtml(scheduleInfo.workshopDay.endTime)}.
 
 Day 2 (${day(scheduleInfo.conferenceDay.date)}) - Main Conference: Registration opens at ${escapeHtml(scheduleInfo.conferenceDay.registrationTime)}. Talks are scheduled from ${escapeHtml(scheduleInfo.conferenceDay.startTime)} to ${escapeHtml(scheduleInfo.conferenceDay.endTime)}.
 
 Important: Please check your ticket type. Workshop tickets (&quot;Workshop + Conference&quot;) grant access to both days, while conference-only tickets grant access to the main conference day only.`
     }
 
-    return `The conference will be held on ${day(conference.startDate)}. Registration opens at ${time(scheduleInfo.conferenceDay?.registrationTime, '08:00')}. The talks are scheduled to start at ${time(scheduleInfo.conferenceDay?.startTime, '09:00')} and to end at ${time(scheduleInfo.conferenceDay?.endTime, '17:00')}.`
+    // Two independent facts, each kept only if it is one: the date, and the
+    // running times. A tenant with a date but no schedule gets the date alone;
+    // a tenant with neither gets no question at all (see below), because an
+    // answer that says nothing is worse than a question that is not asked yet.
+    const sentences = [
+      conference.startDate
+        ? `The conference will be held on ${day(conference.startDate)}.`
+        : null,
+      scheduleInfo.conferenceDay
+        ? `Registration opens at ${time(scheduleInfo.conferenceDay.registrationTime, '08:00')}. The talks are scheduled to start at ${time(scheduleInfo.conferenceDay.startTime, '09:00')} and to end at ${time(scheduleInfo.conferenceDay.endTime, '17:00')}.`
+        : null,
+    ].filter(Boolean)
+
+    return sentences.length > 0 ? sentences.join(' ') : null
   })()
 
   const venueLocation = [conference.city, conference.country]
     .filter(Boolean)
     .map(escapeHtml)
     .join(', ')
+
+  // Provisioning writes city/country but no venue, so the old copy read "will
+  // take place at the venue in Bergen, Norway" — a definite article standing in
+  // for a booking that does not exist. Name the venue when there is one, give
+  // the address alone when that is all there is, say only where the event is
+  // when even that is missing, and ask nothing when none of it is known.
+  const venueAnswer = (() => {
+    const address = conference.venueAddress
+      ? ` The address is ${escapeHtml(conference.venueAddress)}.`
+      : ''
+    const inLocation = venueLocation ? ` in ${venueLocation}` : ''
+    if (conference.venueName) {
+      return `The conference will take place at ${escapeHtml(conference.venueName)}${inLocation}.${address}`
+    }
+    if (conference.venueAddress) {
+      return `The conference will take place${inLocation}.${address}`
+    }
+    if (venueLocation) {
+      return `The conference will take place in ${venueLocation}. The venue has not been announced yet.`
+    }
+    return null
+  })()
 
   const contactEmail = escapeHtml(conference.contactEmail || '')
 
@@ -159,16 +217,27 @@ Important: Please check your ticket type. Workshop tickets (&quot;Workshop + Con
       heading: 'For Attendees',
       description: 'Practical information for attending the conference.',
       questions: [
-        {
-          question: 'What is the date of the conference?',
-          answer: dateAnswer,
-        },
-        {
-          question: 'Where is the conference located?',
-          // `city, country` joined defensively — an unset country used to render
-          // the literal string "undefined" on the public page.
-          answer: `The conference will take place at ${conference.venueName ? escapeHtml(conference.venueName) : 'the venue'}${venueLocation ? ` in ${venueLocation}` : ''}.${conference.venueAddress ? ` The address is ${escapeHtml(conference.venueAddress)}.` : ''}`,
-        },
+        // No dates and no schedule means the organizers have not decided yet —
+        // and a FAQ that answers "we don't know" is noise. The page's own
+        // intro already invites the reader to ask.
+        ...(dateAnswer
+          ? [
+              {
+                question: 'What is the date of the conference?',
+                answer: dateAnswer,
+              },
+            ]
+          : []),
+        // `city, country` joined defensively — an unset country used to render
+        // the literal string "undefined" on the public page.
+        ...(venueAnswer
+          ? [
+              {
+                question: 'Where is the conference located?',
+                answer: venueAnswer,
+              },
+            ]
+          : []),
         // Travel directions are PLACE-SPECIFIC, so they come from the tenant's
         // own `venueTravelInfo`. This used to be hardcoded Bergen transit prose
         // (Byparken, Bybanen, "airport Flesland") rendered with whatever city a
@@ -187,46 +256,75 @@ Important: Please check your ticket type. Workshop tickets (&quot;Workshop + Con
               },
             ]
           : []),
-        {
-          question: 'Is this venue accessible?',
-          answer:
-            'Yes, the venue is accessible. If you have any special needs, please let us know in advance as a part of the ticket registration, and we will do our best to accommodate you.',
-        },
+        // A claim about A venue needs a venue. With none booked this said "Yes,
+        // the venue is accessible" about a room nobody has chosen.
+        ...(conference.venueName
+          ? [
+              {
+                question: 'Is this venue accessible?',
+                answer:
+                  'Yes, the venue is accessible. If you have any special needs, please let us know in advance as a part of the ticket registration, and we will do our best to accommodate you.',
+              },
+            ]
+          : []),
         {
           question: 'What about allergies and dietary restrictions?',
+          // No longer opens with "We will serve food and drinks during the
+          // conference": nothing in the conference document says a tenant
+          // caters, and this page has no business promising lunch on their
+          // behalf. Asking about restrictions costs nothing and stays useful
+          // either way. A `cateringInfo` field would let organizers say it
+          // themselves — filed, not built here.
           answer:
-            'We will serve food and drinks during the conference. If you have any allergies or dietary restrictions, please let us know in advance as a part of the ticket registration, and we will do our best to accommodate you.',
+            'If you have any allergies or dietary restrictions, please let us know in advance as a part of the ticket registration, and we will do our best to accommodate you.',
         },
         {
           question: 'What ticket types are available?',
           answer: scheduleInfo.hasMultipleDays
             ? 'There are two main ticket types: Workshop + Conference (2 days) tickets provide access to both the workshop day and the main conference day, while Conference Only tickets grant access to the main conference day only. Please verify your ticket type before attending to ensure you have access to the correct days.'
-            : 'Please check your ticket confirmation for details about what your ticket includes, such as access to talks, workshops, food, and the afterparty.',
+            : // The old list of inclusions ("talks, workshops, food, and the
+              // afterparty") named three things this site cannot know about.
+              'Please check your ticket confirmation for details about what your ticket includes.',
         },
-        {
-          question: 'When and where can I pick up my badge?',
-          answer:
-            scheduleInfo.hasMultipleDays &&
-            scheduleInfo.workshopDay &&
-            scheduleInfo.conferenceDay
-              ? `You can pick up your badge at the registration desk at the venue. Registration opens at ${escapeHtml(scheduleInfo.workshopDay.registrationTime)} on ${day(scheduleInfo.workshopDay.date)} (workshop day) and at ${escapeHtml(scheduleInfo.conferenceDay.registrationTime)} on ${day(scheduleInfo.conferenceDay.date)} (conference day). If you&apos;re attending both days, we recommend picking up your badge on the first day.`
-              : `You can pick up your badge at the registration desk at the venue. Registration opens at ${time(scheduleInfo.conferenceDay?.registrationTime, '08:00')}. We recommend arriving early to get your badge and find a good seat.`,
-        },
-        {
-          question: 'When will the doors open?',
-          answer: scheduleInfo.hasMultipleDays
-            ? `Doors open for registration at ${time(scheduleInfo.workshopDay?.registrationTime, '08:00')} on the workshop day and at ${time(scheduleInfo.conferenceDay?.registrationTime, '08:00')} on the conference day. The first workshop starts at ${time(scheduleInfo.workshopDay?.startTime, '09:00')} and the first talk starts at ${time(scheduleInfo.conferenceDay?.startTime, '09:00')}. We suggest arriving at registration time to pick up your badge, enjoy coffee, and find a good seat.`
-            : `Doors open for registration at ${time(scheduleInfo.conferenceDay?.registrationTime, '08:00')}. The first talk starts at ${time(scheduleInfo.conferenceDay?.startTime, '09:00')}. We suggest arriving early to pick up your badge and find a good seat.`,
-        },
+        // "When" is the question, and the answer is a registration time read
+        // off the schedule. Without one this said "Registration opens at 08:00"
+        // — and describing a desk "at the venue" two answers below "The venue
+        // has not been announced yet" is its own small absurdity.
+        ...(scheduleInfo.conferenceDay
+          ? [
+              {
+                question: 'When and where can I pick up my badge?',
+                answer:
+                  scheduleInfo.hasMultipleDays && scheduleInfo.workshopDay
+                    ? `You can pick up your badge at the registration desk at the venue. Registration opens at ${escapeHtml(scheduleInfo.workshopDay.registrationTime)} on ${day(scheduleInfo.workshopDay.date)} (workshop day) and at ${escapeHtml(scheduleInfo.conferenceDay.registrationTime)} on ${day(scheduleInfo.conferenceDay.date)} (conference day). If you&apos;re attending both days, we recommend picking up your badge on the first day.`
+                    : `You can pick up your badge at the registration desk at the venue. Registration opens at ${time(scheduleInfo.conferenceDay.registrationTime, '08:00')}. We recommend arriving early to get your badge and find a good seat.`,
+              },
+            ]
+          : []),
+        // Every word of this answer is a clock time read off the schedule, so
+        // without one there is nothing left to say — and "Doors open at 08:00"
+        // was the invention a reader was most likely to plan a train around.
+        ...(hasSchedule
+          ? [
+              {
+                question: 'When will the doors open?',
+                answer: scheduleInfo.hasMultipleDays
+                  ? `Doors open for registration at ${time(scheduleInfo.workshopDay?.registrationTime, '08:00')} on the workshop day and at ${time(scheduleInfo.conferenceDay?.registrationTime, '08:00')} on the conference day. The first workshop starts at ${time(scheduleInfo.workshopDay?.startTime, '09:00')} and the first talk starts at ${time(scheduleInfo.conferenceDay?.startTime, '09:00')}. We suggest arriving at registration time to pick up your badge, enjoy coffee, and find a good seat.`
+                  : `Doors open for registration at ${time(scheduleInfo.conferenceDay?.registrationTime, '08:00')}. The first talk starts at ${time(scheduleInfo.conferenceDay?.startTime, '09:00')}. We suggest arriving early to pick up your badge and find a good seat.`,
+              },
+            ]
+          : []),
         {
           question: 'What is the code of conduct?',
           answer: `We have a code of conduct that all attendees, speakers, and sponsors must follow. You can read the code of conduct on our website at <u><a href="/conduct">Code of Conduct</a></u>. If you have any questions or concerns, please contact us.`,
         },
-        {
-          question: 'What happens after the conference?',
-          answer:
-            'After the conference, we will host an afterparty at the same venue. The afterparty will start at 6 PM and last until late 🌃 There will be food, drinks, and more opertunities to network with other attendees, speakers and sponsors. The afterparty is included in the conference ticket.',
-        },
+        // REMOVED: "What happens after the conference?" — an afterparty at the
+        // same venue, starting at 6 PM, food and drinks included in the ticket.
+        // Four separate commitments made on behalf of a tenant that never
+        // configured any of them, on the page a prospect reads first. There is
+        // no field to key it on, so it is omitted for everyone until one exists
+        // (an `afterpartyInfo` prose field, filed alongside `cateringInfo`),
+        // exactly as the travel and speaker-dinner answers already work.
       ],
     },
     {
@@ -302,7 +400,10 @@ Important: Please check your ticket type. Workshop tickets (&quot;Workshop + Con
         },
         {
           question: 'Do you provide a list of attendees?',
-          answer: `No, we do not provide a list of attendees. However, we encourage you to network with the attendees during the conference and afterparty.`,
+          // No trailing "and afterparty": that event is no longer described
+          // anywhere on this page, because nothing in the document says it
+          // happens.
+          answer: `No, we do not provide a list of attendees. However, we encourage you to network with the attendees during the conference.`,
         },
       ],
     },


### PR DESCRIPTION
A freshly provisioned conference (`src/lib/onboarding/create.ts`) carries a title, an org reference, a city/country, contact emails, minted domains, `registrationEnabled: false` and `visibility: 'unlisted'`. Deliberately absent: tagline, description, venue, dates, schedule, formats, topics. #824 stopped `/cfp` 500ing on that document; this PR fixes what such a tenant's public site **says** — the demo org (`KontainerKonf`, RunKonf/platform#47) is about to be shown to prospects, and all three of these are things a visitor sees.

## 1. The homepage `<h1>` was blank

`Hero` printed `conference.tagline` as the visible heading and kept the title in an `sr-only` span. With no tagline the largest element on the page rendered **empty** — a blank fixed-height block, the conference name reachable only by screen reader.

| | before | after |
|---|---|---|
| no tagline | `<h1>` = "" (+ hidden "Brand New Conf - ") | `<h1>` = **Brand New Conf** |
| tagline set | unchanged | unchanged (byte-identical; the back-compat snapshots still pass untouched) |

- Precedence is now override → tagline → **title**. The typewriter stays a *tagline* treatment, so an override starting with `"Real "` is still plain text.
- The `sr-only` title (classic/minimal) and the eyebrow (emblem) are dropped when the title has *become* the headline, so the name is announced once, not twice.
- The classic heading-height clamp (`h-[5.5rem] … sm:h-[8.5rem]`) exists to stop the typewriter jolting the page. A static title has no animation to reserve room for and a long conference name is exactly what the clamp would cut in half, so the title path lets the heading size itself. The pinned class string is left literal for the tagline path.

## 2. `/speaker` said "Meet our 0 speakers"

…over an empty grid, under "These industry experts will share their insights". Every conference shows this before its first acceptance, and the `/tickets` coming-soon card links "View Speakers" straight into it.

**After:** heading "Speakers", no lead paragraph, and `SpeakersNotAnnouncedNotice` in place of the grid:

> **Speakers have not been announced yet**
> The programme is still being put together. Speaker profiles will appear here as soon as the first talks are confirmed. Check back soon, or reach out to hello@example if you have questions.

The CFP link appears only when `isCfpOpen && hasSubmittableFormats` — the pairing #824's `hasSubmittableFormats` doc asks for, so this never sends a speaker to a form with an empty format dropdown.

## 3. `/info` asserted things the tenant never said

`/info` is the day-one primary CTA. Every answer is now gated on the data that would make it true, following the `venueTravelInfo` / `speakerDinnerInfo` / `localRecommendations` pattern already in the file.

| answer | before (day one) | after |
|---|---|---|
| date | "The conference will be held on **TBD**. Registration opens at 08:00. The talks are scheduled to start at 09:00 and to end at 17:00." | question omitted. Date and times are two independent sentences — a tenant with a date but no schedule gets the date alone |
| multi-day date | "running from **TBD** to **TBD**" + per-day breakdown | span sentence dropped; the schedule-derived breakdown stays |
| location | "will take place at **the venue** in Bergen, Norway." | "will take place in Bergen, Norway. The venue has not been announced yet." (venue named when set; address alone still renders; question omitted when nothing is known) |
| accessibility | "Yes, **the venue** is accessible…" | omitted unless a venue is configured |
| allergies | "**We will serve food and drinks during the conference.** If you have any allergies…" | catering sentence removed; the ask-us-about-restrictions answer stays |
| ticket types | "…such as access to talks, workshops, **food, and the afterparty**." | "Please check your ticket confirmation for details about what your ticket includes." |
| badge pickup | "Registration opens at **08:00**." | omitted without a schedule *that has real times* |
| doors open | "Doors open for registration at **08:00**. The first talk starts at **09:00**." | omitted without a schedule *that has real times* |
| after the conference | "we will host an **afterparty** at the same venue… **6 PM**… included in the conference ticket" | question removed outright |
| sponsors / attendee list | "…during the conference **and afterparty**." | "…during the conference." |

A configured conference (dates + venue + schedule) still gets every one of these answers, with its own real times — see the `Systems/Info/InfoContent` stories, one per state.

## Follow-ups from review

**An EMPTY schedule day bypassed the first time gate** (Greptile). The gate keyed on the day existing, but `getScheduleDayInfo` builds a day for a schedule document with no talks too — filled with `08:00 / 09:00 / 17:00`. A tenant who created their schedule and has not filled it in (an *earlier* setup step than filling it in, so the likelier half-configured state) still published invented times. `ScheduleDayInfo` now carries **`hasRealTimes`** — true only when the day's first talk supplies both of its own times and some talk supplies an end time — and the date / doors-open / badge-pickup answers gate on that, with the two-day answers requiring it on **both** days. Fail-closed by design: a half-filled first talk leaves at least one time invented, and no caller should have to reason about which. A multi-day conference whose schedule is empty keeps the one sentence still true — the span between its configured dates. New story `Systems/Info/InfoContent → ScheduleCreatedButEmpty` is the review surface.

While there: `tracks` / `talks` are typed non-optional but a half-created schedule document carries neither, and `/info` has no error boundary above it — an absent array is now an empty one rather than a TypeError.

**"Meet our 1 speakers"** (Copilot) — pre-existing, but the heading logic is in this diff, so: singular at one.

**Parity re-verified after the refactor.** Every answer was diffed against `origin/main`'s builder for a fully-configured conference, one-day and two-day: the only differences are the four intended ones (afterparty question removed; allergy, ticket-types and attendee-list copy edited). Date, venue, accessibility, badge-pickup and doors-open are byte-identical.

**Not in this PR:** a speaker-fetch failure rendering as "Speakers have not been announced yet" and caching for hours is **#832** — a pre-existing shape this PR makes more affirmative, and it deserves its own change including the caching question.

## Judgement calls

1. **Date-less conference: omit, not soften.** The file's established pattern is "no stored answer → no question", and an FAQ entry that answers "we don't know" is noise; the page intro already invites contact. Partial configuration is preserved: a real date with no schedule keeps the date sentence and drops the times.
2. **Food and afterparty: omitted, not made configurable.** There is no field to key them on and adding schema is a separate design. `cateringInfo` / `afterpartyInfo` prose fields (same shape as `venueTravelInfo`) are **filed, not built** — #831.

   **Stated plainly, because it is a deliberate cost:** this removes the afterparty question and the "We will serve food and drinks during the conference" opener for **every tenant, including Cloud Native Bergen and Cloud Native Days Norway — both of which really do serve food and really do host an afterparty.** Those live sites lose two TRUE answers the moment this merges, and get them back only when #831 lands the fields. The trade is deliberate: a platform that asserts catering and a 6 PM afterparty for tenants who configured neither is worse than two conferences having to re-enter facts they can actually vouch for. If that cost is unacceptable before the demo, #831 is small and can go first.
3. **`formatDate('') → 'TBD'` left alone.** ~30 call sites, several of which want a placeholder in a table cell. The guard is local to the prose that reads badly, which is safer than changing a shared helper.

## Tests

New `__tests__/app/day-one/fresh-tenant-public-pages.test.tsx` builds the conference with the **real** `buildOnboardingDocuments`, pushes it through the real `getConferenceForDomain` boundary and walks `/speaker` and `/info` end to end, with a premise guard asserting provisioning really does omit tagline/dates/venue/schedule — so provisioning drift fails loudly. Hero coverage lives beside the existing suite, per variant, on the same real document.

Sabotage-proven (guard removed → named tests fail → restored → green):

| guard removed | failing tests |
|---|---|
| hero title fallback | 5 |
| hero `sr-only` gate (classic) | 3 |
| `/speaker` empty-state branch | 2 |
| `/info` date gating | 1 |
| `/info` doors-open gating | 1 |
| `/info` afterparty removal | 1 |
| `/info` catering assertion restored | 1 |
| `/info` accessibility gating | 1 |
| `/info` `hasRealTimes` gate (empty schedule day) | 3 |
| `/speaker` singular/plural | 1 |

## Numbers

| check | baseline (`origin/main`) | this branch |
|---|---|---|
| `pnpm test` | 493 files / 7053 tests passed | **494 files / 7080 tests passed** |
| `pnpm typecheck` | clean | clean |
| `npx prettier --check .` | clean | clean |
| `npx eslint .` | 209 problems (0 errors, 209 warnings) | 209 problems (0 errors, 209 warnings) |

Visual inspection per AGENTS.md: `pnpm shoot` at 393×852 for `Components/Layout/Hero → Day one (no tagline)` (title sets on two lines, unclipped), `Systems/Speakers/SpeakersNotAnnouncedNotice → FreshTenant`, and `Systems/Info/InfoContent → FreshTenant` / `ConfiguredConference`. No viewport overflow reported.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves freshly provisioned tenants’ public pages by falling back to the conference title in the hero, introducing a legitimate empty-speaker presentation, and conditionally generating FAQ answers from configured conference data.
- Adds title-aware headline resolution across all hero variants.
- Replaces the zero-speaker grid with a contact and CFP-aware notice.
- Gates date, venue, accessibility, and schedule FAQ entries while removing unsupported catering and afterparty claims.
- Adds day-one integration coverage and Storybook states for fresh and configured tenants.

<h3>Confidence Score: 4/5</h3>

The speaker-query error state and empty-schedule fallback times should be corrected before merging because both can show visitors factually incorrect public information.

A transient speaker fetch failure is rendered as a legitimate “not announced” state, while an existing but untimed schedule day still publishes synthetic registration and talk times.

**Files Needing Attention:** src/app/(main)/speaker/page.tsx; src/lib/conference/info-faq.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/Hero.tsx | Adds shared headline precedence and correctly avoids duplicate title presentation when the title is the fallback. |
| src/app/(main)/speaker/page.tsx | Adds the intended empty-speaker state but conflates speaker-query errors with a successful empty result. |
| src/components/speaker/SpeakersNotAnnouncedNotice.tsx | Introduces a focused empty-state notice with optional contact and CFP links. |
| src/lib/conference/info-faq.ts | Removes unsupported FAQ claims and gates answers, but empty schedule shells still activate invented fallback times. |
| __tests__/app/day-one/fresh-tenant-public-pages.test.tsx | Provides strong provisioning-based day-one coverage but does not exercise query failures or empty persisted schedule days. |
| src/components/Hero.test.tsx | Covers title fallback, duplicate announcements, class behavior, whitespace taglines, and override precedence. |
| src/components/info/InfoContent.stories.tsx | Adds useful fresh and configured visual states for the generated FAQ. |
| src/components/speaker/SpeakersNotAnnouncedNotice.stories.tsx | Covers contact, open-CFP, and missing-contact presentation states. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Conference[Conference document] --> Hero{Tagline or override?}
  Hero -->|Yes| CustomHeadline[Render configured headline]
  Hero -->|No| TitleHeadline[Render conference title]
  Conference --> SpeakerPage[Speaker page]
  SpeakerData[Speaker query] --> SpeakerPage
  SpeakerPage -->|Speakers exist| SpeakerGrid[Render speaker grid]
  SpeakerPage -->|No speakers| EmptyNotice[Render announcement notice]
  Conference --> FAQ[Build info FAQ]
  Schedule[Schedule data] --> FAQ
  FAQ --> GatedAnswers[Render only answers with supporting data]
```

<sub>Reviews (1): Last reviewed commit: ["fix(public): stop a brand-new tenant&#39;s p..."](https://github.com/cloudnativebergen/website/commit/dcd85b63285a0829769b2e306c62372ee29e7cf2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50487096)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Conference Core: Editions, Settings & AI Agent Config](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/conference-core.md)
- Knowledge Base — [Speaker and Sponsor Management](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/speaker-sponsor-management.md)
- Knowledge Base — [Platform Tenancy: Scoping, Domain Verification, and Provisioning](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/platform-tenancy.md)
</details>

<!-- /greptile_comment -->
