### PR TITLE
feat(admin): sell ticketing at the entry paid tier, make a deny a hard kill switch

### DIFF
--- a/__tests__/app/admin/budget-ticketing-gate.test.tsx
+++ b/__tests__/app/admin/budget-ticketing-gate.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * @vitest-environment node
+ *
+ * THE BUDGET PAGE IS A TICKETING SURFACE TOO. It shows live ticket INCOME,
+ * pulled straight from the conference's ticketing provider, so an operator's
+ * explicit ticketing deny has to reach it: a kill switch that blanks
+ * `/admin/tickets` while the budget page keeps printing live revenue is only
+ * half a switch.
+ *
+ * Everything the app owns runs for real — the provider resolver, the credential
+ * seam and the feature gate. Only Sanity, the provider HTTP client and the
+ * budget page's own client component are supplied.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const mockGetConference = vi.fn()
+const mockGetOrganizationById = vi.fn()
+
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    mockGetConference(...args),
+}))
+
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationById: (...args: unknown[]) => mockGetOrganizationById(...args),
+  getOrganizationRefForCurrentConference: () => null,
+}))
+
+const h = vi.hoisted(() => ({
+  fetch: vi.fn(async () => null),
+  fetchEventTickets: vi.fn(),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientRead: { fetch: h.fetch },
+  clientReadUncached: { fetch: h.fetch },
+  clientWrite: { fetch: h.fetch },
+}))
+
+vi.mock('@/lib/tickets/provider/checkin', () => ({
+  CheckinProvider: class {
+    readonly name = 'Checkin.no'
+    isConfigured() {
+      return true
+    }
+    fetchEventTickets = h.fetchEventTickets
+  },
+}))
+
+vi.mock('@/lib/budget', () => ({
+  getBudgetForConference: vi.fn(async () => null),
+  deriveTicketIncome: vi.fn(() => ({ gross: 1000, net: 800, count: 4 })),
+  deriveManualTicketIncome: vi.fn(() => null),
+  deriveSponsorIncome: vi.fn(() => ({ total: 0, deals: [] })),
+}))
+
+vi.mock('@/lib/sponsor-crm/sanity', () => ({
+  listSponsorsForConference: vi.fn(async () => []),
+}))
+
+/** The client component is a marker: the gate decides before it renders. */
+vi.mock('@/components/admin', () => ({
+  BudgetPageClient: ({ ticketIncome }: { ticketIncome: unknown | null }) => (
+    <div data-live-ticket-income={ticketIncome ? 'yes' : 'no'} />
+  ),
+  ErrorDisplay: ({ title }: { title: string }) => <div>{title}</div>,
+}))
+
+import AdminBudgetPage from '@/app/(admin)/admin/budget/page'
+
+const PLATFORM_ORG_ID = 'org-platform'
+const TENANT_ORG_ID = 'org-A'
+
+function stubConference(orgId: string) {
+  mockGetConference.mockResolvedValue({
+    conference: {
+      _id: 'conf-1',
+      title: 'Tenant Conf',
+      checkinCustomerId: 42,
+      checkinEventId: 4242,
+      organization: { _ref: orgId, _type: 'reference' },
+    },
+    error: null,
+  })
+}
+
+/** Did the page hand live provider income to its client component? */
+async function renderedLiveIncome(): Promise<string | null> {
+  const markup = renderToStaticMarkup(
+    (await AdminBudgetPage()) as React.ReactElement,
+  )
+  return markup.match(/data-live-ticket-income="([^"]*)"/)?.[1] ?? null
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubEnv('PLATFORM_ORG_ID', PLATFORM_ORG_ID)
+  vi.stubEnv('TENANT_SECRETS_JSON', '')
+  vi.stubEnv('CHECKIN_API_KEY', 'platform-checkin-key')
+  vi.stubEnv('CHECKIN_API_SECRET', 'platform-checkin-secret')
+  h.fetchEventTickets.mockResolvedValue([])
+  mockGetOrganizationById.mockResolvedValue({
+    _id: TENANT_ORG_ID,
+    name: 'Tenant A',
+    slug: 'tenant-a',
+    plan: 'pro',
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('the budget page and the ticketing kill switch', () => {
+  it('shows live ticket income for a bound, credentialed organization', async () => {
+    stubConference(PLATFORM_ORG_ID)
+    mockGetOrganizationById.mockResolvedValue({
+      _id: PLATFORM_ORG_ID,
+      name: 'Platform',
+      slug: 'platform-org',
+    })
+
+    await expect(renderedLiveIncome()).resolves.toBe('yes')
+    expect(h.fetchEventTickets).toHaveBeenCalled()
+  })
+
+  it('falls back to manual actuals — and never fetches — once an operator denies ticketing', async () => {
+    stubConference(TENANT_ORG_ID)
+    vi.stubEnv(
+      'TENANT_SECRETS_JSON',
+      JSON.stringify({
+        [TENANT_ORG_ID]: { ticketing: { apiKey: 'tenant-key' } },
+      }),
+    )
+    mockGetOrganizationById.mockResolvedValue({
+      _id: TENANT_ORG_ID,
+      name: 'Tenant A',
+      slug: 'tenant-a',
+      plan: 'pro',
+      featureOverrides: [{ feature: 'ticketing', enabled: false }],
+    })
+
+    await expect(renderedLiveIncome()).resolves.toBe('no')
+    expect(h.fetchEventTickets).not.toHaveBeenCalled()
+  })
+
+  /** The #828 guarantee here too: no decision + own credentials still works. */
+  it('still shows live income for a credentialed tenant with no entitlement decision', async () => {
+    stubConference(TENANT_ORG_ID)
+    vi.stubEnv(
+      'TENANT_SECRETS_JSON',
+      JSON.stringify({
+        [TENANT_ORG_ID]: { ticketing: { apiKey: 'tenant-key' } },
+      }),
+    )
+    mockGetOrganizationById.mockResolvedValue({
+      _id: TENANT_ORG_ID,
+      name: 'Tenant A',
+      slug: 'tenant-a',
+      plan: 'community',
+    })
+
+    await expect(renderedLiveIncome()).resolves.toBe('yes')
+    expect(h.fetchEventTickets).toHaveBeenCalled()
+  })
+})

--- a/__tests__/app/admin/layout-features.test.tsx
+++ b/__tests__/app/admin/layout-features.test.tsx
@@ -114,6 +114,29 @@ describe('admin layout — enabled features', () => {
     ])
   })
 
