### PR TITLE
feat(onboarding): provision new conferences with starter session formats

### DIFF
--- a/__tests__/api/trpc/proposal.test.ts
+++ b/__tests__/api/trpc/proposal.test.ts
@@ -749,6 +749,128 @@ describe('proposal router', () => {
       expect(result.proposalStatus).toBe(Status.submitted)
     })
 
+    describe('strict content validation on draft \u2192 submitted', () => {
+      // `create` strict-parses the payload before letting a proposal reach
+      // `submitted`; `action` \u2014 the OTHER route to `submitted` \u2014 did not parse
+      // anything. Since `ProposalDraftSchema` is `.partial()`, the two-step path
+      // `create({ status: draft })` \u2192 `action(submit)` promoted content that
+      // `create({ status: submitted })` would have refused outright. The UI
+      // cannot reach it (`ProposalForm` saves via `update` first), a direct
+      // API/tRPC caller can.
+      function draft(overrides: Record<string, unknown> = {}) {
+        vi.mocked(isCfpOpen).mockReturnValue(true)
+        vi.mocked(hasSubmittableFormats).mockReturnValue(true)
+        vi.mocked(getProposalSanity).mockResolvedValue({
+          proposal: {
+            ...mockProposal,
+            status: Status.draft,
+            ...overrides,
+          } as any,
+          proposalError: null,
+        })
+        vi.mocked(getProposals).mockResolvedValue({
+          proposals: [],
+          proposalsError: null,
+        })
+        vi.mocked(updateProposalStatus).mockClear()
+      }
+
+      it('refuses a draft carrying no topics', async () => {
+        draft({ topics: [] })
+
+        const caller = createAuthenticatedCaller(regularSpeaker._id)
+        await expect(
+          caller.proposal.action({ id: 'proposal-1', action: Action.submit }),
+        ).rejects.toMatchObject({
+          code: 'BAD_REQUEST',
+          message: expect.stringContaining('At least one topic is required'),
+        })
+        expect(updateProposalStatus).not.toHaveBeenCalled()
+      })
+
+      it('refuses a draft with the terms unaccepted', async () => {
+        draft({ tos: false })
+
+        const caller = createAuthenticatedCaller(regularSpeaker._id)
+        await expect(
+          caller.proposal.action({ id: 'proposal-1', action: Action.submit }),
+        ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+        expect(updateProposalStatus).not.toHaveBeenCalled()
+      })
+
+      it('refuses a draft with an empty description', async () => {
+        draft({ description: [] })
+
+        const caller = createAuthenticatedCaller(regularSpeaker._id)
+        await expect(
+          caller.proposal.action({ id: 'proposal-1', action: Action.submit }),
+        ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+      })
+
+      it('gives ORGANIZERS no carve-out either', async () => {
+        // Same reasoning as the format gate: an invalid submitted proposal is
+        // wrong whoever promotes it. (Unlike the 3-proposal cap, which is a
+        // per-speaker fairness rule organizers may override.)
+        draft({ topics: [] })
+
+        const caller = createAdminCaller()
+        await expect(
+          caller.proposal.action({ id: 'proposal-1', action: Action.submit }),
+        ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+      })
+
+      it('accepts DEREFERENCED topics \u2014 the shape the projection returns', async () => {
+        // REGRESSION GUARD. `getProposal` projects `topics[]-> { _id, title }`,
+        // not `{ _type: 'reference', _ref }`. Parsing the stored document
+        // naively against `ProposalInputSchema` would reject every legitimate
+        // submission on the topic field, so the gate folds them back first.
+        draft({
+          topics: [
+            { _id: 'topic-1', title: 'Platform engineering', color: '#fff' },
+          ],
+        })
+        vi.mocked(updateProposalStatus).mockResolvedValue({
+          proposal: { ...mockProposal, status: Status.submitted } as any,
+          err: null,
+        })
+
+        const caller = createAuthenticatedCaller(regularSpeaker._id)
+        const result = await caller.proposal.action({
+          id: 'proposal-1',
+          action: Action.submit,
+        })
+        expect(result.proposalStatus).toBe(Status.submitted)
+      })
+
+      it('does NOT validate content on other transitions', async () => {
+        // Withdrawing or unsubmitting an already-imperfect proposal must stay
+        // possible \u2014 the gate is scoped to the draft \u2192 submitted promotion.
+        vi.mocked(isCfpOpen).mockReturnValue(true)
+        vi.mocked(isWithdrawalCutoffActive).mockReturnValue(false)
+        vi.mocked(getProposalSanity).mockResolvedValue({
+          proposal: {
+            ...mockProposal,
+            status: Status.submitted,
+            topics: [],
+            tos: false,
+          } as any,
+          proposalError: null,
+        })
+        vi.mocked(updateProposalStatus).mockResolvedValue({
+          proposal: { ...mockProposal, status: Status.withdrawn } as any,
+          err: null,
+        })
+
+        const caller = createAuthenticatedCaller(regularSpeaker._id)
+        const result = await caller.proposal.action({
+          id: 'proposal-1',
+          action: Action.withdraw,
+          reason: 'Schedule clash',
+        })
+        expect(result.proposalStatus).toBe(Status.withdrawn)
+      })
+    })
+
     it('should enforce proposal cap when submitting a draft', async () => {
       vi.mocked(isCfpOpen).mockReturnValue(true)
       const draftProposal = { ...mockProposal, status: Status.draft }

--- a/__tests__/app/cfp/fresh-tenant-submit.test.tsx
+++ b/__tests__/app/cfp/fresh-tenant-submit.test.tsx
@@ -1,0 +1,323 @@
+/**
+ * @vitest-environment node
+ *
+ * THE POINT OF THE STARTER FORMATS, proven end to end: a conference document
+ * built by the REAL `buildOnboardingDocuments` takes a proposal from the submit
+ * page to `submitted` with NO format configuration by the organizer at all.
+ *
+ * Deliberately does NOT mock `@/lib/conference/state`: `__tests__/api/trpc/
+ * proposal.test.ts` mocks `hasSubmittableFormats` so it can exercise the gate's
+ * two branches in isolation, which means it can never tell you whether a REAL
+ * provisioned conference passes it. This file runs the real predicates on the
+ * real document — the only arrangement that can catch provisioning and the
+ * gates drifting apart.
+ *
+ * WHAT THE ORGANIZER STILL SUPPLIES, and why it is not seeded:
+ *   - the CFP window (`isCfpOpen` is a separate, purely date-based gate);
+ *   - at least one TOPIC — strict submit validation requires one
+ *     (`ProposalInputSchema.topics.min(1)`) and a topic list is far more
+ *     conference-specific than a session length, so provisioning leaves it.
+ * Both are activation-checklist rows. Everything else is ready.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactElement } from 'react'
+
+vi.mock('next/server', () => ({ connection: vi.fn(async () => {}) }))
+vi.mock('next/headers', () => ({
+  headers: vi.fn(async () => new Headers({ 'x-url': 'https://conf/cfp' })),
+}))
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(() => {
+    throw new Error('unexpected redirect')
+  }),
+  // The submit form is a client component; server-rendering it still runs
+  // `useRouter()` on the way to markup.
+  useRouter: vi.fn(() => ({ push: vi.fn(), refresh: vi.fn() })),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+  usePathname: vi.fn(() => '/cfp/proposal'),
+}))
+vi.mock('@/lib/auth', () => ({
+  getAuthSession: vi.fn(async () => ({
+    speaker: { _id: 'speaker-1', email: 'ada@example.com' },
+  })),
+}))
+vi.mock('@/lib/events/registry', () => ({}))
+vi.mock('@/lib/events/bus', () => ({
+  eventBus: { publish: vi.fn().mockResolvedValue(undefined) },
+}))
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: {
+    fetch: vi.fn(),
+    create: vi.fn(),
+    getDocument: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+  clientReadUncached: {
+    // The reference-injection probe counts client-supplied topic refs as ours;
+    // the cross-tenant refusals live in `src/server/routers/tenancy.writes.test.ts`.
+    fetch: vi.fn(
+      async (_query: string, params: Record<string, unknown> = {}) =>
+        ((params.ids as string[] | undefined) ?? []).length,
+    ),
+  },
+}))
+
+const getConferenceMock = vi.fn()
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    getConferenceMock(...args),
+}))
+
+const getSpeakerMock = vi.fn()
+vi.mock('@/lib/speaker/sanity', () => ({
+  getSpeaker: (...args: unknown[]) => getSpeakerMock(...args),
+}))
+
+vi.mock('@/lib/proposal/data/sanity', () => {
+  class ProposalDeletionBlockedError extends Error {}
+  return {
+    getProposal: vi.fn(),
+    getProposals: vi.fn(),
+    createProposal: vi.fn(),
+    updateProposal: vi.fn(),
+    deleteProposal: vi.fn(),
+    updateProposalStatus: vi.fn(),
+    ProposalDeletionBlockedError,
+  }
+})
+
+vi.mock('@/lib/proposal/server', () => ({
+  updateProposalStatus: vi.fn(),
+  getProposalSanity: vi.fn(),
+}))
+
+vi.mock('@/lib/messaging/sanity', () => ({
+  ensureProposalConversation: vi.fn(),
+  addMessage: vi.fn(),
+}))
+vi.mock('@/lib/messaging/notify', () => ({ notifyNewMessage: vi.fn() }))
+
+import { buildOnboardingDocuments } from '@/lib/onboarding/create'
+import { normalizeConference } from '@/lib/conference/normalize'
+import type { Conference } from '@/lib/conference/types'
+import {
+  createAuthenticatedCaller,
+  speakers,
+  TEST_ORG_ID,
+} from '../../helpers/trpc'
+import { createProposal, getProposals } from '@/lib/proposal/data/sanity'
+import { getProposalSanity, updateProposalStatus } from '@/lib/proposal/server'
+import {
+  Status,
+  Action,
+  Language,
+  Format,
+  Level,
+  Audience,
+} from '@/lib/proposal/types'
+import NewProposalPage from '@/app/(cfp)/cfp/proposal/page'
+
+const regularSpeaker = speakers.find((s) => !s.isOrganizer)!
+
+/** An open window around the frozen clock set in each test. */
+const OPEN_CFP = { cfpStartDate: '2026-01-01', cfpEndDate: '2026-12-01' }
+
+/** The organizer's own topics — provisioning seeds none, on purpose. */
+const ORGANIZER_TOPICS = [
+  { _id: 'topic-1', title: 'Platform engineering', _type: 'topic' },
+]
+
+/**
+ * The conference a concierge provisioning run really writes, through the real
+ * boundary normaliser, with only its CFP dates filled in afterwards. The org id
+ * is the test org so the tRPC authz waist resolves the request's tenant.
+ */
+function freshTenantConference(): Conference {
+  let key = 0
+  const { conference } = buildOnboardingDocuments(
+    {
+      organization: {
+        name: 'Brand New Events',
+        slug: 'brand-new-events',
+        contactEmail: 'hello@brand-new.example',
+      },
+      conference: {
+        title: 'Brand New Conf',
+        city: 'Bergen',
+        country: 'Norway',
+      },
+      organizer: { name: 'Ada Organizer', email: 'ada@brand-new.example' },
+      domains: ['brand-new.konf.run'],
+    },
+    {
+      organizationId: TEST_ORG_ID,
+      conferenceId: 'conf-fresh',
+      speakerId: 'speaker-fresh',
+      mintKey: () => `key-${++key}`,
+    },
+    null,
+  )
+  return normalizeConference({
+    ...conference,
+    ...OPEN_CFP,
+    topics: ORGANIZER_TOPICS,
+  } as unknown as Conference)
+}
+
+async function submitPageTree(): Promise<ReactElement> {
+  return (await NewProposalPage({
+    searchParams: Promise.resolve({}),
+  })) as ReactElement
+}
+
+/** Static markup of the page. Only safe when the page short-circuits to an
+ * error notice — the real form is a client component with tRPC hooks. */
+async function renderSubmitPage(): Promise<string> {
+  return renderToStaticMarkup(await submitPageTree())
+}
+
+/**
+ * The `ProposalForm` element the page decided to render, or null. Found by its
+ * `allowedFormats` prop rather than by rendering: the form is a client
+ * component whose hooks (`useRouter`, tRPC's `useQuery`) need providers this
+ * server-side test has no business standing up. The prop IS the decision under
+ * test — it is what scopes the format picker.
+ */
+function findProposalForm(node: unknown): { allowedFormats?: unknown } | null {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findProposalForm(child)
+      if (found) return found
+    }
+    return null
+  }
+  if (!node || typeof node !== 'object') return null
+  const element = node as { props?: Record<string, unknown> }
+  if (!element.props) return null
+  if ('allowedFormats' in element.props) {
+    return element.props as { allowedFormats?: unknown }
+  }
+  return findProposalForm(element.props.children)
+}
+
+const proposalOnAStarterFormat = {
+  title: 'Shipping on day one',
+  description: [
+    { _type: 'block', children: [{ _type: 'span', text: 'A description' }] },
+  ],
+  language: Language.english,
+  // One of the three formats provisioning seeded — nothing else is on offer.
+  format: Format.presentation_25,
+  level: Level.intermediate,
+  audiences: [Audience.developer],
+  // The organizer's topic — required by strict validation, never seeded.
+  topics: [{ _type: 'reference' as const, _ref: 'topic-1' }],
+  tos: true,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-06-01T12:00:00Z'))
+  getConferenceMock.mockResolvedValue({
+    conference: freshTenantConference(),
+    domain: 'brand-new.konf.run',
+    error: null,
+  })
+  getSpeakerMock.mockResolvedValue({
+    speaker: {
+      _id: regularSpeaker._id,
+      name: 'Ada',
+      email: 'ada@example.com',
+    },
+    err: null,
+  })
+  vi.mocked(getProposals).mockResolvedValue({
+    proposals: [],
+    proposalsError: null,
+  })
+})
+
+describe('the submit page on a freshly provisioned tenant', () => {
+  it('is still held back until the organizer picks topics', async () => {
+    // The pre-topics state, from the SAME real builder: the format half is
+    // done, the topic half is not, so the page apologises rather than render a
+    // form whose required topic field has nothing to choose.
+    const withoutTopics = freshTenantConference()
+    ;(withoutTopics as unknown as { topics: unknown[] }).topics = []
+    getConferenceMock.mockResolvedValue({
+      conference: withoutTopics,
+      domain: 'brand-new.konf.run',
+      error: null,
+    })
+
+    const html = await renderSubmitPage()
+
+    expect(html).toContain('Submissions Not Open Yet')
+    expect(findProposalForm(await submitPageTree())).toBeNull()
+  })
+
+  it('renders the form instead of a "not open yet" apology', async () => {
+    const tree = await submitPageTree()
+
+    expect(findProposalForm(tree)).not.toBeNull()
+  })
+
+  it('scopes the format picker to exactly the starter formats', async () => {
+    const form = findProposalForm(await submitPageTree())
+
+    // Not the whole vocabulary — the picker offers what this conference
+    // configured, and provisioning does not sign a new tenant up for workshops.
+    expect(form?.allowedFormats).toEqual([
+      'lightning_10',
+      'presentation_25',
+      'presentation_45',
+    ])
+  })
+})
+
+describe('submitting on a freshly provisioned tenant', () => {
+  it('accepts a proposal through proposal.create', async () => {
+    vi.mocked(createProposal).mockResolvedValue({
+      proposal: { _id: 'proposal-1', status: Status.submitted } as never,
+      err: null,
+    })
+
+    const caller = createAuthenticatedCaller(regularSpeaker._id)
+    const result = await caller.proposal.create({
+      data: proposalOnAStarterFormat,
+      status: Status.submitted,
+    })
+
+    expect(result.status).toBe(Status.submitted)
+    expect(createProposal).toHaveBeenCalled()
+  })
+
+  it('accepts the draft → submitted transition through proposal.action', async () => {
+    // The OTHER submit route, carrying the same gate.
+    vi.mocked(getProposalSanity).mockResolvedValue({
+      proposal: {
+        _id: 'proposal-1',
+        status: Status.draft,
+        speakers: [{ _id: regularSpeaker._id }],
+        conference: { _id: 'conf-fresh' },
+        ...proposalOnAStarterFormat,
+      } as never,
+      proposalError: null,
+    })
+    vi.mocked(updateProposalStatus).mockResolvedValue({
+      proposal: { _id: 'proposal-1', status: Status.submitted } as never,
+      err: null,
+    })
+
+    const caller = createAuthenticatedCaller(regularSpeaker._id)
+    const result = await caller.proposal.action({
+      id: 'proposal-1',
+      action: Action.submit,
+    })
+
+    expect(result.proposalStatus).toBe(Status.submitted)
+  })
+})

--- a/__tests__/app/cfp/fresh-tenant-submit.test.tsx
+++ b/__tests__/app/cfp/fresh-tenant-submit.test.tsx
@@ -320,4 +320,30 @@ describe('submitting on a freshly provisioned tenant', () => {
 
     expect(result.proposalStatus).toBe(Status.submitted)
   })
+
+  it('does NOT let the two-step path smuggle a topic-less proposal through', async () => {
+    // THE QA PROBE, encoded. Seeding formats removes the accidental shield the
+    // formats gate gave fresh tenants, exposing that `action` ran no content
+    // validation at all: `create({ status: draft })` accepts anything, and this
+    // promoted it. A topics-less fresh tenant is exactly where it showed up.
+    vi.mocked(getProposalSanity).mockResolvedValue({
+      proposal: {
+        _id: 'proposal-1',
+        status: Status.draft,
+        speakers: [{ _id: regularSpeaker._id }],
+        conference: { _id: 'conf-fresh' },
+        ...proposalOnAStarterFormat,
+        topics: [],
+        tos: false,
+      } as never,
+      proposalError: null,
+    })
+    vi.mocked(updateProposalStatus).mockClear()
+
+    const caller = createAuthenticatedCaller(regularSpeaker._id)
+    await expect(
+      caller.proposal.action({ id: 'proposal-1', action: Action.submit }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    expect(updateProposalStatus).not.toHaveBeenCalled()
+  })
 })

--- a/__tests__/app/cfp/fresh-tenant.test.tsx
+++ b/__tests__/app/cfp/fresh-tenant.test.tsx
@@ -1,17 +1,19 @@
 /**
  * @vitest-environment node
  *
- * THE DAY-ONE SCENARIO. `@/lib/onboarding/create.ts` provisions a brand-new
- * tenant with NO `formats` and NO `topics` on the reasoning that "the admin
- * surfaces are empty-safe". The PUBLIC surfaces were not: the conference
- * projection is a bare `...` spread, so both fields come back `undefined`, and
- * `/cfp` did `conference.formats.filter(...)` unguarded. With no `error.tsx`
- * anywhere under `src/app`, that is a bare 500 on the first CFP link a new
- * organizer shares with speakers.
+ * THE DAY-ONE SCENARIO. `@/lib/onboarding/create.ts` now provisions every new
+ * tenant WITH a starter set of session formats, so the CFP a brand-new organizer
+ * shares actually accepts proposals instead of waiting on them to find a
+ * checklist row. This suite is the guard on that: it builds the conference
+ * document EXACTLY the way provisioning builds it — no fixture that "looks
+ * fresh", the real `buildOnboardingDocuments` — pushes it through the real
+ * `getConferenceForDomain` boundary, and walks the public CFP page.
  *
- * This suite builds the conference document EXACTLY the way provisioning builds
- * it — no fixture that "looks fresh", the real builder — pushes it through the
- * real `getConferenceForDomain` boundary, and walks the public CFP page.
+ * It ALSO keeps the crash-safety half of #824 alive: the boundary normalisation
+ * and the empty-formats copy still have to work, because an organizer can empty
+ * the list from admin at any time and every conference created before this
+ * change still has none. Those cases now strip the field explicitly rather than
+ * relying on provisioning to produce it.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderToStaticMarkup } from 'react-dom/server'
@@ -45,15 +47,24 @@ vi.mock('@/lib/sponsor-crm/sanity', () => ({
 
 import { buildOnboardingDocuments } from '@/lib/onboarding/create'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
+import type { Conference } from '@/lib/conference/types'
+import {
+  canAcceptProposals,
+  hasSubmittableFormats,
+} from '@/lib/conference/state'
 import CFPPage from '@/app/(main)/cfp/page'
 
 const FRESH_HOST = 'brand-new.konf.run'
 
+/** What an organizer picks for themselves — provisioning seeds no topics. */
+const ORGANIZER_TOPICS = [
+  { _id: 'topic-1', title: 'Platform engineering', _type: 'topic' },
+]
+
 /**
- * The conference document a concierge provisioning run actually writes. Built
- * by the real `buildOnboardingDocuments` so this fixture can never drift away
- * from what production creates — if provisioning starts seeding formats, this
- * test stops being about an empty tenant and should be updated deliberately.
+ * The conference document a concierge provisioning run actually writes. Built by
+ * the real `buildOnboardingDocuments` so this fixture can never drift away from
+ * what production creates.
  */
 function provisionedConferenceDocument(domains: string[] = [FRESH_HOST]) {
   let key = 0
@@ -83,6 +94,14 @@ function provisionedConferenceDocument(domains: string[] = [FRESH_HOST]) {
   return conference
 }
 
+/** The same document with its formats taken away: a pre-existing tenant, or one
+ * whose organizer emptied the list. */
+function conferenceWithoutFormats(domains: string[] = [FRESH_HOST]) {
+  const doc = provisionedConferenceDocument(domains)
+  delete doc.formats
+  return doc
+}
+
 /**
  * `/cfp` is a server component wrapping ONE async child (`CachedCFPContent`).
  * Awaiting the page yields that child's element; awaiting the child gives a
@@ -104,45 +123,27 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
-describe('a freshly provisioned tenant (no formats, no topics)', () => {
-  it('provisioning really does omit formats and topics', () => {
-    // Guards the premise: if this ever fails, the rest of the suite is
-    // testing a scenario that no longer exists.
+describe('a freshly provisioned tenant', () => {
+  it('is provisioned WITH the starter formats and WITHOUT topics', () => {
+    // Guards the premise of everything below.
     const doc = provisionedConferenceDocument()
-    expect(doc.formats).toBeUndefined()
+    expect(doc.formats).toEqual([
+      'lightning_10',
+      'presentation_25',
+      'presentation_45',
+    ])
     expect(doc.topics).toBeUndefined()
   })
 
-  it('provisioning omits domains too when the operator supplies none', () => {
-    // `create.ts` writes `domains` conditionally, so an operator-created tenant
-    // with no domain yet produces a document missing a THIRD non-optional array
-    // field — the same crash class, one field over.
-    expect(provisionedConferenceDocument([]).domains).toBeUndefined()
-  })
-
-  it('the boundary normalises a document with no domains end to end', async () => {
-    conferenceFetchMock.mockResolvedValue(provisionedConferenceDocument([]))
+  it('passes the submittable-formats gate straight out of provisioning', async () => {
+    // The REAL predicate, on the REAL document, through the REAL boundary —
+    // this is the fact both submit routes key off (`proposal.create`,
+    // `proposal.action`). Before starter formats it was false on day one.
+    conferenceFetchMock.mockResolvedValue(provisionedConferenceDocument())
 
     const { conference } = await getConferenceForDomain(FRESH_HOST)
 
-    expect(conference.domains).toEqual([])
-    expect(conference.formats).toEqual([])
-  })
-
-  it('the conference boundary hands out arrays, not undefined', async () => {
-    conferenceFetchMock.mockResolvedValue(provisionedConferenceDocument())
-
-    const { conference } = await getConferenceForDomain(FRESH_HOST, {
-      topics: true,
-    })
-
-    expect(Array.isArray(conference.formats)).toBe(true)
-    expect(conference.formats).toHaveLength(0)
-    expect(Array.isArray(conference.topics)).toBe(true)
-    expect(conference.topics).toHaveLength(0)
-    // `domains` is also optional at provisioning time (an operator may create a
-    // tenant with none) and is typed non-optional — same crash class.
-    expect(Array.isArray(conference.domains)).toBe(true)
+    expect(hasSubmittableFormats(conference)).toBe(true)
   })
 
   it('renders the public CFP page WITHOUT throwing', async () => {
@@ -154,8 +155,114 @@ describe('a freshly provisioned tenant (no formats, no topics)', () => {
     expect(html).toContain('Brand New Conf')
   })
 
-  it('does not invite a submission it cannot accept', async () => {
+  it('STILL cannot accept a proposal — starter formats are not the whole job', () => {
+    // The day-one truth, stated once so nobody reads the starter formats as
+    // "the CFP works now". Strict submit validation also requires at least one
+    // TOPIC, and provisioning deliberately seeds none (topics are far more
+    // conference-specific than session lengths). One of the two day-one
+    // blockers is gone; the other is the organizer's to clear.
+    const conference = provisionedConferenceDocument() as unknown as Conference
+    expect(hasSubmittableFormats(conference)).toBe(true)
+    expect(canAcceptProposals(conference)).toBe(false)
+  })
+
+  it('does not invite a submission it cannot complete', async () => {
     conferenceFetchMock.mockResolvedValue(provisionedConferenceDocument())
+
+    const html = await renderCfpPage()
+
+    expect(html).not.toContain('Submit your proposal')
+    expect(html).not.toContain('href="/cfp/proposal"')
+    expect(html).toContain('Submissions are not open yet')
+  })
+
+  it('invites submissions as soon as the organizer adds topics', async () => {
+    // NOTHING else needed: no format work, no other configuration. This is what
+    // the starter formats buy — one step instead of two.
+    conferenceFetchMock.mockResolvedValue({
+      ...provisionedConferenceDocument(),
+      topics: ORGANIZER_TOPICS,
+    })
+
+    const html = await renderCfpPage()
+
+    expect(html).toContain('Submit your proposal')
+    expect(html).toContain('href="/cfp/proposal"')
+    expect(html).not.toContain('Submissions are not open yet')
+  })
+
+  it('advertises the starter formats by their human titles', async () => {
+    conferenceFetchMock.mockResolvedValue(provisionedConferenceDocument())
+
+    const html = await renderCfpPage()
+
+    expect(html).toContain('Presentation formats')
+    expect(html).toContain('Lightning Talk (10 min)')
+    expect(html).toContain('Presentation (25 min)')
+    expect(html).toContain('Presentation (45 min)')
+  })
+
+  it('does not promise workshops nobody has planned', async () => {
+    // The starter set is talks only, so the page must not raise the
+    // "Hands-on Workshops" section or its heading over an empty list.
+    conferenceFetchMock.mockResolvedValue(provisionedConferenceDocument())
+
+    const html = await renderCfpPage()
+
+    expect(html).not.toContain('Workshop formats')
+    expect(html).not.toContain('Hands-on Workshops')
+  })
+
+  it('still shows placeholder topics rather than crashing on an absent list', async () => {
+    conferenceFetchMock.mockResolvedValue(provisionedConferenceDocument())
+
+    const html = await renderCfpPage()
+
+    expect(html).toContain('Engineering practice')
+  })
+
+  it('provisioning omits domains when the operator supplies none', () => {
+    // `create.ts` writes `domains` conditionally, so an operator-created tenant
+    // with no domain yet produces a document missing a non-optional array
+    // field — the #824 crash class, one field over.
+    expect(provisionedConferenceDocument([]).domains).toBeUndefined()
+  })
+
+  it('the boundary normalises a document with no domains end to end', async () => {
+    conferenceFetchMock.mockResolvedValue(provisionedConferenceDocument([]))
+
+    const { conference } = await getConferenceForDomain(FRESH_HOST)
+
+    expect(conference.domains).toEqual([])
+    expect(conference.formats).toHaveLength(3)
+  })
+})
+
+describe('a conference with no formats (pre-existing, or emptied by its organizer)', () => {
+  it('the conference boundary hands out arrays, not undefined', async () => {
+    conferenceFetchMock.mockResolvedValue(conferenceWithoutFormats())
+
+    const { conference } = await getConferenceForDomain(FRESH_HOST, {
+      topics: true,
+    })
+
+    expect(Array.isArray(conference.formats)).toBe(true)
+    expect(conference.formats).toHaveLength(0)
+    expect(Array.isArray(conference.topics)).toBe(true)
+    expect(conference.topics).toHaveLength(0)
+    expect(Array.isArray(conference.domains)).toBe(true)
+  })
+
+  it('renders the public CFP page WITHOUT throwing', async () => {
+    conferenceFetchMock.mockResolvedValue(conferenceWithoutFormats())
+
+    const html = await renderCfpPage()
+
+    expect(html).toContain('Call for Presentations')
+  })
+
+  it('does not invite a submission it cannot accept', async () => {
+    conferenceFetchMock.mockResolvedValue(conferenceWithoutFormats())
 
     const html = await renderCfpPage()
 
@@ -171,29 +278,19 @@ describe('a freshly provisioned tenant (no formats, no topics)', () => {
     expect(html).not.toContain('Presentation formats')
     expect(html).not.toContain('Workshop formats')
   })
-
-  it('still shows placeholder topics rather than crashing on an absent list', async () => {
-    conferenceFetchMock.mockResolvedValue(provisionedConferenceDocument())
-
-    const html = await renderCfpPage()
-
-    expect(html).toContain('Engineering practice')
-  })
 })
 
-describe('a configured tenant keeps the submit CTA', () => {
-  it('advertises formats and links to the proposal form', async () => {
+describe('a tenant that has added workshops', () => {
+  it('advertises them in their own section', async () => {
     conferenceFetchMock.mockResolvedValue({
       ...provisionedConferenceDocument(),
-      cfpStartDate: '2026-01-01',
-      cfpEndDate: '2026-12-01',
       formats: ['lightning_10', 'presentation_25', 'workshop_120'],
+      topics: ORGANIZER_TOPICS,
     })
 
     const html = await renderCfpPage()
 
     expect(html).toContain('Submit your proposal')
-    expect(html).toContain('href="/cfp/proposal"')
     expect(html).toContain('Presentation formats')
     expect(html).toContain('Workshop formats')
     expect(html).not.toContain('Submissions are not open yet')

--- a/__tests__/app/cfp/proposal-page-gate.test.tsx
+++ b/__tests__/app/cfp/proposal-page-gate.test.tsx
@@ -2,11 +2,14 @@
  * @vitest-environment node
  *
  * The SUBMIT page's honesty gate. A conference whose CFP window is open but
- * which has configured NO session formats cannot accept a proposal — a proposal
- * must carry a format (`validateProposalForm`) and the form only offers the
- * formats the conference configured. Provisioning creates every new tenant in
- * exactly that state (`@/lib/onboarding/create.ts`), so a speaker following the
- * CFP link must be told that, not handed a form with an empty dropdown.
+ * which is missing a piece a proposal cannot be submitted without cannot accept
+ * one: strict validation requires BOTH a format and a topic
+ * (`validateProposalForm`), and each picker is populated purely from the
+ * conference's own list. A speaker following the CFP link must be told that,
+ * not handed a form with an empty dropdown over a required field.
+ *
+ * A freshly provisioned tenant has the starter formats but no topics
+ * (`@/lib/onboarding/create.ts`), so it lands in the second case.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderToStaticMarkup } from 'react-dom/server'
@@ -77,7 +80,7 @@ beforeEach(() => {
   getProposalsMock.mockResolvedValue({ proposals: [], proposalsError: null })
 })
 
-describe('the CFP submit page with no configured formats', () => {
+describe('the CFP submit page with an incomplete configuration', () => {
   it('explains that submissions are not open yet instead of rendering the form', async () => {
     getConferenceMock.mockResolvedValue({
       conference: conference(),
@@ -87,10 +90,40 @@ describe('the CFP submit page with no configured formats', () => {
     const html = await renderPage()
 
     expect(html).toContain('Submissions Not Open Yet')
-    expect(html).toContain('session formats have not been announced')
+    expect(html).toContain('still setting up the Call for Papers')
     expect(html).toContain('hello@brand-new.example')
     // Not the pre-existing closed-window message — the window IS open.
     expect(html).not.toContain('The Call for Papers is currently closed')
+  })
+
+  it('refuses a freshly provisioned tenant: formats yes, topics no', async () => {
+    // The remaining day-one blocker. Starter formats fill the format picker,
+    // but the topic picker would still be empty over a required field.
+    getConferenceMock.mockResolvedValue({
+      conference: conference({
+        formats: ['lightning_10', 'presentation_25', 'presentation_45'],
+        topics: [],
+      }),
+      error: null,
+    })
+
+    const html = await renderPage()
+
+    expect(html).toContain('Submissions Not Open Yet')
+  })
+
+  it('refuses topics-but-no-formats too', async () => {
+    getConferenceMock.mockResolvedValue({
+      conference: conference({
+        formats: [],
+        topics: [{ _id: 'topic-1', title: 'Platform engineering' }],
+      }),
+      error: null,
+    })
+
+    const html = await renderPage()
+
+    expect(html).toContain('Submissions Not Open Yet')
   })
 
   it('still reports a genuinely closed CFP as closed', async () => {

--- a/src/app/(cfp)/cfp/proposal/page.tsx
+++ b/src/app/(cfp)/cfp/proposal/page.tsx
@@ -67,7 +67,7 @@ export default async function NewProposalPage({
   }
 
   if (conference) {
-    const { isCfpOpen, hasSubmittableFormats } =
+    const { isCfpOpen, canAcceptProposals } =
       await import('@/lib/conference/state')
     const contactEmail = conference.cfpEmail || conference.contactEmail
     if (!isCfpOpen(conference)) {
@@ -77,16 +77,17 @@ export default async function NewProposalPage({
           ? `The Call for Papers is currently closed. We'd love to have you speak at our next conference! Please check back when the next CFP opens, or reach out to ${contactEmail} if you have any questions.`
           : 'The Call for Papers is currently closed. We&apos;d love to have you speak at our next conference! Please check back when the next CFP opens, or contact the organizers if you have any questions.',
       }
-    } else if (!hasSubmittableFormats(conference)) {
-      // The CFP window is open but the organizers have not configured a single
-      // session format — and a proposal cannot be submitted without one
-      // (`validateProposalForm`). Say so, instead of rendering a form whose
-      // Format dropdown has no options.
+    } else if (!canAcceptProposals(conference)) {
+      // The CFP window is open but the conference is missing a piece a proposal
+      // cannot be submitted without (`validateProposalForm`): a session format,
+      // or a topic to tag it with. Say so, instead of rendering a form with an
+      // empty dropdown over a required field. Safe to ask here: this page
+      // projects topics (`{ topics: true }` above).
       loadingError = {
         type: 'Submissions Not Open Yet',
         message: contactEmail
-          ? `The organizers are still setting up the Call for Papers — the session formats have not been announced yet, so proposals cannot be submitted. Please check back soon, or reach out to ${contactEmail} if you have any questions.`
-          : 'The organizers are still setting up the Call for Papers — the session formats have not been announced yet, so proposals cannot be submitted. Please check back soon.',
+          ? `The organizers are still setting up the Call for Papers, so proposals cannot be submitted yet. Please check back soon, or reach out to ${contactEmail} if you have any questions.`
+          : 'The organizers are still setting up the Call for Papers, so proposals cannot be submitted yet. Please check back soon.',
       }
     }
   }

--- a/src/app/(main)/cfp/page.tsx
+++ b/src/app/(main)/cfp/page.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/Button'
 import { SubmissionsNotOpenNotice } from '@/components/cfp/SubmissionsNotOpenNotice'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
 import { isUnknownHost } from '@/lib/conference/guard'
-import { hasSubmittableFormats } from '@/lib/conference/state'
+import { canAcceptProposals } from '@/lib/conference/state'
 import { formatDate } from '@/lib/time'
 import { Topic } from '@/lib/topic/types'
 import { formats } from '@/lib/proposal/types'
@@ -61,12 +61,15 @@ async function CachedCFPContent({ domain }: { domain: string }) {
   const hasWorkshops =
     Array.isArray(workshopFormats) && workshopFormats.length > 0
 
-  // A CFP with NO configured formats cannot receive anything: a proposal must
-  // carry a format, and the submit form only offers what the conference
-  // configured. Every freshly provisioned tenant starts here
-  // (@/lib/onboarding/create.ts), so this page must not hand a speaker a
-  // "Submit your proposal" button that leads to an empty dropdown.
-  const acceptingSubmissions = hasSubmittableFormats(conference)
+  // A CFP missing either half of its configuration cannot receive anything: a
+  // proposal must carry a format AND at least one topic, and both pickers are
+  // populated purely from this conference's own lists. Provisioning seeds the
+  // formats but deliberately leaves topics to the organizer
+  // (@/lib/onboarding/create.ts), so a brand-new tenant still lands here — and
+  // this page must not hand a speaker a "Submit your proposal" button that
+  // leads to a form with a required field it cannot satisfy. Safe to ask here:
+  // this page projects topics (`{ topics: true }` above).
+  const acceptingSubmissions = canAcceptProposals(conference)
   const cfpContactEmail = conference.cfpEmail || conference.contactEmail
 
   // Fact rows are OMITTED rather than rendered empty: an unconfigured

--- a/src/components/admin/ActivationChecklist.stories.tsx
+++ b/src/components/admin/ActivationChecklist.stories.tsx
@@ -4,6 +4,7 @@ import {
   buildActivationChecklist,
   type ConferenceForActivation,
 } from '@/lib/settings/activation'
+import { STARTER_SESSION_FORMATS } from '@/lib/onboarding/create'
 import type { SystemCheck } from '@/lib/system-status/types'
 
 /**
@@ -39,10 +40,16 @@ const emailAndSlackOk: SystemCheck[] = [
   },
 ]
 
-/** A brand-new, unlisted trial conference — almost nothing configured. */
+/**
+ * A brand-new, unlisted conference EXACTLY as provisioning creates it — almost
+ * nothing configured, except the starter session formats
+ * (`@/lib/onboarding/create.ts`). That one row therefore starts ticked, with the
+ * advisory note that says whose choice it was.
+ */
 const FRESH: ConferenceForActivation = {
   title: 'My New Conference',
   organizer: 'Acme Events',
+  formats: [...STARTER_SESSION_FORMATS],
   visibility: 'unlisted',
 }
 

--- a/src/components/admin/ActivationChecklist.tsx
+++ b/src/components/admin/ActivationChecklist.tsx
@@ -124,11 +124,19 @@ function ActivationRowItem({ row }: { row: ActivationRow }) {
             </span>
             {row.optional && <StatusBadge label="Optional" color="gray" />}
           </span>
-          {!row.done && (
+          {/* An outstanding row shows what to do; a done row normally shows
+              nothing — except a `note`, the advisory for a requirement that is
+              satisfied by something the organizer did not choose (the seeded
+              starter formats), where a bare strike-through would overstate. */}
+          {!row.done ? (
             <span className="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
               {row.hint}
             </span>
-          )}
+          ) : row.note ? (
+            <span className="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
+              {row.note}
+            </span>
+          ) : null}
         </span>
         <span
           aria-hidden="true"

--- a/src/components/cfp/SubmissionsNotOpenNotice.tsx
+++ b/src/components/cfp/SubmissionsNotOpenNotice.tsx
@@ -2,12 +2,17 @@ import Link from 'next/link'
 
 /**
  * Shown on the public CFP page IN PLACE OF the "Submit your proposal" button
- * when the conference has not configured a single session format.
+ * when the conference is missing something a proposal cannot be submitted
+ * without — a session format, or a topic to tag it with (`canAcceptProposals`).
  *
- * A proposal must carry a format (`validateProposalForm`) and the submit form
- * only offers the formats the conference configured, so a CTA here would lead
- * a speaker to an empty dropdown. Every freshly provisioned tenant starts in
- * this state — see `@/lib/onboarding/create.ts`.
+ * Both pickers on the submit form are populated purely from the conference's
+ * own lists, so a CTA here would lead a speaker to an empty dropdown over a
+ * required field. Provisioning seeds starter formats but deliberately leaves
+ * topics to the organizer, so a freshly provisioned tenant lands here until
+ * they pick some — see `@/lib/onboarding/create.ts`.
+ *
+ * Copy names no particular field on purpose: a speaker cannot act on "topics
+ * are missing", and the organizer reads the activation checklist, not this.
  */
 export function SubmissionsNotOpenNotice({
   contactEmail,
@@ -24,8 +29,8 @@ export function SubmissionsNotOpenNotice({
         Submissions are not open yet
       </h2>
       <p className="font-inter mt-2 text-base text-amber-800 dark:text-amber-300">
-        The organizers are still putting the call for presentations together —
-        the session formats have not been announced. Please check back soon
+        The organizers are still putting the call for presentations together.
+        Please check back soon
         {contactEmail ? (
           <>
             , or reach out to{' '}

--- a/src/lib/conference/normalize.ts
+++ b/src/lib/conference/normalize.ts
@@ -5,13 +5,14 @@ import type { Conference } from './types'
  * that a real `conference` DOCUMENT is routinely missing.
  *
  * The main conference projection is a bare `...` spread, so an absent field
- * comes back as `undefined` rather than `[]` — and
- * `@/lib/onboarding/create.ts` deliberately provisions a brand-new tenant with
- * NO `formats`, NO `topics` and (when the operator supplies none) no
- * `domains`. The type says `Format[]`, the data says `undefined`, and the
- * first `.filter` / `.map` / `.includes` on a public page is a TypeError — a
- * bare 500 on the first CFP link a new organizer shares (there is no
- * `error.tsx` boundary in this app).
+ * comes back as `undefined` rather than `[]` — and `@/lib/onboarding/create.ts`
+ * provisions a brand-new tenant with NO `topics` and (when the operator
+ * supplies none) no `domains`. Any conference can also lose `formats` the
+ * moment an organizer empties the list, and every conference created before
+ * starter formats existed still has none. The type says `Format[]`, the data
+ * says `undefined`, and the first `.filter` / `.map` / `.includes` on a public
+ * page is a TypeError — a bare 500 on the first CFP link a new organizer shares
+ * (there is no `error.tsx` boundary in this app).
  *
  * KEEP THIS LIST HONEST: only fields the type declares NON-optional belong
  * here. A field typed `foo?: T[]` is already telling every caller to check.

--- a/src/lib/conference/sanity.ts
+++ b/src/lib/conference/sanity.ts
@@ -391,8 +391,9 @@ export async function getConferenceForDomain(
   // THE data boundary. Every conference this module hands out — resolved,
   // unknown-host or errored — leaves here with its non-optional array fields
   // actually being arrays, so no consumer has to guess. A freshly provisioned
-  // tenant has no `formats` and no `topics` (see @/lib/onboarding/create.ts),
-  // and the public CFP page dereferences both. See ./normalize.ts.
+  // tenant has no `topics` (see @/lib/onboarding/create.ts), any conference can
+  // lose its `formats` the moment an organizer empties the list, and the public
+  // CFP page dereferences both. See ./normalize.ts.
   return { conference: normalizeConference(conference), domain, error }
 }
 

--- a/src/lib/conference/state.test.ts
+++ b/src/lib/conference/state.test.ts
@@ -1,7 +1,16 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { hasSubmittableFormats, isCfpOpen } from './state'
+import {
+  canAcceptProposals,
+  hasSubmittableFormats,
+  hasSubmittableTopics,
+  isCfpOpen,
+} from './state'
 import type { Conference } from './types'
 import { Format } from '@/lib/proposal/types'
+import { STARTER_SESSION_FORMATS } from '@/lib/onboarding/create'
+
+/** A minimal topic reference, as the `{ topics: true }` join resolves them. */
+const TOPIC = { _id: 'topic-1', title: 'Platform engineering' } as never
 
 /** An open CFP window around the frozen "now" used below. */
 const OPEN_WINDOW = {
@@ -45,6 +54,47 @@ describe('hasSubmittableFormats', () => {
     expect(
       hasSubmittableFormats(conference({ formats: [Format.lightning_10] })),
     ).toBe(true)
+  })
+})
+
+describe('hasSubmittableTopics', () => {
+  it('is false for empty, absent and non-array topic lists', () => {
+    expect(hasSubmittableTopics(conference({ topics: [] }))).toBe(false)
+    expect(hasSubmittableTopics({})).toBe(false)
+    expect(
+      hasSubmittableTopics({ topics: 'kubernetes' } as unknown as Conference),
+    ).toBe(false)
+  })
+
+  it('is true once a single topic is configured', () => {
+    expect(hasSubmittableTopics(conference({ topics: [TOPIC] }))).toBe(true)
+  })
+})
+
+describe('canAcceptProposals', () => {
+  it('needs BOTH halves — a format and a topic', () => {
+    const formatsOnly = conference({
+      formats: [...STARTER_SESSION_FORMATS],
+      topics: [],
+    })
+    const topicsOnly = conference({ formats: [], topics: [TOPIC] })
+
+    expect(canAcceptProposals(formatsOnly)).toBe(false)
+    expect(canAcceptProposals(topicsOnly)).toBe(false)
+    expect(
+      canAcceptProposals(
+        conference({ formats: [...STARTER_SESSION_FORMATS], topics: [TOPIC] }),
+      ),
+    ).toBe(true)
+  })
+
+  it('rejects a freshly provisioned conference — starter formats are not enough', () => {
+    // THE DAY-ONE TRUTH. Provisioning seeds formats but deliberately no topics,
+    // and strict submit validation requires at least one topic. A CTA on that
+    // conference would lead to a form with an unsatisfiable required field.
+    expect(canAcceptProposals({ formats: [...STARTER_SESSION_FORMATS] })).toBe(
+      false,
+    )
   })
 })
 

--- a/src/lib/conference/state.ts
+++ b/src/lib/conference/state.ts
@@ -120,9 +120,14 @@ export function hasSubmittableTopics(conference: {
  * it gets `[]` from the boundary normaliser and this predicate would fail
  * CLOSED on a perfectly well configured conference. Both current call sites
  * (the public `/cfp` page and the `/cfp/proposal` submit page) pass
- * `{ topics: true }`. `src/server/routers/proposal.ts` does NOT project topics
- * and so keeps the narrower `hasSubmittableFormats` gate; a topic-less proposal
- * is still refused there, by strict validation, with a field-level message.
+ * `{ topics: true }`.
+ *
+ * `src/server/routers/proposal.ts` does NOT project topics and so keeps the
+ * narrower `hasSubmittableFormats` gate. What refuses a topic-less proposal
+ * there is the STRICT CONTENT VALIDATION on both submit paths — `create`
+ * parses the incoming payload, `action`'s draft → submitted transition parses
+ * the stored document — not a conference-level gate. Do not read the formats
+ * gate as covering topics; it does not.
  */
 export function canAcceptProposals(conference: {
   formats?: Conference['formats']

--- a/src/lib/conference/state.ts
+++ b/src/lib/conference/state.ts
@@ -90,6 +90,48 @@ export function hasSubmittableFormats(conference: {
 }
 
 /**
+ * Whether the conference offers any topic a speaker could tag a proposal with.
+ *
+ * The SAME trap as {@link hasSubmittableFormats}, one field over: strict submit
+ * validation requires at least one topic (`validateProposalForm`, and
+ * `ProposalInputSchema.topics.min(1)` server-side), and the submit form's topic
+ * picker is populated purely from `conference.topics`. With none configured the
+ * picker is an empty dropdown over a required field — unsatisfiable.
+ *
+ * Provisioning deliberately seeds NO topics (`@/lib/onboarding/create.ts`): a
+ * topic list is conference-specific in a way session lengths are not, so it is
+ * the organizer's to choose. That makes this the day-one blocker that remains
+ * after starter formats.
+ */
+export function hasSubmittableTopics(conference: {
+  topics?: Conference['topics']
+}): boolean {
+  return Array.isArray(conference.topics) && conference.topics.length > 0
+}
+
+/**
+ * Whether a NEW proposal could actually be completed on this conference —
+ * everything strict submit validation needs that comes from the CONFERENCE
+ * rather than the speaker. Deliberately excludes {@link isCfpOpen}: the window
+ * is a separate question with separate copy ("closed" vs "not set up yet").
+ *
+ * ONLY FOR CALLERS THAT PROJECTED TOPICS. `topics` is an opt-in join
+ * (`getConferenceForDomain({ topics: true })`) — a caller that did not ask for
+ * it gets `[]` from the boundary normaliser and this predicate would fail
+ * CLOSED on a perfectly well configured conference. Both current call sites
+ * (the public `/cfp` page and the `/cfp/proposal` submit page) pass
+ * `{ topics: true }`. `src/server/routers/proposal.ts` does NOT project topics
+ * and so keeps the narrower `hasSubmittableFormats` gate; a topic-less proposal
+ * is still refused there, by strict validation, with a field-level message.
+ */
+export function canAcceptProposals(conference: {
+  formats?: Conference['formats']
+  topics?: Conference['topics']
+}): boolean {
+  return hasSubmittableFormats(conference) && hasSubmittableTopics(conference)
+}
+
+/**
  * Check if the program has been published
  */
 export function isProgramPublished(conference: Conference): boolean {

--- a/src/lib/onboarding/create.test.ts
+++ b/src/lib/onboarding/create.test.ts
@@ -1,16 +1,19 @@
 /**
- * Unit tests for the onboarding S1 pure document builder — the blank-start
- * tenant defaults are contractual: unlisted, registration closed, empty
- * formats/topics, comms funneled to the org contact address, and NO
- * plan/billing fields (the org schema excludes them until billing lands).
+ * Unit tests for the onboarding S1 pure document builder — the new-tenant
+ * defaults are contractual: unlisted, registration closed, the STARTER session
+ * formats (so the CFP is usable on day one) but NO topics, comms funneled to the
+ * org contact address, and NO plan/billing fields (the org schema excludes them
+ * until billing lands).
  */
 import { describe, it, expect } from 'vitest'
 import {
   buildOnboardingDocuments,
   slugifyOrganizationName,
   ORG_SLUG_RE,
+  STARTER_SESSION_FORMATS,
   type OnboardingInput,
 } from './create'
+import { Format, formats, isWorkshopFormat } from '@/lib/proposal/types'
 
 function input(overrides: Partial<OnboardingInput> = {}): OnboardingInput {
   return {
@@ -101,9 +104,67 @@ describe('buildOnboardingDocuments — conference defaults', () => {
       visibility: 'unlisted',
       domains: ['oslo.cloudnativedays.no'],
     })
-    // Empty-safe CFP config: the activation checklist fills these later.
-    expect(conference).not.toHaveProperty('formats')
+    // Topics stay empty on purpose: a topic list is conference-specific, so any
+    // seed would be one conference's subject matter imposed on every tenant.
     expect(conference).not.toHaveProperty('topics')
+  })
+
+  describe('starter session formats', () => {
+    it('seeds the exact starter set, in order', () => {
+      const { conference } = buildOnboardingDocuments(input(), ids(), null)
+      // Written out literally, not derived from the constant: a test that
+      // recomputes the answer from the code under test cannot notice the set
+      // changing. Changing this list is a product decision, not a refactor.
+      expect(conference.formats).toEqual([
+        'lightning_10',
+        'presentation_25',
+        'presentation_45',
+      ])
+    })
+
+    it('exports the same set it writes', () => {
+      const { conference } = buildOnboardingDocuments(input(), ids(), null)
+      expect(conference.formats).toEqual([...STARTER_SESSION_FORMATS])
+    })
+
+    it('writes a COPY, so a later mutation cannot corrupt the constant', () => {
+      const { conference } = buildOnboardingDocuments(input(), ids(), null)
+      ;(conference.formats as string[]).push('workshop_240')
+      expect([...STARTER_SESSION_FORMATS]).toEqual([
+        'lightning_10',
+        'presentation_25',
+        'presentation_45',
+      ])
+      // …and the next tenant is unaffected.
+      const second = buildOnboardingDocuments(input(), ids(), null)
+      expect(second.conference.formats).toHaveLength(3)
+    })
+
+    it('offers only formats the vocabulary actually defines', () => {
+      // `formats` is a closed enum rendered through a title map on the CFP page
+      // and in the admin editor — an invented id would render as a blank option.
+      for (const format of STARTER_SESSION_FORMATS) {
+        expect(Object.values(Format)).toContain(format)
+        expect(formats.get(format)).toBeTruthy()
+      }
+    })
+
+    it('includes the format ProposalDraftSchema falls back to', () => {
+      // A draft created without an explicit format carries `lightning_10`
+      // (`ProposalDraftSchema`). If the starter set omitted it, the very first
+      // draft on a fresh tenant would carry a format the conference never
+      // offered — exactly the mismatch `proposal.action`'s gate warns about.
+      expect([...STARTER_SESSION_FORMATS]).toContain(Format.lightning_10)
+    })
+
+    it('does not commit a new conference to running workshops', () => {
+      // Workshops mean rooms, instructors and a separate track, and the public
+      // CFP page renders a whole "Hands-on Workshops" section promising them.
+      // Opt-in, never a default.
+      expect(
+        [...STARTER_SESSION_FORMATS].filter((f) => isWorkshopFormat(f)),
+      ).toEqual([])
+    })
   })
 
   it('omits dates and domains entirely when not provided', () => {

--- a/src/lib/onboarding/create.ts
+++ b/src/lib/onboarding/create.ts
@@ -16,14 +16,66 @@
  *   - `visibility: 'unlisted'` — a new tenant is NEVER publicly discoverable
  *     on creation (absent-means-live, see `@/lib/conference/visibility`).
  *   - `registrationEnabled: false` — registration never opens on creation.
- *   - `formats` / `topics` are LEFT EMPTY (the admin surfaces are empty-safe);
- *     the activation checklist walks the new organizer through filling them.
+ *   - `formats` are SEEDED with {@link STARTER_SESSION_FORMATS} so the format
+ *     half of the CFP needs no work at all — see that constant for why a blank
+ *     list was the wrong default.
+ *   - `topics` are LEFT EMPTY, deliberately: a topic list is far more
+ *     conference-specific than a session length, so any seed we picked would be
+ *     one conference's subject matter imposed on every tenant. The public CFP
+ *     page renders greyed placeholder topics until an organizer picks real
+ *     ones, and the activation checklist carries the row.
  *   - conference contact/CFP/sponsor emails default to the org contact email.
  *   - NO plan/billing fields: the organization schema deliberately excludes
  *     them until the billing issue lands (see `sanity/schemaTypes/organization.ts`).
+ *
+ * WHAT THAT LEAVES ON DAY ONE: a submitted proposal requires BOTH a format and
+ * at least one topic (`validateProposalForm`, `ProposalInputSchema`), so a
+ * freshly provisioned CFP still cannot accept a submission until the organizer
+ * picks topics — `canAcceptProposals` says so, and the public CFP page and the
+ * submit page both defer to it rather than offering a form nobody can complete.
+ * The starter formats remove ONE of the two day-one blockers; seeding the other
+ * would mean guessing what the conference is about.
  */
 
 import { normalizeDomain } from '@/lib/conference/domains'
+import { Format } from '@/lib/proposal/types'
+
+/**
+ * The session formats a newly provisioned conference starts with.
+ *
+ * WHY THESE EXIST AT ALL: provisioning used to write no formats, on the theory
+ * that the activation checklist would walk the organizer through choosing them.
+ * It does — but a proposal cannot be submitted without a format, so until the
+ * organizer found that row their public CFP link accepted nothing (and, before
+ * #824, 500'd outright). An empty format list is never the right answer for any
+ * conference, so it is a bad default; a fresh tenant should get an organizer who
+ * EDITS the list, not one who discovers it is empty.
+ *
+ * WHY THIS SET: ids come from the fixed {@link Format} vocabulary — this is a
+ * closed enum, not free text, so a starter set can only pick from it.
+ *
+ *   - `lightning_10` — the short-slot staple, and the format
+ *     `ProposalDraftSchema` falls back to when a draft carries none. Seeding it
+ *     means that default is always a format the conference actually offers.
+ *   - `presentation_25` — a talk that fits a 30-minute grid slot with changeover.
+ *   - `presentation_45` — a talk that fits a 60-minute grid slot with changeover.
+ *
+ * WHAT IS DELIBERATELY ABSENT: workshops. `workshop_120`/`workshop_240` commit a
+ * conference to rooms, instructors and a separate track — the public CFP page
+ * renders a whole "Hands-on Workshops" section promising them — so they are an
+ * opt-in, not a default. `presentation_20`/`presentation_40` are omitted as
+ * near-duplicates of the two lengths above; a starter list that offers five
+ * talk lengths is a menu to prune, not a default to accept.
+ *
+ * These are ORDINARY formats once written. Nothing marks them as defaults and
+ * nothing should: the organizer's edits are the only state worth keeping, and a
+ * "still the defaults" flag would be state to maintain forever for no behaviour.
+ */
+export const STARTER_SESSION_FORMATS: readonly Format[] = [
+  Format.lightning_10,
+  Format.presentation_25,
+  Format.presentation_45,
+]
 
 /** Same normalization as the organization schema's `slugify` (and the 044
  * backfill migration) — strip punctuation and edge dashes, not just whitespace. */
@@ -166,8 +218,13 @@ export function buildOnboardingDocuments(
     // absent-means-live, so the explicit 'unlisted' is required.
     registrationEnabled: false,
     visibility: 'unlisted',
-    // formats/topics are deliberately ABSENT (empty-safe): the activation
-    // checklist walks the organizer through CFP configuration.
+    // A usable CFP on day one: without formats a proposal cannot be submitted
+    // at all (`validateProposalForm`, and the `hasSubmittableFormats` gate on
+    // the CFP page, the submit form and both submit routes). The organizer
+    // edits this list from admin; nothing distinguishes it from one they typed.
+    // Primitive array — Sanity `_key`s apply to objects, not strings.
+    formats: [...STARTER_SESSION_FORMATS],
+    // `topics` stays ABSENT (empty-safe) on purpose — see the module header.
   }
 
   return { organization, conference, speaker }

--- a/src/lib/settings/activation.test.ts
+++ b/src/lib/settings/activation.test.ts
@@ -220,6 +220,17 @@ describe('buildActivationChecklist', () => {
         ]),
       ).toBe(false)
     })
+
+    it('rejects the starter set with a member repeated', () => {
+      // A four-entry list is something the organizer edited, whatever its
+      // deduplicated contents. Set membership alone would wave this through.
+      expect(
+        isUntouchedStarterFormatSet([
+          ...STARTER_SESSION_FORMATS,
+          'lightning_10',
+        ]),
+      ).toBe(false)
+    })
   })
 
   it('the emails row needs all three addresses', () => {

--- a/src/lib/settings/activation.test.ts
+++ b/src/lib/settings/activation.test.ts
@@ -3,8 +3,10 @@ import {
   buildActivationChecklist,
   hasCustomDomain,
   hasTicketingBinding,
+  isUntouchedStarterFormatSet,
   type ConferenceForActivation,
 } from './activation'
+import { STARTER_SESSION_FORMATS } from '@/lib/onboarding/create'
 import type { SystemCheck } from '@/lib/system-status/types'
 
 /** A fully configured, live conference — every required row should be done. */
@@ -103,16 +105,16 @@ describe('buildActivationChecklist', () => {
   })
 
   describe('the formats row', () => {
-    // Provisioning creates a tenant with NO formats and defers to "the
-    // activation checklist walks the organizer through CFP configuration" —
-    // which only works if the checklist actually has this row. A proposal
-    // cannot be submitted without a format (`validateProposalForm`), so this is
-    // a launch blocker, not a nicety.
-    it('is outstanding for a freshly provisioned conference', () => {
+    // A proposal cannot be submitted without a format (`validateProposalForm`),
+    // so an empty list is a launch blocker, not a nicety. Provisioning now
+    // seeds the starter set, so this row starts SATISFIED — the note is what
+    // keeps that tick from claiming the organizer picked them.
+    it('is outstanding for a conference with no formats at all', () => {
       const checklist = buildActivationChecklist({ title: 'Brand New' }, [])
       const row = rowById(checklist, 'formats')
       expect(row.done).toBe(false)
       expect(row.optional).toBeUndefined()
+      expect(row.note).toBeUndefined()
     })
 
     it('is outstanding for an explicitly empty formats array', () => {
@@ -130,6 +132,52 @@ describe('buildActivationChecklist', () => {
       ).toBe(true)
     })
 
+    it('is already done for a freshly provisioned conference', () => {
+      // The CFP genuinely can accept proposals on day one, so reporting this as
+      // outstanding would be a false launch blocker.
+      const row = rowById(
+        buildActivationChecklist({ formats: [...STARTER_SESSION_FORMATS] }, []),
+        'formats',
+      )
+      expect(row.done).toBe(true)
+    })
+
+    it('says whose choice the starter formats were, and names them', () => {
+      const row = rowById(
+        buildActivationChecklist({ formats: [...STARTER_SESSION_FORMATS] }, []),
+        'formats',
+      )
+      expect(row.note).toContain('We started you off with')
+      expect(row.note).toContain('edit them')
+      // The human titles, not raw ids — the same map the editor renders.
+      expect(row.note).toContain('Lightning Talk (10 min)')
+      expect(row.note).toContain('Presentation (25 min)')
+      expect(row.note).toContain('Presentation (45 min)')
+      expect(row.note).not.toContain('lightning_10')
+    })
+
+    it('drops the note as soon as the organizer changes the list', () => {
+      // Derived from the list itself — nothing stores "these are defaults", so
+      // any edit (add, remove, replace) retires the advisory.
+      const noted = (formats: string[]) =>
+        rowById(buildActivationChecklist({ formats }, []), 'formats').note
+
+      expect(
+        noted([...STARTER_SESSION_FORMATS, 'workshop_120']),
+      ).toBeUndefined()
+      expect(noted(['lightning_10', 'presentation_25'])).toBeUndefined()
+      expect(noted(['presentation_20', 'presentation_40'])).toBeUndefined()
+      // Order is not a change.
+      expect(noted([...STARTER_SESSION_FORMATS].reverse())).toBeDefined()
+    })
+
+    it('a fully configured conference carries no starter note', () => {
+      expect(
+        rowById(buildActivationChecklist(FULLY_LIVE, CHECKS_OK), 'formats')
+          .note,
+      ).toBeUndefined()
+    })
+
     it('counts toward required progress and links to the editor', () => {
       const row = rowById(buildActivationChecklist({}, []), 'formats')
       expect(row.anchor).toBe('#team-content')
@@ -137,6 +185,40 @@ describe('buildActivationChecklist', () => {
         (r) => !r.optional,
       )
       expect(required.map((r) => r.id)).toContain('formats')
+    })
+  })
+
+  describe('isUntouchedStarterFormatSet', () => {
+    it('recognises the seeded set regardless of order', () => {
+      expect(
+        isUntouchedStarterFormatSet([
+          'presentation_45',
+          'lightning_10',
+          'presentation_25',
+        ]),
+      ).toBe(true)
+    })
+
+    it('rejects supersets, subsets, empties and absent lists', () => {
+      expect(
+        isUntouchedStarterFormatSet([
+          ...STARTER_SESSION_FORMATS,
+          'workshop_240',
+        ]),
+      ).toBe(false)
+      expect(isUntouchedStarterFormatSet(['lightning_10'])).toBe(false)
+      expect(isUntouchedStarterFormatSet([])).toBe(false)
+      expect(isUntouchedStarterFormatSet(undefined)).toBe(false)
+    })
+
+    it('is not fooled by a duplicate padding the length', () => {
+      expect(
+        isUntouchedStarterFormatSet([
+          'lightning_10',
+          'lightning_10',
+          'presentation_25',
+        ]),
+      ).toBe(false)
     })
   })
 

--- a/src/lib/settings/activation.ts
+++ b/src/lib/settings/activation.ts
@@ -17,11 +17,17 @@
  * of any `server-only` / `next/cache` transitive import. Two tiny pure predicates
  * that would otherwise come from server-only barrels
  * (`@/lib/tickets/provider`, `@/lib/conference/visibility`) are re-expressed
- * inline below; the type it does import is erased at compile time.
+ * inline below; the type it does import is erased at compile time. The two
+ * VALUE imports it does keep — the provisioning starter formats and the format
+ * title map — are both pure client-safe constants, and importing them beats
+ * restating either (a checklist that names a different set than provisioning
+ * writes would be worse than no note at all).
  */
 
 import type { SystemCheck } from '@/lib/system-status/types'
 import { APPEARANCE_SECTION } from '@/lib/settings/appearance'
+import { STARTER_SESSION_FORMATS } from '@/lib/onboarding/create'
+import { formats as FORMAT_TITLES } from '@/lib/proposal/types'
 
 /** A single checklist line. */
 export interface ActivationRow {
@@ -39,8 +45,16 @@ export interface ActivationRow {
    * settings page use the path form; the checklist routes them client-side.
    */
   anchor: string
-  /** One-line orientation / what to do to satisfy the row. */
+  /** One-line orientation / what to do to satisfy the row. Shown while the row
+   * is outstanding; a satisfied row needs no instructions. */
   hint: string
+  /**
+   * An advisory shown even when the row is DONE — for the case where a
+   * requirement is technically satisfied but by something the organizer did not
+   * choose (the seeded starter formats), so a bare tick would read as a
+   * decision they made. Rare by design: most done rows should say nothing.
+   */
+  note?: string
   /**
    * Present-but-not-required informational rows (Slack, custom domain). Excluded
    * from the progress numerator/denominator and rendered in a muted style.
@@ -125,6 +139,35 @@ export function hasTicketingBinding(c: ConferenceForActivation): boolean {
     return present(c.titoAccountSlug) && present(c.titoEventSlug)
   }
   return present(c.checkinCustomerId) && present(c.checkinEventId)
+}
+
+/** "Lightning Talk (10 min), Presentation (25 min) and Presentation (45 min)" —
+ * the human titles, from the same map the admin editor and CFP page render, so
+ * the checklist can never name a format differently from the surface it links to. */
+const starterFormatNames = ((): string => {
+  const names = STARTER_SESSION_FORMATS.map((f) => FORMAT_TITLES.get(f) ?? f)
+  return names.length <= 1
+    ? (names[0] ?? '')
+    : `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`
+})()
+
+/**
+ * True when `formats` is EXACTLY the set provisioning seeds — same members, no
+ * additions, no removals. DERIVED, never stored: nothing marks a format as a
+ * default, so "the organizer has not touched this list yet" is inferred from the
+ * list itself. An organizer who edits it back to precisely these three has, for
+ * checklist purposes, chosen the same thing the starter set chose — the copy is
+ * still true, so the false positive costs nothing.
+ */
+export function isUntouchedStarterFormatSet(
+  formats: unknown[] | undefined,
+): boolean {
+  if (!Array.isArray(formats)) return false
+  const seen = new Set(formats.map((f) => String(f)))
+  return (
+    seen.size === STARTER_SESSION_FORMATS.length &&
+    STARTER_SESSION_FORMATS.every((f) => seen.has(f))
+  )
 }
 
 /**
@@ -217,14 +260,24 @@ export function buildActivationChecklist(
     {
       // REQUIRED to submit, not cosmetic: a proposal must carry a format
       // (`validateProposalForm`), and the CFP page only advertises the formats
-      // this conference configured. A new tenant is provisioned with NONE (see
-      // @/lib/onboarding/create.ts), so without this row the checklist would
-      // report "ready to launch" for a CFP that can accept nothing.
+      // this conference configured. An organizer who empties the list has
+      // closed their own CFP, so this stays a launch blocker.
+      //
+      // A NEW tenant is provisioned WITH the starter set (see
+      // @/lib/onboarding/create.ts), so this row starts ticked — correctly: the
+      // CFP really can accept proposals. The `note` keeps that tick honest by
+      // saying whose choice it was, since a bare strike-through would read as
+      // "you picked these".
       id: 'formats',
-      label: 'At least one session format',
+      label: 'Session formats',
       done: Array.isArray(conference.formats) && conference.formats.length > 0,
       anchor: '#team-content',
-      hint: 'Choose the session formats speakers may submit (talks, workshops).',
+      hint: 'Choose at least one session format speakers may submit (talks, workshops).',
+      ...(isUntouchedStarterFormatSet(conference.formats)
+        ? {
+            note: `We started you off with ${starterFormatNames} — edit them to match your programme.`,
+          }
+        : {}),
     },
     {
       id: 'topics',

--- a/src/lib/settings/activation.ts
+++ b/src/lib/settings/activation.ts
@@ -153,16 +153,25 @@ const starterFormatNames = ((): string => {
 
 /**
  * True when `formats` is EXACTLY the set provisioning seeds — same members, no
- * additions, no removals. DERIVED, never stored: nothing marks a format as a
- * default, so "the organizer has not touched this list yet" is inferred from the
- * list itself. An organizer who edits it back to precisely these three has, for
- * checklist purposes, chosen the same thing the starter set chose — the copy is
- * still true, so the false positive costs nothing.
+ * additions, no removals, no duplicates. DERIVED, never stored: nothing marks a
+ * format as a default, so "this list is still the one we wrote" is inferred from
+ * the list itself.
+ *
+ * KNOWN FALSE POSITIVE, accepted: a conference that never saw the starter set —
+ * one created before it existed, or one whose organizer independently landed on
+ * precisely these three — reads as untouched, so the note claims a provenance
+ * that is not true of it. The cost is one line of slightly wrong attribution on
+ * a row that is already satisfied, it self-heals on the next edit, and the
+ * alternative is a stored "these are the defaults" flag — exactly the state this
+ * design exists to avoid. Not worth a schema field.
  */
 export function isUntouchedStarterFormatSet(
   formats: unknown[] | undefined,
 ): boolean {
   if (!Array.isArray(formats)) return false
+  // Length is checked against the ARRAY, not the deduplicated set: a list of
+  // four with a repeated starter format is something the organizer edited.
+  if (formats.length !== STARTER_SESSION_FORMATS.length) return false
   const seen = new Set(formats.map((f) => String(f)))
   return (
     seen.size === STARTER_SESSION_FORMATS.length &&

--- a/src/server/routers/proposal.ts
+++ b/src/server/routers/proposal.ts
@@ -831,6 +831,44 @@ export const proposalRouter = router({
                 'The organizers have not announced any session formats yet, so proposals cannot be submitted. Please check back soon.',
             })
           }
+
+          // THE OTHER HALF of what `create` enforces on submission, which this
+          // route was missing entirely. `create` strict-parses the incoming
+          // payload before letting a proposal reach `submitted`; here the
+          // content is already stored, so the DOCUMENT is what gets parsed —
+          // the `update` route's merged-content pattern with nothing to merge.
+          //
+          // Without this, the two-step path bypassed EVERY content rule
+          // `create` applies: `create({ status: draft })` accepts anything
+          // (`ProposalDraftSchema` is `.partial()`), and `action(submit)` then
+          // promoted it with no topics, no accepted terms and an empty
+          // description. Not reachable from the UI — `ProposalForm` saves via
+          // `update` first, and the submit page is gated — but wide open to a
+          // direct API/tRPC caller, which is a real population given the
+          // agent-facing CLI. Applies to organizers too, like the format gate:
+          // an invalid submitted proposal is wrong whoever promotes it.
+          //
+          // The stored document is the same content in READ shape, so two
+          // fields are folded back to what the schema describes: `speakers` is
+          // dropped (dereferenced objects, and `create` does not validate them
+          // either) and `topics` is folded from dereferenced topic documents
+          // back to references.
+          const candidate = {
+            ...proposal,
+            speakers: undefined,
+            topics: topicIdsOf(proposal.topics).map((ref) => ({
+              _type: 'reference' as const,
+              _ref: ref,
+            })),
+          }
+          const strict = ProposalInputSchema.safeParse(candidate)
+          if (!strict.success) {
+            const fieldErrors = strict.error.issues.map((i) => i.message)
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: `Please fix the following before submitting: ${fieldErrors.join('. ')}`,
+            })
+          }
         }
 
         // Enforce cap when submitting a draft (draft → submitted transition)


### PR DESCRIPTION
## Decision

Provisioning deliberately wrote **no** `formats`, with a comment saying the activation checklist would walk the organizer through it. That is what caused the day-one CFP crash fixed in #824. Owner decision: ship starter formats so a fresh tenant's CFP does not depend on an organizer finding a checklist row.

**Topics stay empty** — a topic list is far more conference-specific than a session length, so any seed would be one conference's subject matter imposed on every tenant.

## The starter set — and why

`lightning_10`, `presentation_25`, `presentation_45`. Ids come from the fixed `Format` enum (`src/lib/proposal/types.ts`); nothing invented.

| Format | Why |
| --- | --- |
| `lightning_10` | The short-slot staple, **and** the format `ProposalDraftSchema` falls back to when a draft carries none. Seeding it means that schema default is always a format the conference actually offers — the exact mismatch `proposal.action`'s gate warns about. |
| `presentation_25` | Fits a 30-minute grid slot with changeover. |
| `presentation_45` | Fits a 60-minute grid slot with changeover. |

**Deliberately absent:** workshops (`workshop_120`/`workshop_240`) commit a conference to rooms, instructors and a separate track — the public CFP page renders an entire "Hands-on Workshops" section promising them — so they are opt-in, never a default. `presentation_20`/`presentation_40` are omitted as near-duplicates; a starter list offering five talk lengths is a menu to prune, not a default to accept.

## The finding: starter formats alone were NOT enough

Verifying end to end rather than assuming turned up the other half of the #824 trap. **A submitted proposal requires at least one TOPIC too** (`validateProposalForm`, `ProposalInputSchema.topics.min(1)`), and the submit form's topic picker is populated purely from `conference.topics`.

So starter formats on their own would have made day one *worse*: the public CFP page would have shown "Submit your proposal", handed the speaker a form with a working format picker and an **empty dropdown over a required field**, and rejected the submission — replacing an honest "Submissions are not open yet" with a dead end. Same bug class as #824, one field over.

Fix: `canAcceptProposals(conference)` = `hasSubmittableFormats && hasSubmittableTopics`, used by the two surfaces that invite a NEW submission (`/cfp` and `/cfp/proposal`). Both already fetch with `{ topics: true }`.

`src/server/routers/proposal.ts` deliberately keeps the narrower `hasSubmittableFormats` gate: it calls `getConferenceForCurrentDomain()` **without** projecting topics, so a topic-aware gate there would read `[]` from the boundary normaliser and fail CLOSED on every well-configured conference. What refuses a topic-less proposal there is the strict **content** validation on both submit paths — see the next section, which is where that turned out not to be true yet.

Owner decision on this finding: **the remaining topic step stays a checklist step.** Net effect on day one: one of the two blockers is gone, and adding topics now needs no format work.

## Second commit: `action` promoted drafts with no content validation at all

Adversarial QA probed the carve-out above and found the comment was making a claim the code did not back. `create` strict-parses a proposal before it can reach `submitted`; **`action`'s draft→submitted transition parsed nothing** — only the formats gate and the proposal cap. QA promoted a draft with `topics: []` and `tos: false` to `submitted` on a topics-less fresh tenant. Accepted, no error.

The hole is **pre-existing on any conference**: `ProposalDraftSchema` is `.partial()`, so `create({ status: draft })` accepts anything and `action(submit)` then promoted it — bypassing every content rule `create` enforces. The `update` route has the strict-validation-on-merged-content pattern; `action` never got it. What this PR changes is that fresh tenants were previously shielded by the formats gate, and seeding formats removes that accidental shield.

Fixed rather than merely re-documented, because the UI cannot reach it but **direct API and tRPC callers can** — a real population given the agent-facing CLI direction (`konfctl`, MCP server in the works).

Applies the `update` route's pattern with nothing to merge: the stored document is parsed. Two fields are folded from read shape back to what the schema describes — `speakers` dropped, and **`topics` folded from dereferenced topic documents back to references**. The projection returns `topics[]-> { _id, title, color }`, so parsing the document naively would have rejected every legitimate submission on the topic field; there is a named regression test for exactly that. No organizer carve-out, matching the formats gate. Scoped to draft→submitted, so withdraw/unsubmit on an already-imperfect proposal still work.

The `canAcceptProposals` docstring is corrected to say what is now true.

### Third asymmetry found, NOT fixed — needs an owner call

While auditing "what else guards `create` but not `action`", I probed the CFP window and confirmed it live:

- `create` refuses **any** call — even a draft — when `isCfpOpen` is false.
- `action`'s draft→submitted has **no window check at all**. A speaker sitting on an old draft can promote it to `submitted` a month after the CFP closed. (`action` *does* block `unsubmit` after close, so the omission looks like an oversight rather than a design.)

Left alone deliberately: it is unrelated to starter formats, it is pre-existing, and closing it changes behaviour for organizers too (who may legitimately promote drafts after close on a speaker's behalf). Happy to fix in a follow-up — it wants a decision, not a guess.

## Checklist row

Row starts ticked — correctly, because the CFP genuinely has formats — with a `note` that keeps the tick honest:

> ~~Session formats~~
> We started you off with Lightning Talk (10 min), Presentation (25 min) and Presentation (45 min) — edit them to match your programme.

`ActivationRow.note` is new: an advisory shown even when a row is done, for a requirement satisfied by something the organizer did not choose. Rare by design. Format titles come from the same map the editor and CFP page render, so the checklist can never name a format differently from the surface it links to.

Verified visually in Storybook (light + dark) via `pnpm shoot`.

## Judgement calls

- **Are starter formats marked as defaults anywhere in admin? No** — agreeing with the stated instinct. They are ordinary formats once written; a "still the defaults" flag would be state to maintain forever for no behaviour. The checklist note instead **derives** "untouched starter set" from the list itself (`isUntouchedStarterFormatSet`), so any edit retires it with nothing to clean up.
- **The known false positive is accepted and now documented as such.** A conference that never saw the starter set — created before it existed, or whose organizer independently landed on precisely these three — reads as untouched, so the note claims a provenance untrue of it. Cost: one line of slightly wrong attribution on an already-satisfied row, self-healing on the next edit. The alternative is a stored flag, which is exactly what this design avoids. The docstring no longer claims "the copy is still true".
- **Fixed alongside:** the set-membership compare accepted a four-entry list containing a duplicated starter member. Now length-checked against the array.
- **The checklist row stays `required` and stays ticked on a fresh tenant.** Marking it outstanding would be a false launch blocker — the formats really are there.
- **Copy on `SubmissionsNotOpenNotice` no longer names formats specifically**, now that either half can be the missing one. A speaker cannot act on "topics are missing"; the organizer reads the checklist, not this notice.

## Existing conferences

**Unaffected.** This changes provisioning only — no migration, no backfill, no script. Existing conferences keep whatever formats they have.

The one behaviour change that could reach them is the `canAcceptProposals` gate. In practice it cannot: `conference.topics` is `Rule.required().min(1)` in `sanity/schemaTypes/conference.ts`, so any conference an organizer has edited already has topics. And even if one somehow had none, the gate would only withhold a CTA from a conference that could not have accepted the submission anyway.

The `action` validation guard does reach existing conferences — deliberately. It refuses only promotions that `create` would already have refused, and the UI path (`update` then `action`) always saves complete content first.

## Sabotage proof

**Starter formats.** Removing the single line `formats: [...STARTER_SESSION_FORMATS],` from `create.ts`:

- **14 tests fail across 3 files** (`src/lib/onboarding/create.test.ts`, `__tests__/app/cfp/fresh-tenant.test.tsx`, `__tests__/app/cfp/fresh-tenant-submit.test.tsx`) — including "seeds the exact starter set", "is provisioned WITH the starter formats", "scopes the format picker to exactly the starter formats", and both `proposal.create` / `proposal.action` submissions.
- Restored → green again.

**The new validation guard.** Removing the `ProposalInputSchema.safeParse` block from `action`:

- **5 tests fail across 2 files** — "refuses a draft carrying no topics", "refuses a draft with the terms unaccepted", "refuses a draft with an empty description", "gives ORGANIZERS no carve-out either", and the QA repro "does NOT let the two-step path smuggle a topic-less proposal through".
- Restored → green again.

Tests build the fixture with the **real** `buildOnboardingDocuments` (reusing #824's precedent), assert the starter list **literally** rather than recomputing it from the constant, and run the **real** `hasSubmittableFormats` / `canAcceptProposals` (`__tests__/api/trpc/proposal.test.ts` mocks that predicate, so it can never tell you whether a real provisioned conference passes it).

## Numbers

Rebased onto `origin/main` @ `1199fc01` (#830). Baseline re-derived on that commit in a clean worktree.

| Check | Baseline `origin/main` | Branch |
| --- | --- | --- |
| `pnpm test` | 501 files / 7169 tests pass | **502 files / 7208 tests pass** (+1 file, +39) |
| `pnpm typecheck` | clean | clean |
| `npx prettier --check .` | clean | clean |
| `npx eslint .` | 209 problems (0 errors, 209 warnings) | 209 problems (0 errors, 209 warnings) |
| `pnpm knip` | exit 0 | exit 0 |