+  /** The entry paid tier buys ticketing (owner decision, 2026-08-06). */
+  it('gives a pro tenant the ticketing destination on plan alone', async () => {
+    mockGetOrganizationById.mockResolvedValue({
+      _id: 'org-A',
+      name: 'Tenant A',
+      slug: 'tenant-a',
+      plan: 'pro',
+    })
+    await expect(enabledFeatures()).resolves.toContain('ticketing')
+  })
+
+  /** The nav side of the kill switch: a deny beats the plan that sold it. */
+  it('hides ticketing from a paid tenant an operator has denied', async () => {
+    mockGetOrganizationById.mockResolvedValue({
+      _id: 'org-A',
+      name: 'Tenant A',
+      slug: 'tenant-a',
+      plan: 'pro',
+      featureOverrides: [{ feature: 'ticketing', enabled: false }],
+    })
+    await expect(enabledFeatures()).resolves.not.toContain('ticketing')
+  })
+
   it('honours a per-feature override — not just workshops', async () => {
     mockGetOrganizationById.mockResolvedValue({
       _id: 'org-A',

--- a/__tests__/app/admin/tickets-states.test.tsx
+++ b/__tests__/app/admin/tickets-states.test.tsx
@@ -216,6 +216,79 @@ describe('a non-entitled organization', () => {
   })
 })
 
+/**
+ * THE KILL SWITCH ON THE PAGE ITSELF (owner decision, 2026-08-06). #828 hid the
+ * nav entry on an explicit deny, but a deep link still rendered live sales for
+ * an org whose own credentials resolved — the pages asked the provider first.
+ * Every one of the five pages must now blank on a deny, and say something true:
+ * this org HAS a working integration, so "not available for your organization"
+ * would be a lie.
+ */
+describe('an organization an operator has explicitly DENIED', () => {
+  beforeEach(() => {
+    stubConference(TENANT_ORG_ID, CHECKIN_BINDING)
+    vi.stubEnv(
+      'TENANT_SECRETS_JSON',
+      JSON.stringify({
+        [TENANT_ORG_ID]: { ticketing: { apiKey: 'tenant-key' } },
+      }),
+    )
+    mockGetOrganizationById.mockResolvedValue({
+      _id: TENANT_ORG_ID,
+      name: 'Tenant A',
+      slug: 'tenant-a',
+      plan: 'pro',
+      featureOverrides: [{ feature: 'ticketing', enabled: false }],
+    })
+  })
+
+  for (const [route, page] of PAGES) {
+    it(`${route} is blocked by the deny, credentials and all`, async () => {
+      const markup = await html(page)
+
+      expect(markup).toContain(
+        'Ticketing has been turned off for your organization',
+      )
+      // NOT the never-had-it copy: this org had a working integration.
+      expect(markup).not.toContain(
+        'Ticketing is not available for your organization',
+      )
+      expect(markup).not.toContain('Configuration Error')
+      // Nothing to fix in settings, so no dead-end link.
+      expect(markup).not.toContain('Open ticket settings')
+    })
+  }
+
+  it('never calls the provider for a denied org', async () => {
+    for (const [, page] of PAGES) await html(page)
+    expect(h.fetchEventTickets).not.toHaveBeenCalled()
+    expect(h.fetchPublicTicketTypes).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * THE #828 GUARANTEE, PAGE-LEVEL: no decision either way + the org's own
+ * credentials still opens the surface. Only an explicit deny closes it.
+ */
+describe('a credentialed organization with no entitlement decision', () => {
+  beforeEach(() => {
+    stubConference(TENANT_ORG_ID, CHECKIN_BINDING)
+    vi.stubEnv(
+      'TENANT_SECRETS_JSON',
+      JSON.stringify({
+        [TENANT_ORG_ID]: { ticketing: { apiKey: 'tenant-key' } },
+      }),
+    )
+  })
+
+  it('/admin/tickets/orders opens and fetches its real sales', async () => {
+    const markup = await html(OrdersAdminPage)
+    expect(markup).not.toContain('Ticketing is not')
+    expect(markup).not.toContain('Ticketing has been turned off')
+    expect(h.fetchEventTickets).toHaveBeenCalled()
+  })
+})
+
 /** Entitled but not bound yet — actionable, and NOT an error. */
 describe('an entitled organization with no event binding', () => {
   beforeEach(() => {

--- a/__tests__/lib/dashboard/actions.test.ts
+++ b/__tests__/lib/dashboard/actions.test.ts
@@ -61,11 +61,14 @@ vi.mock('@/lib/sponsor-crm/activities', () => ({
     mockListActivities(...args),
 }))
 
-// Tickets — fetchTicketSales now resolves a TicketingProvider from the
-// domain conference; mock the resolver so the provider's fetchEventTickets is
-// the spy. The resolver mirrors the real unconfigured/configured branching.
+// Tickets — fetchTicketSales resolves the ticketing ADMIN ACCESS state from the
+// domain conference (provider + feature gate); mock the provider seam so the
+// provider's fetchEventTickets is the spy, and let the real gate run on the
+// mocked organization document. The resolver mirrors the real
+// unconfigured/configured branching.
 const mockFetchEventTickets = vi.fn<AnyFn>()
 vi.mock('@/lib/tickets/provider', () => ({
+  conferenceProviderType: () => 'checkin',
   resolveTicketingProvider: (conference: {
     checkinCustomerId?: number
     checkinEventId?: number
@@ -153,9 +156,12 @@ vi.mock('@/lib/conference/sanity', () => ({
 // session speaker's `organizerOrgIds` contains the org the REQUEST resolves to
 // (`isOrganizerForCurrentOrg` → `getOrganizationRefForCurrentConference`), so
 // the request org has to be pinned to the one the session below carries.
+const mockGetOrganizationById = vi.fn<AnyFn>(async () => null)
 vi.mock('@/lib/organization/sanity', async (importOriginal) => ({
   ...(await importOriginal<object>()),
   getOrganizationRefForCurrentConference: async () => 'org-test',
+  // The ticketing feature gate reads the org document (plan + overrides).
+  getOrganizationById: (...args: unknown[]) => mockGetOrganizationById(...args),
 }))
 
 // Time utilities
@@ -985,6 +991,32 @@ describe('Dashboard Server Actions', () => {
         customerId: 123,
         eventId: 456,
       })
+    })
+
+    /**
+     * THE KILL SWITCH REACHES THE DASHBOARD TILE. An explicit operator deny
+     * blocks the ticket pages; a widget that kept streaming live sales for the
+     * same organization would make it a half-switch. Reported as its own status
+     * so the tile does not tell a denied org to go and configure something.
+     */
+    it('returns disabled — and never fetches — when an operator has denied ticketing', async () => {
+      setDomainConference({
+        ...baseConference,
+        checkinCustomerId: 123,
+        checkinEventId: 456,
+        organization: { _ref: 'org-test', _type: 'reference' },
+      } as Conference)
+      mockGetOrganizationById.mockResolvedValue({
+        _id: 'org-test',
+        name: 'Tenant',
+        slug: 'tenant',
+        plan: 'pro',
+        featureOverrides: [{ feature: 'ticketing', enabled: false }],
+      })
+
+      const result = await fetchTicketSales()
+      expect(result).toEqual({ status: 'disabled' })
+      expect(mockFetchEventTickets).not.toHaveBeenCalled()
     })
 
     it('returns error (not unconfigured) when the ticket API fails', async () => {

--- a/__tests__/lib/dashboard/actions.test.ts
+++ b/__tests__/lib/dashboard/actions.test.ts
@@ -963,7 +963,19 @@ describe('Dashboard Server Actions', () => {
   })
 
   describe('fetchTicketSales', () => {
-    it('returns unconfigured when conference lacks checkin IDs', async () => {
+    /** ENTITLED but not bound yet — the one state that IS a settings fix. */
+    it('returns unconfigured when an entitled conference lacks checkin IDs', async () => {
+      setDomainConference({
+        ...baseConference,
+        organization: { _ref: 'org-test', _type: 'reference' },
+      } as Conference)
+      mockGetOrganizationById.mockResolvedValue({
+        _id: 'org-test',
+        name: 'Tenant',
+        slug: 'tenant',
+        plan: 'pro',
+      })
+
       const result = await fetchTicketSales()
       expect(result).toEqual({ status: 'unconfigured' })
       expect(mockFetchEventTickets).not.toHaveBeenCalled()
@@ -1016,6 +1028,28 @@ describe('Dashboard Server Actions', () => {
 
       const result = await fetchTicketSales()
       expect(result).toEqual({ status: 'disabled' })
+      expect(mockFetchEventTickets).not.toHaveBeenCalled()
+    })
+
+    /**
+     * NOT "unconfigured": ticketing is sold from the entry paid tier, so a
+     * community org has nothing to connect. Telling it to go and configure a
+     * provider is the dead end #828 set out to remove.
+     */
+    it('returns unavailable for an organization that does not have ticketing', async () => {
+      setDomainConference({
+        ...baseConference,
+        organization: { _ref: 'org-test', _type: 'reference' },
+      } as Conference)
+      mockGetOrganizationById.mockResolvedValue({
+        _id: 'org-test',
+        name: 'Tenant',
+        slug: 'tenant',
+        plan: 'community',
+      })
+
+      const result = await fetchTicketSales()
+      expect(result).toEqual({ status: 'unavailable' })
       expect(mockFetchEventTickets).not.toHaveBeenCalled()
     })
 

--- a/src/app/(admin)/admin/actions.ts
+++ b/src/app/(admin)/admin/actions.ts
@@ -514,15 +514,15 @@ export async function fetchTicketSales(): Promise<TicketSalesResult> {
   // organizer point the server's Checkin credentials at arbitrary accounts.
   const conference = await resolveConference()
 
-  // Same THREE-STATE resolution the ticket pages use, for the same reason: an
-  // operator's explicit deny is a kill switch, so the dashboard tile must not
-  // keep streaming live sales for an organization whose ticketing was switched
-  // off. `disabled` is reported separately from `unconfigured` — telling a
-  // denied org to go and connect a provider would be a dead end.
+  // The SAME resolution the ticket pages use, state for state — the tile must
+  // not tell a different story than the page it links to. An operator's explicit
+  // deny is a kill switch, so the tile stops streaming live sales; and an org
+  // that is not entitled at all is NOT "unconfigured", because "connect a
+  // provider in settings" is a dead end for a tenant whose plan does not include
+  // ticketing. Only a genuinely entitled-but-unbound conference gets that nudge.
   const access = await resolveTicketingAdminAccess(conference)
-  if (access.state === 'disabled') {
-    return { status: 'disabled' }
-  }
+  if (access.state === 'disabled') return { status: 'disabled' }
+  if (access.state === 'unavailable') return { status: 'unavailable' }
   if (access.state !== 'ready') {
     return { status: 'unconfigured' }
   }

--- a/src/app/(admin)/admin/actions.ts
+++ b/src/app/(admin)/admin/actions.ts
@@ -12,7 +12,7 @@ import { calculateAverageRating } from '@/lib/proposal/business'
 import { getSpeakers } from '@/lib/speaker/sanity'
 import { getFeaturedSpeakers } from '@/lib/featured/sanity'
 import { Flags } from '@/lib/speaker/types'
-import { resolveTicketingProvider } from '@/lib/tickets/provider'
+import { resolveTicketingAdminAccess } from '@/lib/tickets/admin-access'
 import { TicketSalesProcessor } from '@/lib/tickets/processor'
 import type { ProcessTicketSalesInput } from '@/lib/tickets/types'
 import { DEFAULT_TARGET_CONFIG, DEFAULT_CAPACITY } from '@/lib/tickets/config'
@@ -514,15 +514,21 @@ export async function fetchTicketSales(): Promise<TicketSalesResult> {
   // organizer point the server's Checkin credentials at arbitrary accounts.
   const conference = await resolveConference()
 
-  const ticketing = await resolveTicketingProvider(conference)
-  if (!ticketing.configured) {
+  // Same THREE-STATE resolution the ticket pages use, for the same reason: an
+  // operator's explicit deny is a kill switch, so the dashboard tile must not
+  // keep streaming live sales for an organization whose ticketing was switched
+  // off. `disabled` is reported separately from `unconfigured` — telling a
+  // denied org to go and connect a provider would be a dead end.
+  const access = await resolveTicketingAdminAccess(conference)
+  if (access.state === 'disabled') {
+    return { status: 'disabled' }
+  }
+  if (access.state !== 'ready') {
     return { status: 'unconfigured' }
   }
 
   try {
-    const tickets = await ticketing.provider.fetchEventTickets(
-      ticketing.eventRef,
-    )
+    const tickets = await access.provider.fetchEventTickets(access.eventRef)
 
     const capacity = conference.ticketCapacity || DEFAULT_CAPACITY
 

--- a/src/app/(admin)/admin/budget/page.tsx
+++ b/src/app/(admin)/admin/budget/page.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/lib/budget'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { listSponsorsForConference } from '@/lib/sponsor-crm/sanity'
-import { resolveTicketingProvider } from '@/lib/tickets/provider'
+import { resolveTicketingAdminAccess } from '@/lib/tickets/admin-access'
 import { BudgetPageClient, ErrorDisplay } from '@/components/admin'
 
 /**
@@ -35,15 +35,18 @@ export default async function AdminBudgetPage() {
   }
 
   // The live-ticket fetch (secret store + external provider API) only needs
-  // `conference`, so it runs in parallel with the Sanity reads.
+  // `conference`, so it runs in parallel with the Sanity reads. It goes through
+  // `resolveTicketingAdminAccess` rather than the provider directly so an
+  // operator's explicit ticketing DENY reaches this surface too: a kill switch
+  // that leaves live ticket revenue on the budget page is only half a switch.
+  // Everything short of `ready` falls back to the manually-entered actuals,
+  // exactly as an unconfigured provider always has.
   const fetchLiveTicketIncome =
     async (): Promise<TicketIncomeActuals | null> => {
-      const ticketing = await resolveTicketingProvider(conference)
-      if (!ticketing.configured) return null
+      const access = await resolveTicketingAdminAccess(conference)
+      if (access.state !== 'ready') return null
       try {
-        const tickets = await ticketing.provider.fetchEventTickets(
-          ticketing.eventRef,
-        )
+        const tickets = await access.provider.fetchEventTickets(access.eventRef)
         return deriveTicketIncome(tickets)
       } catch (error) {
         // Soft-fail to the manual fallback: a provider outage must not take

--- a/src/components/admin/TicketingStateNotice.stories.tsx
+++ b/src/components/admin/TicketingStateNotice.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'The three honest ticketing empty states an organizer can land on: not connected yet (actionable), not available for the organization (nothing to do), and not supported by the conference’s vendor. None of them is an error frame.',
+          'The four honest ticketing empty states an organizer can land on: not connected yet (actionable), not available for the organization (never had it), turned off by an operator (had it, someone switched it off), and not supported by the conference’s vendor. None of them is an error frame.',
       },
     },
   },
@@ -43,6 +43,20 @@ export const Unavailable: Story = {
     state: 'unavailable',
     providerLabel: 'Checkin.no',
     surface: 'orders',
+  },
+}
+
+/**
+ * An operator switched ticketing OFF for this organization. The distinction
+ * from `Unavailable` is the point: this org may have had working sales pages,
+ * so the copy names what happened and who can undo it instead of claiming the
+ * integration was never theirs.
+ */
+export const Disabled: Story = {
+  args: {
+    state: 'disabled',
+    providerLabel: 'Checkin.no',
+    surface: 'ticket sales',
   },
 }
 

--- a/src/components/admin/TicketingStateNotice.tsx
+++ b/src/components/admin/TicketingStateNotice.tsx
@@ -8,7 +8,7 @@ import { PLATFORM_NAME } from '@/lib/branding/platform'
  * alternative to the red `ErrorDisplay "Checkin.no Configuration Error"` every
  * ticket page used to render whenever the provider did not resolve.
  *
- * Three states, matching {@link import('@/lib/tickets/admin-access')}'s
+ * Four states, matching {@link import('@/lib/tickets/admin-access')}'s
  * resolution (and the budget page's empty ≠ error ≠ unavailable rule):
  *
  * - `unconfigured` — the org MAY use ticketing but this conference is not bound
@@ -16,6 +16,12 @@ import { PLATFORM_NAME } from '@/lib/branding/platform'
  * - `unavailable` — the org has no ticketing integration at all. There is
  *   nothing to configure, so there is no settings link to offer; saying so
  *   plainly beats sending an organizer to a form that cannot help.
+ * - `disabled` — the org HAD ticketing and an operator switched it off. Kept
+ *   separate from `unavailable` on purpose: "not available for your
+ *   organization" is the truth for a tenant that never had it, and a lie to one
+ *   whose sales pages worked yesterday. This copy names what happened and who
+ *   can undo it, and promises nothing was deleted — the deny hides OUR surface,
+ *   it does not touch the tenant's own provider account.
  * - `unsupported` — the surface exists but this conference's vendor has no
  *   equivalent (discount codes are a Checkin-only API).
  *
@@ -23,7 +29,7 @@ import { PLATFORM_NAME } from '@/lib/branding/platform'
  * keeps its own header so the organizer stays oriented.
  */
 export type TicketingNoticeState =
-  'unconfigured' | 'unavailable' | 'unsupported'
+  'unconfigured' | 'unavailable' | 'disabled' | 'unsupported'
 
 interface TicketingStateNoticeProps {
   state: TicketingNoticeState
@@ -49,32 +55,44 @@ export function TicketingStateNotice({
   providerLabel,
   surface,
 }: TicketingStateNoticeProps) {
-  const copy: { title: string; description: string } =
-    state === 'unconfigured'
-      ? {
-          title: 'Ticketing is not connected yet',
-          description: `Connect this conference to its ${providerLabel} event in the ticket settings and ${surface} will show up here.`,
-        }
-      : state === 'unsupported'
-        ? {
-            // NAMES ONLY THIS CONFERENCE'S OWN VENDOR. An earlier draft said the
-            // surface was "managed in Checkin.no", which is exactly backwards:
-            // this state fires when the CURRENT provider is the one our
-            // integration cannot drive, so pointing a Tito organizer at
-            // Checkin.no sends them somewhere they have no account.
-            title: `${capitalize(surface)} are not available for ${providerLabel}`,
-            description: `${PLATFORM_NAME} cannot manage ${surface} for ${providerLabel} events. Create and manage them in your ${providerLabel} dashboard instead — ticket sales here are unaffected.`,
-          }
-        : {
-            title: 'Ticketing is not available for your organization',
-            description: `Your organization does not have ${PLATFORM_NAME}'s ticketing integration enabled, so there are no ${surface} to show. Everything else in the admin area works as usual.`,
-          }
+  const copy: Record<
+    TicketingNoticeState,
+    { title: string; description: string }
+  > = {
+    unconfigured: {
+      title: 'Ticketing is not connected yet',
+      description: `Connect this conference to its ${providerLabel} event in the ticket settings and ${surface} will show up here.`,
+    },
+    // NAMES ONLY THIS CONFERENCE'S OWN VENDOR. An earlier draft said the
+    // surface was "managed in Checkin.no", which is exactly backwards: this
+    // state fires when the CURRENT provider is the one our integration cannot
+    // drive, so pointing a Tito organizer at Checkin.no sends them somewhere
+    // they have no account.
+    unsupported: {
+      title: `${capitalize(surface)} are not available for ${providerLabel}`,
+      description: `${PLATFORM_NAME} cannot manage ${surface} for ${providerLabel} events. Create and manage them in your ${providerLabel} dashboard instead — ticket sales here are unaffected.`,
+    },
+    // A DELIBERATE OFF SWITCH, said out loud. This org may have been running
+    // sales through us yesterday, so it gets the fact ("turned off"), the
+    // remedy (whom to ask) and the reassurance that the deny only hid our
+    // surface. NO vendor name here: unlike `unsupported` this state does not
+    // depend on which provider the conference picked, and a denied org that
+    // never chose one would be told about a vendor it has no account with.
+    disabled: {
+      title: 'Ticketing has been turned off for your organization',
+      description: `${PLATFORM_NAME}'s ticketing integration is switched off for your organization, so ${surface} are not shown here. Nothing has been deleted and your ticketing provider account is untouched — ask your ${PLATFORM_NAME} administrator to turn it back on.`,
+    },
+    unavailable: {
+      title: 'Ticketing is not available for your organization',
+      description: `Your organization does not have ${PLATFORM_NAME}'s ticketing integration enabled, so there are no ${surface} to show. Everything else in the admin area works as usual.`,
+    },
+  }
 
   return (
     <EmptyState
       icon={TicketIcon}
-      title={copy.title}
-      description={copy.description}
+      title={copy[state].title}
+      description={copy[state].description}
       className="rounded-lg bg-white p-12 shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:ring-gray-700"
       action={
         state === 'unconfigured' ? (

--- a/src/components/admin/dashboard/widgets/TicketSalesDashboardWidget.tsx
+++ b/src/components/admin/dashboard/widgets/TicketSalesDashboardWidget.tsx
@@ -204,26 +204,39 @@ export function TicketSalesDashboardWidget({
     )
   }
 
-  // Planning & Execution phases: the conference is not bound to a ticketing
-  // event (`result.status === 'unconfigured'`). Kept VENDOR-NEUTRAL — the
-  // binding is Checkin ids OR Tito slugs depending on `ticketingProvider`, so
-  // naming Checkin here would mislead a Tito tenant.
+  // Planning & Execution phases: no sales to show, for one of two reasons that
+  // must NOT tell the same story. `unconfigured` = the conference is not bound
+  // to a ticketing event, which the organizer can fix in settings.
+  // `disabled` = an operator switched ticketing off for this organization, so
+  // there is nothing here for the organizer to fix and pointing them at the
+  // settings would be a dead end. Both stay VENDOR-NEUTRAL — the binding is
+  // Checkin ids OR Tito slugs depending on `ticketingProvider`, so naming
+  // Checkin here would mislead a Tito tenant.
   if (!data) {
+    const turnedOff = result?.status === 'disabled'
     return (
       <div className="flex h-full flex-col">
         <WidgetHeader
           title="Ticket Sales"
-          badge={<PhaseBadge label="Not Configured" variant="amber" />}
+          badge={
+            <PhaseBadge
+              label={turnedOff ? 'Turned Off' : 'Not Configured'}
+              variant="amber"
+            />
+          }
         />
         <div className="flex min-h-0 flex-1 items-center justify-center rounded-lg bg-gray-50 p-6 text-center dark:bg-gray-800">
           <div className="space-y-2">
             <TicketIcon className="mx-auto h-8 w-8 text-gray-400 dark:text-gray-500" />
             <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
-              Ticket integration not configured
+              {turnedOff
+                ? 'Ticketing is turned off'
+                : 'Ticket integration not configured'}
             </p>
             <p className="text-xs text-gray-500 dark:text-gray-400">
-              Connect this conference to its ticketing provider in the ticket
-              settings to enable sales tracking.
+              {turnedOff
+                ? 'Ticketing is switched off for your organization, so sales are not tracked here.'
+                : 'Connect this conference to its ticketing provider in the ticket settings to enable sales tracking.'}
             </p>
           </div>
         </div>

--- a/src/components/admin/dashboard/widgets/TicketSalesDashboardWidget.tsx
+++ b/src/components/admin/dashboard/widgets/TicketSalesDashboardWidget.tsx
@@ -204,39 +204,46 @@ export function TicketSalesDashboardWidget({
     )
   }
 
-  // Planning & Execution phases: no sales to show, for one of two reasons that
-  // must NOT tell the same story. `unconfigured` = the conference is not bound
-  // to a ticketing event, which the organizer can fix in settings.
-  // `disabled` = an operator switched ticketing off for this organization, so
-  // there is nothing here for the organizer to fix and pointing them at the
-  // settings would be a dead end. Both stay VENDOR-NEUTRAL — the binding is
-  // Checkin ids OR Tito slugs depending on `ticketingProvider`, so naming
-  // Checkin here would mislead a Tito tenant.
+  // Planning & Execution phases: no sales to show, for three reasons that must
+  // NOT tell the same story — the same distinction `TicketingStateNotice` draws
+  // on the pages this tile links to. ONLY `unconfigured` sends the organizer to
+  // settings; for the other two there is nothing there that can help, and a
+  // settings nudge would be the dead end #828 set out to remove.
+  // Kept VENDOR-NEUTRAL — the binding is Checkin ids OR Tito slugs depending on
+  // `ticketingProvider`, so naming Checkin here would mislead a Tito tenant.
   if (!data) {
-    const turnedOff = result?.status === 'disabled'
+    const noSalesCopy =
+      result?.status === 'disabled'
+        ? {
+            badge: 'Turned Off',
+            title: 'Ticketing is turned off',
+            body: 'Ticketing is switched off for your organization, so sales are not tracked here.',
+          }
+        : result?.status === 'unavailable'
+          ? {
+              badge: 'Not Available',
+              title: 'Ticketing is not available',
+              body: 'Your organization does not have the ticketing integration, so there are no sales to track.',
+            }
+          : {
+              badge: 'Not Configured',
+              title: 'Ticket integration not configured',
+              body: 'Connect this conference to its ticketing provider in the ticket settings to enable sales tracking.',
+            }
     return (
       <div className="flex h-full flex-col">
         <WidgetHeader
           title="Ticket Sales"
-          badge={
-            <PhaseBadge
-              label={turnedOff ? 'Turned Off' : 'Not Configured'}
-              variant="amber"
-            />
-          }
+          badge={<PhaseBadge label={noSalesCopy.badge} variant="amber" />}
         />
         <div className="flex min-h-0 flex-1 items-center justify-center rounded-lg bg-gray-50 p-6 text-center dark:bg-gray-800">
           <div className="space-y-2">
             <TicketIcon className="mx-auto h-8 w-8 text-gray-400 dark:text-gray-500" />
             <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
-              {turnedOff
-                ? 'Ticketing is turned off'
-                : 'Ticket integration not configured'}
+              {noSalesCopy.title}
             </p>
             <p className="text-xs text-gray-500 dark:text-gray-400">
-              {turnedOff
-                ? 'Ticketing is switched off for your organization, so sales are not tracked here.'
-                : 'Connect this conference to its ticketing provider in the ticket settings to enable sales tracking.'}
+              {noSalesCopy.body}
             </p>
           </div>
         </div>

--- a/src/components/admin/dashboard/widgets/__matrix__/TicketSales.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/TicketSales.matrix.stories.tsx
@@ -12,6 +12,7 @@ import {
   ticketSalesSelling,
   ticketSalesZero,
   ticketSalesUnconfigured,
+  ticketSalesDisabled,
   ticketSalesApiError,
 } from './fixtures'
 import {
@@ -27,6 +28,7 @@ const TYPE = 'ticket-sales'
 const selling = conferenceInPhase('execution', 'ticket-sales/selling')
 const zero = conferenceInPhase('execution', 'ticket-sales/zero')
 const unconfigured = conferenceInPhase('execution', 'ticket-sales/unconfigured')
+const disabled = conferenceInPhase('execution', 'ticket-sales/disabled')
 const apiError = conferenceInPhase('execution', 'ticket-sales/api-error')
 const loading = conferenceInPhase('execution', 'ticket-sales/loading')
 const failing = conferenceInPhase('execution', 'ticket-sales/error')
@@ -47,6 +49,11 @@ setMockActionFor(
   unconfigured._id,
   'fetchTicketSales',
   mockResolved(ticketSalesUnconfigured),
+)
+setMockActionFor(
+  disabled._id,
+  'fetchTicketSales',
+  mockResolved(ticketSalesDisabled),
 )
 setMockActionFor(
   apiError._id,
@@ -100,7 +107,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'State x size matrix for TicketSalesDashboardWidget inside the real WidgetContainer geometry. The fetcher returns a discriminated TicketSalesResult (unconfigured | error | ok), all three arms are covered. Wrapped in a next-themes ThemeProvider because the widget calls useTheme() for ApexCharts theming.',
+          'State x size matrix for TicketSalesDashboardWidget inside the real WidgetContainer geometry. The fetcher returns a discriminated TicketSalesResult (unconfigured | disabled | error | ok), all four arms are covered. Wrapped in a next-themes ThemeProvider because the widget calls useTheme() for ApexCharts theming.',
       },
     },
   },
@@ -150,6 +157,9 @@ export const AllStatesDefaultSize: Story = {
         </WidgetFrame>
         <WidgetFrame label="unconfigured" {...size}>
           <TicketSalesDashboardWidget conference={unconfigured} />
+        </WidgetFrame>
+        <WidgetFrame label="disabled (operator deny)" {...size}>
+          <TicketSalesDashboardWidget conference={disabled} />
         </WidgetFrame>
         <WidgetFrame label="zero sales" {...size}>
           <TicketSalesDashboardWidget conference={zero} />

--- a/src/components/admin/dashboard/widgets/__matrix__/TicketSales.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/TicketSales.matrix.stories.tsx
@@ -12,6 +12,7 @@ import {
   ticketSalesSelling,
   ticketSalesZero,
   ticketSalesUnconfigured,
+  ticketSalesUnavailable,
   ticketSalesDisabled,
   ticketSalesApiError,
 } from './fixtures'
@@ -28,6 +29,7 @@ const TYPE = 'ticket-sales'
 const selling = conferenceInPhase('execution', 'ticket-sales/selling')
 const zero = conferenceInPhase('execution', 'ticket-sales/zero')
 const unconfigured = conferenceInPhase('execution', 'ticket-sales/unconfigured')
+const unavailable = conferenceInPhase('execution', 'ticket-sales/unavailable')
 const disabled = conferenceInPhase('execution', 'ticket-sales/disabled')
 const apiError = conferenceInPhase('execution', 'ticket-sales/api-error')
 const loading = conferenceInPhase('execution', 'ticket-sales/loading')
@@ -49,6 +51,11 @@ setMockActionFor(
   unconfigured._id,
   'fetchTicketSales',
   mockResolved(ticketSalesUnconfigured),
+)
+setMockActionFor(
+  unavailable._id,
+  'fetchTicketSales',
+  mockResolved(ticketSalesUnavailable),
 )
 setMockActionFor(
   disabled._id,
@@ -107,7 +114,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'State x size matrix for TicketSalesDashboardWidget inside the real WidgetContainer geometry. The fetcher returns a discriminated TicketSalesResult (unconfigured | disabled | error | ok), all four arms are covered. Wrapped in a next-themes ThemeProvider because the widget calls useTheme() for ApexCharts theming.',
+          'State x size matrix for TicketSalesDashboardWidget inside the real WidgetContainer geometry. The fetcher returns a discriminated TicketSalesResult (unconfigured | unavailable | disabled | error | ok), all five arms are covered. Wrapped in a next-themes ThemeProvider because the widget calls useTheme() for ApexCharts theming.',
       },
     },
   },
@@ -157,6 +164,9 @@ export const AllStatesDefaultSize: Story = {
         </WidgetFrame>
         <WidgetFrame label="unconfigured" {...size}>
           <TicketSalesDashboardWidget conference={unconfigured} />
+        </WidgetFrame>
+        <WidgetFrame label="unavailable (not entitled)" {...size}>
+          <TicketSalesDashboardWidget conference={unavailable} />
         </WidgetFrame>
         <WidgetFrame label="disabled (operator deny)" {...size}>
           <TicketSalesDashboardWidget conference={disabled} />

--- a/src/components/admin/dashboard/widgets/__matrix__/fixtures.ts
+++ b/src/components/admin/dashboard/widgets/__matrix__/fixtures.ts
@@ -398,6 +398,9 @@ export const ticketSalesUnconfigured: TicketSalesResult = {
   status: 'unconfigured',
 }
 
+/** An operator switched ticketing OFF for this organization (an explicit deny). */
+export const ticketSalesDisabled: TicketSalesResult = { status: 'disabled' }
+
 export const ticketSalesApiError: TicketSalesResult = { status: 'error' }
 
 export const speakerEngagementDense: SpeakerEngagementData = {

--- a/src/components/admin/dashboard/widgets/__matrix__/fixtures.ts
+++ b/src/components/admin/dashboard/widgets/__matrix__/fixtures.ts
@@ -398,6 +398,11 @@ export const ticketSalesUnconfigured: TicketSalesResult = {
   status: 'unconfigured',
 }
 
+/** The organization has no ticketing integration at all (not entitled). */
+export const ticketSalesUnavailable: TicketSalesResult = {
+  status: 'unavailable',
+}
+
 /** An operator switched ticketing OFF for this organization (an explicit deny). */
 export const ticketSalesDisabled: TicketSalesResult = { status: 'disabled' }
 

--- a/src/lib/dashboard/data-types.ts
+++ b/src/lib/dashboard/data-types.ts
@@ -118,11 +118,14 @@ export interface TicketSalesData {
  * Discriminated result for ticket sales so the widget can distinguish
  * "integration not configured" (no ticketing binding on the conference) from
  * "the ticket API call failed" — previously both collapsed to `null` — and both
- * of those from "an operator switched ticketing off for this organization",
- * which is a decision rather than a gap and has no settings fix.
+ * of those from the two states with NO settings fix: `unavailable` (the
+ * organization does not have ticketing at all) and `disabled` (an operator
+ * switched it off). Mirrors `resolveTicketingAdminAccess` state for state, so
+ * the dashboard tile never tells a different story than the page it links to.
  */
 export type TicketSalesResult =
   | { status: 'unconfigured' }
+  | { status: 'unavailable' }
   | { status: 'disabled' }
   | { status: 'error' }
   | { status: 'ok'; data: TicketSalesData }

--- a/src/lib/dashboard/data-types.ts
+++ b/src/lib/dashboard/data-types.ts
@@ -116,11 +116,14 @@ export interface TicketSalesData {
 
 /**
  * Discriminated result for ticket sales so the widget can distinguish
- * "integration not configured" (no checkin IDs on the conference) from
- * "the ticket API call failed" — previously both collapsed to `null`.
+ * "integration not configured" (no ticketing binding on the conference) from
+ * "the ticket API call failed" — previously both collapsed to `null` — and both
+ * of those from "an operator switched ticketing off for this organization",
+ * which is a decision rather than a gap and has no settings fix.
  */
 export type TicketSalesResult =
   | { status: 'unconfigured' }
+  | { status: 'disabled' }
   | { status: 'error' }
   | { status: 'ok'; data: TicketSalesData }
 

--- a/src/lib/features/badges.ts
+++ b/src/lib/features/badges.ts
@@ -28,19 +28,34 @@ import { isPlatformOrganization } from './platform'
  * ── THE GATE TRACKS THE CAPABILITY, IN BOTH DIRECTIONS ──────────────────────
  *
  * This is the MIRROR of the ticketing gate, and the asymmetry is deliberate.
- * Ticketing resolves the provider FIRST so the gate is never STRICTER than the
- * credentials — it must not hide a surface that works. Badges have the opposite
- * hazard: the capability is a single global key pair that exists for exactly one
- * org, so a gate that is LOOSER than issuance would hand an organizer the full
- * management UI for something structurally broken — every Issue, every Rebake,
- * every bulk run failing with the tripwire's message. That is the dead end this
- * whole change exists to remove, re-created by an operator's own grant.
+ * Ticketing resolves the provider before it falls back on the absence of a
+ * decision, so the gate is never STRICTER than the credentials — it must not
+ * hide a surface that works. Badges have the opposite hazard: the capability is
+ * a single global key pair that exists for exactly one org, so a gate that is
+ * LOOSER than issuance would hand an organizer the full management UI for
+ * something structurally broken — every Issue, every Rebake, every bulk run
+ * failing with the tripwire's message. That is the dead end this whole change
+ * exists to remove, re-created by an operator's own grant.
  *
  * So a `badges` override can REVOKE (a deny beats the platform default, like
  * every other feature) but cannot GRANT: the final word is
  * `isPlatformOrganization`, the same comparison `issueBadgeForSpeaker` makes. An
  * `enabled: true` override on a non-platform org is therefore inert TODAY, by
  * design — it is not a way to opt into a broken surface.
+ *
+ * A DENY IS A HARD KILL SWITCH HERE ALREADY, and that is the rule both modules
+ * now state the same way (owner decision, 2026-08-06): the deny is checked
+ * FIRST and the page 404s, so there is no deep link that outlives it. What
+ * capability-tracking protects is the ABSENCE of a decision — never hide a
+ * working surface (ticketing), never open a broken one (badges). An explicit
+ * operator deny is not an absence, so it wins in both modules regardless of
+ * what the capability says.
+ *
+ * NO PLAN TIER, DELIBERATELY. `ticketing` moved to `minPlan: 'pro'` once the
+ * capability became per-tenant (the customer's own provider account); badges
+ * cannot follow until platform#46 makes signing per-tenant, so the registry
+ * entry carries no `minPlan` at all. Selling it first would sell something that
+ * cannot work.
  *
  * WHEN platform#46 SHIPS per-tenant signing keys, this is the ONE line to
  * change: replace `isPlatformOrganization` with "the org has resolvable signing

--- a/src/lib/features/badges.ts
+++ b/src/lib/features/badges.ts
@@ -45,11 +45,23 @@ import { isPlatformOrganization } from './platform'
  *
  * A DENY IS A HARD KILL SWITCH HERE ALREADY, and that is the rule both modules
  * now state the same way (owner decision, 2026-08-06): the deny is checked
- * FIRST and the page 404s, so there is no deep link that outlives it. What
- * capability-tracking protects is the ABSENCE of a decision — never hide a
- * working surface (ticketing), never open a broken one (badges). An explicit
- * operator deny is not an absence, so it wins in both modules regardless of
- * what the capability says.
+ * FIRST and the page 404s, so no UI route outlives it. What capability-tracking
+ * protects is the ABSENCE of a decision — never hide a working surface
+ * (ticketing), never open a broken one (badges). An explicit operator deny is
+ * not an absence, so it wins in both modules regardless of what the capability
+ * says.
+ *
+ * SCOPE, SAID PRECISELY: the deny covers the ORGANIZER-FACING UI. It does not
+ * reach the tRPC layer — `tickets.admin.*` (`getTicketTypes`,
+ * `getDiscountCodes`, `getPaymentDetails`, `create`/`deleteDiscountCode`) are
+ * plain `adminProcedure` and still answer for a denied org, and the discount
+ * ones still WRITE to that tenant's own provider account. An API call is a deep
+ * link; an earlier draft of this comment claimed none outlived the deny, which
+ * was false. Nor does it reach the weekly Slack summary
+ * (`buildTicketSection`), which keeps posting live ticket counts. Whether the
+ * kill switch should mean every organizer-visible output rather than the UI
+ * surface is an open owner decision — do not read this gate as a security
+ * boundary in the meantime.
  *
  * NO PLAN TIER, DELIBERATELY. `ticketing` moved to `minPlan: 'pro'` once the
  * capability became per-tenant (the customer's own provider account); badges

--- a/src/lib/features/enabled.test.ts
+++ b/src/lib/features/enabled.test.ts
@@ -33,6 +33,7 @@ import {
 } from './enabled'
 import { PLATFORM_DEFAULT_FEATURES } from './platform-default'
 import { FEATURES } from './registry'
+import { ORGANIZATION_PLANS } from '@/lib/organization/types'
 
 const PLATFORM_ORG_ID = 'org-platform'
 
@@ -51,13 +52,30 @@ afterEach(() => {
 })
 
 /**
- * NO PLAN TIER SELLS THESE YET. Which tier eventually sells ticketing, badges
- * or workshops is an open owner decision; encoding a guess would hand a
- * customer a surface that cannot work (one WorkOS client, one provider account,
- * one badge signing key pair). This fails the moment someone adds a `minPlan`.
+ * A TIER IS ATTACHED ONLY WHEN THE CAPABILITY IS PER-TENANT.
+ *
+ * #828 shipped this as a blanket "no platform-default feature may have a
+ * `minPlan`", because no tier had been decided for any of them. The owner
+ * decided ticketing's tier on 2026-08-06 — a tenant brings its OWN Checkin/Tito
+ * account, so the integration works for whoever buys it and costs the platform
+ * nothing per tenant — so the guard is narrowed to what it was actually
+ * protecting: `workshops` and `badges`, whose single global credential (one
+ * WorkOS client, one badge signing key pair) still cannot serve a second
+ * tenant. Attaching a tier to either would sell a surface that cannot work.
  */
-describe('the platform-default features stay internal and tier-less', () => {
-  it.each(PLATFORM_DEFAULT_FEATURES)('%s', (id) => {
+describe('platform-default feature tiers track the capability', () => {
+  it('sells ticketing at the ENTRY PAID tier', () => {
+    expect(FEATURES.ticketing.readiness).toBe('ga')
+    expect(FEATURES.ticketing.minPlan).toBe('pro')
+    // "Entry PAID": the ladder's first rung is the free/comped community tier,
+    // so the lowest tier a customer can BUY is the second one.
+    expect(ORGANIZATION_PLANS[0]).toBe('community')
+    expect(FEATURES.ticketing.minPlan).toBe(ORGANIZATION_PLANS[1])
+  })
+
+  const tierless = PLATFORM_DEFAULT_FEATURES.filter((id) => id !== 'ticketing')
+
+  it.each(tierless)('%s stays internal and tier-less', (id) => {
     expect(FEATURES[id].readiness).toBe('internal')
     expect(FEATURES[id].minPlan).toBeUndefined()
   })
@@ -76,12 +94,39 @@ describe('resolveEnabledFeaturesForOrg', () => {
     ).resolves.toEqual(['workshops', 'ticketing', 'badges'])
   })
 
+  /**
+   * The entry paid tier now BUYS ticketing (owner decision, 2026-08-06), so the
+   * nav offers it to a pro tenant that has bought nothing else and configured
+   * nothing yet — the pages then walk it through connecting its own provider
+   * account. `dedicated-email` is the other ga/minPlan-pro registry entry.
+   */
   it('includes plan-granted ga features alongside the platform defaults', async () => {
-    // `dedicated-email` is the ga/minPlan-pro registry entry.
     getOrganizationById.mockResolvedValue(org({ plan: 'pro' }))
     await expect(resolveEnabledFeaturesForOrg('org-A')).resolves.toEqual([
       'dedicated-email',
+      'ticketing',
     ])
+  })
+
+  it('does NOT give ticketing to a community tenant that has not bought it', async () => {
+    getOrganizationById.mockResolvedValue(org({ plan: 'community' }))
+    await expect(resolveEnabledFeaturesForOrg('org-A')).resolves.not.toContain(
+      'ticketing',
+    )
+  })
+
+  /**
+   * The platform org is a TENANT too, and its own organization document may
+   * carry any plan (this deployment's carries none at all). Its implicit grant
+   * must survive the tier decision.
+   */
+  it('keeps ticketing for the platform org on the free community plan', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({ _id: PLATFORM_ORG_ID, plan: 'community' }),
+    )
+    await expect(
+      resolveEnabledFeaturesForOrg(PLATFORM_ORG_ID),
+    ).resolves.toEqual(['workshops', 'ticketing', 'badges'])
   })
 
   it('honours a single override without granting its siblings', async () => {

--- a/src/lib/features/platform-default.ts
+++ b/src/lib/features/platform-default.ts
@@ -2,21 +2,27 @@ import 'server-only'
 import { getOrganizationById } from '@/lib/organization/sanity'
 import { computeEntitlements, hasActiveOverride } from './entitlements'
 import { isPlatformOrganization } from './platform'
+import type { OrganizationFeatureOverride } from '@/lib/organization/types'
 import type { FeatureId } from './registry'
 
 /**
  * The shared resolution shape behind every PLATFORM-DEFAULT feature — the
- * features that are `readiness: 'internal'` in the registry AND carry an
- * implicit grant to the organization configured as `PLATFORM_ORG_ID`.
+ * features that carry an implicit grant to the organization configured as
+ * `PLATFORM_ORG_ID` on top of whatever the registry decides.
  *
  * WHY THE SHAPE EXISTS. `workshops` (#689), `ticketing` (#820) and `badges`
- * (RunKonf/platform#46) each depend on ONE global credential the platform
+ * (RunKonf/platform#46) each began as ONE global credential the platform
  * deployment owns — one WorkOS client, one provider account, one badge signing
- * key pair. None of them works for a second tenant today, and none has a plan
- * tier yet. So the honest default for all three is "the platform org, and
- * whoever an operator explicitly grants", which is exactly what
- * `./workshops.ts` worked out first; this module is that logic, factored out so
- * the three gates cannot drift.
+ * key pair — none of which works for a second tenant on its own. So the honest
+ * default for all three is "the platform org, and whoever an operator
+ * explicitly grants", which is exactly what `./workshops.ts` worked out first;
+ * this module is that logic, factored out so the three gates cannot drift.
+ *
+ * The implicit grant OUTLIVES the internal readiness that motivated it:
+ * `ticketing` is now `readiness: 'ga'` with `minPlan: 'pro'` (a tenant brings
+ * its own provider account), and the platform org must keep it whatever plan
+ * its own organization document happens to carry. That is exactly what rule 3
+ * below preserves.
  *
  * RESOLUTION ORDER — fail-CLOSED at every step:
  *
@@ -25,7 +31,10 @@ import type { FeatureId } from './registry'
  *     it anyway"; this mirrors the org-scoped authz waist's posture.
  *  2. An ACTIVE `featureOverrides` entry wins, in BOTH directions —
  *     `enabled: true` grants it to a pilot org, `enabled: false` revokes it even
- *     from the platform org (rule 3).
+ *     from the platform org (rule 3). An `enabled: false` is an operator's
+ *     deliberate decision and is honoured EVERYWHERE, including by surfaces that
+ *     would otherwise resolve their own capability first; see
+ *     {@link isFeatureExplicitlyDeniedForOrg} and `../tickets/admin-access`.
  *  3. Otherwise the decision is UNSET and the caller applies its own default.
  *     {@link isPlatformDefaultFeatureEnabledForOrg} applies the shared one: the
  *     org whose id is `PLATFORM_ORG_ID` keeps the feature. `./ticketing.ts`
@@ -65,22 +74,58 @@ export async function resolveRegistryEntitlement(
   feature: FeatureId,
 ): Promise<RegistryDecision> {
   if (!orgId) return 'denied'
+  const org = await readOrganizationFor(orgId, feature)
+  if (!org) return 'denied'
+  return decideFromDocument(org, feature)
+}
 
-  // A REJECTED read (transient Sanity failure) must resolve to DENIED like any
-  // other unresolvable org — never propagate, or one flaky read would 500 the
-  // whole admin dashboard through the nav's entitlement lookup.
-  let org
+/**
+ * Whether an OPERATOR has explicitly denied `feature` to this org — an active
+ * `featureOverrides` entry with `enabled: false`, and nothing else.
+ *
+ * WHY THIS IS NOT `resolveRegistryEntitlement(...) === 'denied'`. That function
+ * folds "unresolvable tenant" into `'denied'` so a grant can never leak; here
+ * the answer is used as a KILL SWITCH (see `../tickets/admin-access`), and a
+ * nullish org id, a missing document or a transient REJECTED read are not
+ * operator decisions. Reporting them as a deny would let one flaky Sanity read
+ * blank a working ticketing page — the exact hazard #828's provider-first order
+ * exists to prevent. A real document that is neither entitled nor granted but
+ * carries an active override can only be an explicit `enabled: false`, so
+ * `'denied'` FROM A DOCUMENT is precisely the operator's own decision.
+ */
+export async function isFeatureExplicitlyDeniedForOrg(
+  orgId: string | null | undefined,
+  feature: FeatureId,
+): Promise<boolean> {
+  if (!orgId) return false
+  const org = await readOrganizationFor(orgId, feature)
+  if (!org) return false
+  return decideFromDocument(org, feature) === 'denied'
+}
+
+/**
+ * The org document, or `null` when it cannot be resolved. A REJECTED read
+ * (transient Sanity failure) resolves to `null` like an unknown org — never
+ * propagate, or one flaky read would 500 the whole admin dashboard through the
+ * nav's entitlement lookup.
+ */
+async function readOrganizationFor(orgId: string, feature: FeatureId) {
   try {
-    org = await getOrganizationById(orgId)
+    return await getOrganizationById(orgId)
   } catch (error) {
     console.error(
       `[features] organization read failed for ${orgId}; treating "${feature}" as DISABLED`,
       error,
     )
-    return 'denied'
+    return null
   }
-  if (!org) return 'denied'
+}
 
+/** The registry decision for a RESOLVED org document (see the module doc). */
+function decideFromDocument(
+  org: { plan?: string; featureOverrides?: OrganizationFeatureOverride[] },
+  feature: FeatureId,
+): RegistryDecision {
   const now = new Date()
   if (computeEntitlements(org.plan, org.featureOverrides, now).has(feature)) {
     return 'granted'

--- a/src/lib/features/registry.ts
+++ b/src/lib/features/registry.ts
@@ -41,12 +41,17 @@ import {
  * pattern or the `requireFeature` tRPC middleware.
  *
  * `workshops`, `ticketing` and `badges` share the PLATFORM-DEFAULT shape
- * (`./platform-default.ts`): `internal` readiness plus an implicit grant to the
- * organization configured as `PLATFORM_ORG_ID`, because each depends on a single
- * global credential the platform deployment owns (one WorkOS client, one
- * provider account, one badge signing key pair). NO plan tier maps to them yet —
- * which tier eventually sells ticketing or badges is an open owner decision, and
- * encoding a guess here would grant a customer a surface that cannot work.
+ * (`./platform-default.ts`): an implicit grant to the organization configured as
+ * `PLATFORM_ORG_ID`, because each started as a single global credential the
+ * platform deployment owns (one WorkOS client, one provider account, one badge
+ * signing key pair).
+ *
+ * A TIER IS ATTACHED ONLY WHEN THE CAPABILITY IS PER-TENANT. `ticketing` now
+ * carries `readiness: 'ga'` + `minPlan: 'pro'` — the entry PAID tier — because a
+ * tenant supplies its own provider account, so the feature genuinely works for a
+ * customer who buys it. `workshops` and `badges` stay `internal` with NO
+ * `minPlan`: their single global credential still cannot serve a second tenant,
+ * and encoding a tier there would sell a surface that cannot work.
  */
 
 export const FEATURE_IDS = [
@@ -112,7 +117,17 @@ export const FEATURES: Record<FeatureId, FeatureDefinition> = {
     title: 'Ticketing integration',
     description:
       'Organizer ticket sales, orders, ticket types, discount codes and company breakdown, read live from the conference’s ticketing provider (Checkin.no or Tito).',
-    readiness: 'internal',
+    // SOLD AT THE ENTRY PAID TIER (owner decision, 2026-08-06). A tenant brings
+    // its OWN Checkin.no or Tito account — the integration reads that account
+    // through the tenant's own per-org credentials, so it costs the platform
+    // nothing per tenant. There is no per-tenant cost to recover and no scarce
+    // platform resource to ration, so it belongs in the cheapest paid plan
+    // rather than behind the top of the ladder. The ladder here is community
+    // (the free/comped tier) < pro < enterprise, so the entry PAID tier is
+    // `pro`. Contrast `badges` below, which stays internal because the
+    // capability itself does not exist per-tenant yet.
+    readiness: 'ga',
+    minPlan: 'pro',
   },
   badges: {
     id: 'badges',
@@ -123,6 +138,11 @@ export const FEATURES: Record<FeatureId, FeatureDefinition> = {
     // whose every action fails. Revoking still works.
     description:
       'Issuing and emailing OpenBadges v3.0 credentials to speakers and organizers. Platform organization only until per-tenant signing keys exist (platform#46) — an override can revoke this, but cannot grant it.',
+    // DELIBERATELY NO `minPlan` (owner decision, 2026-08-06). Unlike ticketing,
+    // badges have no per-tenant capability to sell yet: issuance signs with one
+    // global key pair, so per-tenant signing keys (RunKonf/platform#46) must
+    // land before any plan can promise this. Attaching a tier now would sell
+    // something that cannot work.
     readiness: 'internal',
   },
 }

--- a/src/lib/features/ticketing.test.ts
+++ b/src/lib/features/ticketing.test.ts
@@ -31,6 +31,7 @@ vi.mock('@/lib/sanity/client', () => ({
 }))
 
 import {
+  isTicketingDeniedForOrg,
   isTicketingEnabledForOrg,
   isTicketingEnabledForConference,
 } from './ticketing'
@@ -80,12 +81,136 @@ describe('isTicketingEnabledForOrg — fail closed', () => {
     logged.mockRestore()
   })
 
-  /** THE DEMO-ORG CASE: a brand-new tenant, any plan, no credentials. */
-  it('is DISABLED for an ordinary tenant with no credentials, on every plan', async () => {
+  /** THE DEMO-ORG CASE: a brand-new tenant on the free plan, no credentials. */
+  it('is DISABLED for a community tenant that has neither bought it nor got credentials', async () => {
+    getOrganizationById.mockResolvedValue(org({ plan: 'community' }))
+    await expect(isTicketingEnabledForOrg('org-A')).resolves.toBe(false)
+  })
+})
+
+/**
+ * THE TIER (owner decision, 2026-08-06). Ticketing is sold at the entry PAID
+ * tier — `readiness: 'ga'` + `minPlan: 'pro'` — because the tenant brings its
+ * own Checkin/Tito account, so the integration costs the platform nothing per
+ * tenant. The free community tier does not include it.
+ */
+describe('isTicketingEnabledForOrg — the entry paid tier buys it', () => {
+  it('is DISABLED on the free community plan', async () => {
+    getOrganizationById.mockResolvedValue(org({ plan: 'community' }))
+    await expect(isTicketingEnabledForOrg('org-A')).resolves.toBe(false)
+  })
+
+  it('is DISABLED for an org with no plan at all (absent → community)', async () => {
+    getOrganizationById.mockResolvedValue(org())
+    await expect(isTicketingEnabledForOrg('org-A')).resolves.toBe(false)
+  })
+
+  it('is ENABLED on the entry paid plan, with nothing else configured', async () => {
+    getOrganizationById.mockResolvedValue(org({ plan: 'pro' }))
+    await expect(isTicketingEnabledForOrg('org-A')).resolves.toBe(true)
+  })
+
+  it('is ENABLED on every plan ABOVE the entry paid one', async () => {
+    getOrganizationById.mockResolvedValue(org({ plan: 'enterprise' }))
+    await expect(isTicketingEnabledForOrg('org-A')).resolves.toBe(true)
+  })
+
+  /** The plan sells it; an operator can still take it away. */
+  it('is DISABLED on a paid plan when an operator denies it', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        plan: 'pro',
+        featureOverrides: [{ feature: 'ticketing', enabled: false }],
+      }),
+    )
+    await expect(isTicketingEnabledForOrg('org-A')).resolves.toBe(false)
+  })
+
+  /**
+   * THE PLATFORM ORG IS A TENANT TOO and its own document may carry any plan
+   * (this deployment's carries none). The tier decision must not touch it.
+   */
+  it('is ENABLED for the platform org on EVERY plan, including the free one', async () => {
     for (const plan of ['community', 'pro', 'enterprise'] as const) {
-      getOrganizationById.mockResolvedValue(org({ plan }))
-      await expect(isTicketingEnabledForOrg('org-A')).resolves.toBe(false)
+      getOrganizationById.mockResolvedValue(org({ _id: PLATFORM_ORG_ID, plan }))
+      await expect(isTicketingEnabledForOrg(PLATFORM_ORG_ID)).resolves.toBe(
+        true,
+      )
     }
+    getOrganizationById.mockResolvedValue(org({ _id: PLATFORM_ORG_ID }))
+    await expect(isTicketingEnabledForOrg(PLATFORM_ORG_ID)).resolves.toBe(true)
+  })
+})
+
+/**
+ * THE KILL SWITCH (owner decision, 2026-08-06). `isTicketingDeniedForOrg` is
+ * deliberately NARROW: only an operator's own `enabled: false` counts. Widen it
+ * to "not enabled" and a transient Sanity failure would blank a working
+ * ticketing page — the hazard #828's provider-first order exists to prevent.
+ */
+describe('isTicketingDeniedForOrg', () => {
+  it('is TRUE for an active explicit deny — even with own credentials', async () => {
+    stubOwnTicketingSecret('org-A')
+    getOrganizationById.mockResolvedValue(
+      org({ featureOverrides: [{ feature: 'ticketing', enabled: false }] }),
+    )
+    await expect(isTicketingDeniedForOrg('org-A')).resolves.toBe(true)
+  })
+
+  it('is TRUE for the platform org when an operator denies it', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        _id: PLATFORM_ORG_ID,
+        featureOverrides: [{ feature: 'ticketing', enabled: false }],
+      }),
+    )
+    await expect(isTicketingDeniedForOrg(PLATFORM_ORG_ID)).resolves.toBe(true)
+  })
+
+  it('is FALSE for an EXPIRED deny (the override is ignored entirely)', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        featureOverrides: [
+          {
+            feature: 'ticketing',
+            enabled: false,
+            expiresAt: '2020-01-01T00:00:00.000Z',
+          },
+        ],
+      }),
+    )
+    await expect(isTicketingDeniedForOrg('org-A')).resolves.toBe(false)
+  })
+
+  it('is FALSE for a deny aimed at a DIFFERENT feature', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({ featureOverrides: [{ feature: 'badges', enabled: false }] }),
+    )
+    await expect(isTicketingDeniedForOrg('org-A')).resolves.toBe(false)
+  })
+
+  it('is FALSE for an org that simply never had ticketing', async () => {
+    getOrganizationById.mockResolvedValue(org({ plan: 'community' }))
+    await expect(isTicketingDeniedForOrg('org-A')).resolves.toBe(false)
+  })
+
+  /**
+   * NOT-A-DENY, three ways. A deny is an operator DECISION; an unresolvable
+   * tenant is an accident, and must not be able to kill a page.
+   */
+  it('is FALSE for a nullish org id, an unknown document and a REJECTED read', async () => {
+    await expect(isTicketingDeniedForOrg(null)).resolves.toBe(false)
+    await expect(isTicketingDeniedForOrg(undefined)).resolves.toBe(false)
+    await expect(isTicketingDeniedForOrg('')).resolves.toBe(false)
+    expect(getOrganizationById).not.toHaveBeenCalled()
+
+    getOrganizationById.mockResolvedValue(null)
+    await expect(isTicketingDeniedForOrg('org-missing')).resolves.toBe(false)
+
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {})
+    getOrganizationById.mockRejectedValue(new Error('sanity unavailable'))
+    await expect(isTicketingDeniedForOrg('org-A')).resolves.toBe(false)
+    logged.mockRestore()
   })
 })
 

--- a/src/lib/features/ticketing.ts
+++ b/src/lib/features/ticketing.ts
@@ -2,6 +2,7 @@ import 'server-only'
 import { perOrgSecretsStore } from '@/lib/secrets/store'
 import {
   conferenceOrgId,
+  isFeatureExplicitlyDeniedForOrg,
   resolveRegistryEntitlement,
   type ConferenceTenant,
 } from './platform-default'
@@ -20,42 +21,58 @@ import { isPlatformOrganization } from './platform'
  * configure". This gate lets the nav hide the section and lets the pages say so
  * honestly instead.
  *
- * WHAT COUNTS AS ENABLED (in order):
+ * WHAT COUNTS AS ENABLED — THREE STATES, NOT TWO, resolved in this order:
  *
- *  1. The registry decision (plan + `featureOverrides`) when it is not unset —
- *     an operator grant enables it, an explicit deny revokes it even from the
- *     platform org. See `./platform-default`.
- *  2. Otherwise: the platform org (it owns the env account), OR any org that has
- *     its OWN ticketing credentials in the per-org secret store. Rule 2's second
- *     half deliberately MIRRORS `resolveTicketingCredentials`: an org the secret
- *     seam can serve has a working ticketing integration, so hiding the surface
- *     from it would hide something that works. The gate must never be stricter
- *     than the credential resolver it fronts.
+ *  1. An explicit operator DENY (an active `featureOverrides` entry with
+ *     `enabled: false`) → DISABLED, and disabled EVERYWHERE: the nav, the ⌘K
+ *     destination and the pages themselves, even for an org whose own
+ *     credentials resolve, even for the platform org. See "a deny is a kill
+ *     switch" below.
+ *  2. An explicit GRANT (or a plan that reaches `minPlan`), OR the platform org
+ *     (it owns the env account), OR any org that has its OWN ticketing
+ *     credentials in the per-org secret store → ENABLED. That last clause
+ *     deliberately MIRRORS `resolveTicketingCredentials`: an org the secret seam
+ *     can serve has a working ticketing integration, so hiding the surface from
+ *     it would hide something that works. The gate must never be stricter than
+ *     the credential resolver it fronts.
  *  3. Otherwise DISABLED — including every unresolvable org (fail closed).
  *
- * NOT A SECURITY BOUNDARY, AND A DENY IS NOT A KILL SWITCH. Credential
- * isolation is enforced in `resolveTicketingCredentials` and the tRPC tenancy
- * guards; this decides what an organizer is SHOWN. One consequence is worth
- * stating outright, because it looks like a bug and is not: because the ticket
- * pages resolve the PROVIDER first (`resolveTicketingAdminAccess`), an explicit
- * `enabled: false` override on an org that HAS working credentials hides the nav
- * entry and the ⌘K destination but does not blank a deep link — that conference
- * still renders its real sales data. That is the deliberate price of "never hide
- * a surface that works", and it is safe precisely because this is presentation:
- * revoking actual ACCESS means removing the org's credentials (or its binding),
- * which the seam above already governs. If a nav-level deny should ever become a
- * hard kill switch, that is a design change to make on purpose, not a comment to
- * quietly reinterpret here.
+ * ── A DENY *IS* A KILL SWITCH; AN ABSENT GRANT IS NOT ───────────────────────
  *
- * The `ticketing` registry entry is `readiness: 'internal'` with NO `minPlan` —
- * which plan tier eventually sells ticketing is an open owner decision, so
- * nothing but an explicit grant (or owning credentials) turns it on.
+ * #828 shipped the second half of that sentence and left the first half
+ * undone: because the ticket pages resolved the PROVIDER first, an
+ * `enabled: false` override hid the nav entry but a deep link still rendered a
+ * credentialed org's real sales data. That gap is closed (owner decision,
+ * 2026-08-06) — `resolveTicketingAdminAccess` now asks about an explicit deny
+ * BEFORE it resolves the provider.
+ *
+ * This REFINES #828's rule rather than reversing it, and the distinction is the
+ * whole point: the ABSENCE of a grant must never hide a surface that works —
+ * that is what provider-first protects, and rule 2 above still enforces it. An
+ * EXPLICIT DENY is not an absence; it is an operator's deliberate decision, and
+ * a decision that only half-applies is worse than either answer. So ordering
+ * matters and is load-bearing: deny beats credentials, credentials beat the
+ * absence of a decision. Swap those and you re-create the exact dead end #828
+ * removed.
+ *
+ * NOT A SECURITY BOUNDARY, still. Credential isolation is enforced in
+ * `resolveTicketingCredentials` and the tRPC tenancy guards; this decides what
+ * an organizer is SHOWN. A deny is an operator's off switch for the SURFACE, not
+ * a way to revoke access to a vendor account we never held.
+ *
+ * THE PLAN TIER. The `ticketing` registry entry is `readiness: 'ga'` with
+ * `minPlan: 'pro'` — the entry paid tier — because a tenant brings its own
+ * provider account (see `./registry`). Rule 2's other clauses stand alongside
+ * it: the platform org keeps ticketing on whatever plan its own document
+ * carries, and a community org with its own credentials keeps the surface that
+ * already works for it.
  *
  * CONTRAST WITH `./badges.ts`, whose gate is the MIRROR of this one: badges'
  * capability exists for exactly one org, so there a grant cannot reach past the
  * capability. Ticketing is never stricter than its credentials; badges are never
- * looser than theirs. Both rules say the same thing — the gate tracks what the
- * surface can actually do.
+ * looser than theirs — except that an explicit deny overrides BOTH, because an
+ * operator's decision is not a capability question. Both rules say the same
+ * thing — absent a decision, the gate tracks what the surface can actually do.
  */
 
 /** The registry id this module gates. */
@@ -92,6 +109,23 @@ export async function isTicketingEnabledForOrg(
   if (!orgId) return false
   if (await isPlatformOrganization(orgId)) return true
   return hasOwnTicketingCredentials(orgId)
+}
+
+/**
+ * Whether an OPERATOR has explicitly switched ticketing OFF for this org — the
+ * kill switch of rule 1, and the one question a caller must ask BEFORE it
+ * resolves the provider.
+ *
+ * This is deliberately narrower than `!isTicketingEnabledForOrg`: it is true
+ * only for an active `enabled: false` override on a resolvable organization.
+ * A nullish org, a missing document and a rejected read are NOT denies (see
+ * `isFeatureExplicitlyDeniedForOrg`) — treating them as such would let one flaky
+ * Sanity read blank a working ticketing page.
+ */
+export async function isTicketingDeniedForOrg(
+  orgId: string | null | undefined,
+): Promise<boolean> {
+  return isFeatureExplicitlyDeniedForOrg(orgId, TICKETING_FEATURE)
 }
 
 /**

--- a/src/lib/tickets/admin-access.test.ts
+++ b/src/lib/tickets/admin-access.test.ts
@@ -1,8 +1,8 @@
 /**
  * @vitest-environment node
  *
- * The three-way ticketing state the admin pages render — empty ≠ error ≠
- * unavailable. Everything the app owns runs for real: the provider resolver
+ * The ticketing state the admin pages render — empty ≠ error ≠ unavailable ≠
+ * turned off. Everything the app owns runs for real: the provider resolver
  * (including its Tito branch), the credential seam and the feature gate. Only
  * the org document read is supplied; no network is involved because the state
  * is decided before any provider call.
@@ -169,18 +169,128 @@ describe('resolveTicketingAdminAccess — unavailable (not entitled)', () => {
     })
     expect(access.state).toBe('unavailable')
   })
+})
 
-  it('is UNAVAILABLE when an explicit DENY revokes ticketing from the platform org', async () => {
+/**
+ * THE KILL SWITCH (owner decision, 2026-08-06). #828 hid the nav entry on a
+ * deny but left the deep link rendering real sales data for any org whose own
+ * credentials resolved, because the provider was resolved first. A deny is an
+ * operator's deliberate decision and must be honoured on the page too, so it is
+ * now asked FIRST — and reported as its own state, because "not available for
+ * your organization" is a lie to an org that had it yesterday.
+ */
+describe('resolveTicketingAdminAccess — disabled (an explicit operator deny)', () => {
+  const denied = (orgId: string) =>
+    org({
+      _id: orgId,
+      featureOverrides: [{ feature: 'ticketing', enabled: false }],
+    })
+
+  /** THE BUG THIS CLOSES: credentials no longer rescue a denied org. */
+  it('is DISABLED for a fully bound, fully credentialed tenant', async () => {
+    vi.stubEnv(
+      'TENANT_SECRETS_JSON',
+      JSON.stringify({
+        [TENANT_ORG_ID]: { ticketing: { apiKey: 'tenant-key' } },
+      }),
+    )
+    getOrganizationById.mockResolvedValue(denied(TENANT_ORG_ID))
+    const access = await resolveTicketingAdminAccess(
+      checkinBound(TENANT_ORG_ID),
+    )
+    expect(access).toEqual({ state: 'disabled', providerType: 'checkin' })
+  })
+
+  it('is DISABLED for the platform org’s own bound Checkin conference', async () => {
+    getOrganizationById.mockResolvedValue(denied(PLATFORM_ORG_ID))
+    const access = await resolveTicketingAdminAccess(
+      checkinBound(PLATFORM_ORG_ID),
+    )
+    expect(access.state).toBe('disabled')
+  })
+
+  it('is DISABLED for a paid plan the deny overrides', async () => {
     getOrganizationById.mockResolvedValue(
       org({
-        _id: PLATFORM_ORG_ID,
+        plan: 'pro',
         featureOverrides: [{ feature: 'ticketing', enabled: false }],
       }),
     )
+    const access = await resolveTicketingAdminAccess(
+      checkinBound(TENANT_ORG_ID),
+    )
+    expect(access.state).toBe('disabled')
+  })
+
+  it('is DISABLED, not unavailable, when the conference is not bound either', async () => {
+    getOrganizationById.mockResolvedValue(denied(PLATFORM_ORG_ID))
     const access = await resolveTicketingAdminAccess({
       organization: { _ref: PLATFORM_ORG_ID },
     })
-    expect(access.state).toBe('unavailable')
+    expect(access.state).toBe('disabled')
+  })
+
+  it('ignores an EXPIRED deny — the surface comes back', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({
+        _id: PLATFORM_ORG_ID,
+        featureOverrides: [
+          {
+            feature: 'ticketing',
+            enabled: false,
+            expiresAt: '2020-01-01T00:00:00.000Z',
+          },
+        ],
+      }),
+    )
+    const access = await resolveTicketingAdminAccess(
+      checkinBound(PLATFORM_ORG_ID),
+    )
+    expect(access.state).toBe('ready')
+  })
+})
+
+/**
+ * THE #828 GUARANTEE, WHICH MUST NOT REGRESS: the ABSENCE of a grant is not a
+ * deny. Only an operator's explicit `enabled: false` blocks a page; everything
+ * else that fails to resolve leaves a working surface working.
+ */
+describe('resolveTicketingAdminAccess — no decision still never hides what works', () => {
+  beforeEach(() => {
+    vi.stubEnv(
+      'TENANT_SECRETS_JSON',
+      JSON.stringify({
+        [TENANT_ORG_ID]: { ticketing: { apiKey: 'tenant-key' } },
+      }),
+    )
+  })
+
+  it('is READY for a credentialed tenant with NO entitlement decision at all', async () => {
+    getOrganizationById.mockResolvedValue(org({ plan: 'community' }))
+    const access = await resolveTicketingAdminAccess(
+      checkinBound(TENANT_ORG_ID),
+    )
+    expect(access.state).toBe('ready')
+  })
+
+  it('is READY for a credentialed tenant whose org read REJECTS', async () => {
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {})
+    getOrganizationById.mockRejectedValue(new Error('sanity unavailable'))
+    const access = await resolveTicketingAdminAccess(
+      checkinBound(TENANT_ORG_ID),
+    )
+    expect(access.state).toBe('ready')
+    logged.mockRestore()
+  })
+
+  it('is READY for a credentialed tenant with a deny on a DIFFERENT feature', async () => {
+    getOrganizationById.mockResolvedValue(
+      org({ featureOverrides: [{ feature: 'badges', enabled: false }] }),
+    )
+    const access = await resolveTicketingAdminAccess(
+      checkinBound(TENANT_ORG_ID),
+    )
+    expect(access.state).toBe('ready')
   })
 })
 

--- a/src/lib/tickets/admin-access.ts
+++ b/src/lib/tickets/admin-access.ts
@@ -1,5 +1,8 @@
 import 'server-only'
-import { isTicketingEnabledForOrg } from '@/lib/features/ticketing'
+import {
+  isTicketingDeniedForOrg,
+  isTicketingEnabledForOrg,
+} from '@/lib/features/ticketing'
 import {
   conferenceProviderType,
   resolveTicketingProvider,
@@ -31,10 +34,23 @@ import {
  *     make those pages work at all, and pointing it at conference settings was
  *     a dead end.
  *
- * ORDER MATTERS. The provider is resolved FIRST, so a conference that is
- * genuinely configured renders its data regardless of what the entitlement says
- * — the gate must never hide a surface that works. Only when nothing resolves
- * does the entitlement decide WHICH honest empty state to show.
+ * ORDER MATTERS — THREE STATES, NOT TWO:
+ *
+ *  1. An explicit operator DENY (`featureOverrides: enabled: false`) is a HARD
+ *     KILL SWITCH and is checked BEFORE anything else, so it blocks the page and
+ *     not merely the nav entry (owner decision, 2026-08-06). Credentials do not
+ *     rescue a denied org, and no provider call is made on its behalf.
+ *  2. Otherwise the provider is resolved NEXT, so a conference that is genuinely
+ *     configured renders its data regardless of what the entitlement says — the
+ *     gate must never hide a working surface behind the mere ABSENCE of a grant.
+ *  3. Only when nothing resolves does the entitlement decide WHICH honest empty
+ *     state to show.
+ *
+ * Steps 1 and 2 must stay in this order in both directions: move the deny after
+ * the provider and it stops being a kill switch (the #828 bug this refines);
+ * widen step 1 from "explicit deny" to "not enabled" and a flaky org read or an
+ * un-granted-but-credentialed tenant loses a page that works — the exact hazard
+ * #828 fixed. `isTicketingDeniedForOrg` is narrow on purpose.
  */
 export type TicketingAdminAccess =
   /** Bound, credentialed and ready — the caller may fetch. */
@@ -49,11 +65,28 @@ export type TicketingAdminAccess =
   | { state: 'unconfigured'; providerType: TicketingProviderType }
   /** Not entitled: ticketing is not available to this organization at all. */
   | { state: 'unavailable'; providerType: TicketingProviderType }
+  /**
+   * Explicitly switched OFF by an operator. Distinct from `unavailable` because
+   * the organizer's situation is different: this org may well have a working
+   * integration and have been using it, so "not available for your
+   * organization" would read as a lie. The copy says it was turned off and who
+   * to ask; see `TicketingStateNotice`.
+   */
+  | { state: 'disabled'; providerType: TicketingProviderType }
 
 export async function resolveTicketingAdminAccess(
   conference: ConferenceTicketingBinding,
 ): Promise<TicketingAdminAccess> {
   const providerType = conferenceProviderType(conference)
+  const orgId = conference.organization?._ref
+
+  // 1. THE KILL SWITCH, ahead of the provider: an operator's explicit deny is a
+  // decision, not a missing grant, and it must be honoured on the page as well
+  // as in the nav.
+  if (await isTicketingDeniedForOrg(orgId)) {
+    return { state: 'disabled', providerType }
+  }
+
   const ticketing = await resolveTicketingProvider(conference)
 
   if (ticketing.configured) {


### PR DESCRIPTION
Applies two owner decisions (2026-08-06) on top of the gating that landed in #828.

## 1. Ticketing moves to the entry PAID tier; badges stay internal

`ticketing` is now `readiness: 'ga'` with `minPlan: 'pro'`. The plan ladder in this codebase is **community (free/comped) < pro < enterprise** (`ORGANIZATION_PLANS`), so the lowest tier a customer can actually *buy* is `pro` — that is the entry paid tier, and the registry comment says so.

Why the entry tier and not the top of the ladder: a tenant brings its **own** Checkin.no/Tito account, and the integration reads that account through the tenant's own per-org credentials. There is no per-tenant cost to recover and no scarce platform resource to ration.

`badges` keeps `readiness: 'internal'` and **no** `minPlan`: issuance still signs with one global key pair, so until per-tenant signing keys exist (RunKonf/platform#46) a tier would sell something that cannot work.

#828's guard ("no platform-default feature may carry a `minPlan`") is **narrowed, not deleted**: it now asserts ticketing has the entry-tier `minPlan` and that every *other* platform-default feature (workshops, badges) stays internal and tier-less — so it still fails the moment someone attaches a tier to badges.

The platform org is unaffected by the tier: it is also a tenant and its own document may carry any plan (this deployment's carries none), so its implicit grant is asserted across every plan including community.

## 2. An explicit `enabled: false` is now a HARD kill switch

Before: a deny hid the nav entry, but the ticket pages resolved the provider first, so a deep link still rendered live sales for an org whose own credentials resolved. That is now closed at the page gate **and** in the dashboard action.

**Three states, ordered, and the order is load-bearing:**

1. explicit operator deny → **blocked** (nav, pages, dashboard tile; credentials do not rescue it, no provider call is made)
2. explicit grant / plan / platform org / own credentials → **allowed**
3. no decision + own credentials → **allowed** — the #828 guarantee, untouched

This refines #828's principle rather than reversing it, and both module docs now say so: the *absence* of a grant must never hide a surface that works (what provider-first protects); an *explicit deny* is a deliberate decision and is honoured everywhere. `isTicketingDeniedForOrg` is deliberately narrow — a nullish org, a missing document or a rejected Sanity read is **not** a deny, or one flaky read could blank a working page.

### Copy for a denied-but-credentialed org

A new `disabled` notice state, separate from `unavailable`: \"not available for your organization\" is true for a tenant that never had ticketing and a lie to one whose sales pages worked yesterday. The new copy is **\"Ticketing has been turned off for your organization\"** — it names what happened, says nothing was deleted and the tenant's own provider account is untouched, and points at the administrator. No settings link (there is nothing to fix). It deliberately does **not** name a vendor: unlike `unsupported`, this state does not depend on which provider the conference picked. The dashboard tile gets the matching `Turned Off` variant instead of telling a denied org to go and connect a provider. The tile now mirrors the resolver state for state (also from review): an org that is **not entitled at all** gets a `Not Available` variant rather than being nudged at settings it cannot use — a dead end that mattered little while ticketing was override-only and matters now that a plan sells it.

### Surfaces checked

- `/admin/tickets`, `/orders`, `/types`, `/discount`, `/companies` — all five go through `resolveTicketingAdminAccess`; all five blank on a deny.
- Admin nav / ⌘K — already honoured the deny via the registry decision; now covered by a test.
- Ticket-sales dashboard widget — its server action resolved the provider directly and would have kept streaming sales for a denied org; it now goes through the same three-state resolution.
- Badge surfaces (`/admin/speakers/badge`, the Manage Badges entry) already check the deny first and 404 — no change needed; the badges module doc now states the shared rule.
- `/admin/budget` — reads live ticket **income** straight from the provider, so a deny left it printing real revenue after every ticket page had gone dark (caught in review). Now resolved through the same gate; anything short of `ready` falls back to the manually-entered actuals, as an unconfigured provider always did.

Deliberately **not** gated: the public ticket-sales section (`src/lib/tickets/public.ts`), workshop eligibility and speaker-ticket issuance, and the status-page probe. Those are attendee-facing or backend flows, not organizer display surfaces — switching an organizer's admin view off should not break a live conference's public ticket sales. Flagging in case the owner wants a wider blast radius.

## Tests

`pnpm test`: **501 files / 7177 tests passing** (baseline on `main`: 500 / 7142 — +35 tests). `pnpm typecheck` clean, `npx prettier --check .` clean, `npx eslint .` 0 errors / 209 warnings (identical to the baseline).

Sabotage-proven, each guard removed by exact string, test failures observed, restored green:

| guard removed | tests that failed |
| --- | --- |
| the deny check in `resolveTicketingAdminAccess` | 11 (5 pages + provider-never-called + 4 resolver + dashboard action) |
| deny widened to \"not enabled\" (the #828 hazard) | 13 (incl. READY-on-rejected-read, and every unavailable state) |
| `minPlan: 'pro'` on ticketing | 18 |
| `readiness: 'ga'` reverted to internal | 5 |
| a `minPlan` added to **badges** | 1 (the narrowed guard still bites) |
| the platform-org grant in `ticketing.ts` | 15 |
| unresolvable org treated as a deny | 2 |
| the budget page's deny check | 1 |
| the tile's `unavailable` mapping | 1 |

Storybook: new `TicketingStateNotice` `Disabled` story and a `disabled (operator deny)` cell in the TicketSales matrix, both captured with `pnpm shoot` and inspected — no clipping, consistent with the neighbouring states.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves ticketing to the Pro plan and changes explicit ticketing denials into a deny-first kill switch.
- Adds a distinct disabled state and organizer-facing copy for ticket pages and the sales dashboard.
- Routes dashboard sales through the shared ticketing access resolver.
- Updates feature registry behavior and tests for paid-plan grants, platform defaults, and explicit denials.

<h3>Confidence Score: 4/5</h3>

The remaining budget-page bypass must be fixed before merging because a denied organization can still retrieve live ticket-income data there.

The new deny-first resolver works for migrated ticket pages and dashboard sales, but the budget page continues to resolve the provider directly and therefore does not honor the newly promised hard kill switch.

**Files Needing Attention:** src/lib/tickets/admin-access.ts and src/app/(admin)/admin/budget/page.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/tickets/admin-access.ts | Adds the deny-first disabled state correctly for its callers, but the centralized resolver is not used by the budget ticket-income surface. |
| src/app/(admin)/admin/actions.ts | Migrates dashboard ticket sales to the shared access resolver and returns a distinct disabled result before fetching provider data. |
| src/lib/features/platform-default.ts | Factors organization reads and adds a narrow explicit-deny query while preserving fail-closed ordinary entitlement behavior. |
| src/lib/features/registry.ts | Makes ticketing generally available at the Pro plan while preserving the platform organization’s separate implicit grant. |
| src/components/admin/TicketingStateNotice.tsx | Adds exhaustive disabled-state copy distinct from unavailable and unconfigured states. |
| src/components/admin/dashboard/widgets/TicketSalesDashboardWidget.tsx | Correctly renders the new disabled result as turned off rather than directing organizers to provider settings. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Request[Admin ticket surface] --> Deny{Explicit deny?}
  Deny -->|Yes| Disabled[Return disabled without provider call]
  Deny -->|No| Provider{Provider configured?}
  Provider -->|Yes| Ready[Fetch ticket data]
  Provider -->|No| Entitled{Entitled by plan, grant, or platform default?}
  Entitled -->|Yes| Unconfigured[Show connection guidance]
  Entitled -->|No| Unavailable[Show unavailable notice]
  Budget[Budget page] --> DirectProvider[Direct provider resolution]
  DirectProvider -. bypasses deny .-> Ready
```

<sub>Reviews (1): Last reviewed commit: ["feat(admin): sell ticketing at the entry..."](https://github.com/cloudnativebergen/website/commit/b9d8f15c91891a9447f758e9a4dc5a3a89a61b65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50496049)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Ticketing and contract e-signature](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/ticketing-signing.md)
- Knowledge Base — [Admin Dashboard](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/admin-dashboard.md)

<!-- /greptile_comment -->

