### PR TITLE
fix(admin): stop four fresh-tenant admin surfaces from stating things that are not true

### DIFF
--- a/__tests__/app/day-one/fresh-tenant-admin-surfaces.test.tsx
+++ b/__tests__/app/day-one/fresh-tenant-admin-surfaces.test.tsx
@@ -1,0 +1,304 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * DAY ONE, ADMIN SIDE — the counterpart to `fresh-tenant-public-pages.test.tsx`
+ * (#830), which covered the public half of the same class of bug.
+ *
+ * `@/lib/onboarding/create.ts` provisions a tenant with a title, an org
+ * reference, a city/country, contact addresses and a starter format list —
+ * and NO dates of any kind: no `startDate`/`endDate`, no `cfpStartDate`/
+ * `cfpEndDate`. Four admin surfaces responded to that silence by stating
+ * something false rather than nothing (#838):
+ *
+ *   - the CFP Health widget subtracted an absent `cfpStartDate` from now and
+ *     printed the result, so its tiles read "Opens In: NaNd" / "Duration: NaNd";
+ *   - the Proposal Pipeline widget derived CFP status from the same absent
+ *     dates, and because `NaN > 0` is false it reported the CFP as **Open** on a
+ *     conference whose CFP had never been configured;
+ *   - `/admin/schedule` offered "Create First Track", took a track name, and
+ *     dropped it — with zero conference dates there are zero days, so the
+ *     reducer had nothing to attach it to and returned state unchanged;
+ *   - `/admin/marketing` printed a hardcoded 'June 15, 2025' on a DOWNLOADABLE
+ *     share graphic, so the invented date could leave the product entirely.
+ *
+ * Every conference here is built by the REAL `buildOnboardingDocuments`, so if
+ * provisioning ever starts seeding dates the premise guard below fails loudly
+ * instead of this suite quietly testing a scenario that no longer exists.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import type { ReactElement } from 'react'
+
+/* -------------------------------------------------------------------------- */
+/* Module boundaries                                                          */
+/* -------------------------------------------------------------------------- */
+
+const fetchCFPHealthMock = vi.fn()
+const fetchProposalPipelineMock = vi.fn()
+vi.mock('@/app/(admin)/admin/actions', () => ({
+  fetchCFPHealth: () => fetchCFPHealthMock(),
+  fetchProposalPipeline: () => fetchProposalPipelineMock(),
+}))
+
+const {
+  saveMutateAsync,
+  actionMutateAsync,
+  pollInvalidate,
+  pollSetData,
+  routerRefresh,
+} = vi.hoisted(() => ({
+  saveMutateAsync: vi.fn(),
+  actionMutateAsync: vi.fn(),
+  pollInvalidate: vi.fn(),
+  pollSetData: vi.fn(),
+  routerRefresh: vi.fn(),
+}))
+
+vi.mock('@/lib/trpc/client', () => ({
+  api: {
+    useUtils: () => ({
+      schedule: {
+        admin: {
+          pollVersions: { invalidate: pollInvalidate, setData: pollSetData },
+        },
+      },
+    }),
+    schedule: {
+      save: { useMutation: () => ({ mutateAsync: saveMutateAsync }) },
+      action: { useMutation: () => ({ mutateAsync: actionMutateAsync }) },
+      admin: { pollVersions: { useQuery: () => ({ data: undefined }) } },
+    },
+  },
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: routerRefresh }),
+}))
+
+/* Marketing page boundaries. */
+const getConferenceForCurrentDomainMock = vi.fn()
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    getConferenceForCurrentDomainMock(...args),
+}))
+vi.mock('@/lib/auth', () => ({ getAuthSession: vi.fn(async () => ({})) }))
+vi.mock('@/lib/authz/organizer', () => ({
+  isOrganizerForCurrentOrg: vi.fn(async () => true),
+}))
+vi.mock('@/lib/gallery/sanity', () => ({
+  getFeaturedGalleryImages: vi.fn(async () => []),
+}))
+vi.mock('@/lib/proposal/server', () => ({
+  getProposals: vi.fn(async () => ({ proposals: [], proposalsError: null })),
+}))
+vi.mock('@/components/CloudNativePattern', () => ({
+  CloudNativePattern: () => <div data-testid="pattern" />,
+}))
+vi.mock('@/components/admin/MemeGeneratorWithDownload', () => ({
+  MemeGeneratorWithDownload: () => <div data-testid="meme-generator" />,
+}))
+vi.mock('@/components/admin/PhotoGalleryWithDownload', () => ({
+  PhotoGalleryWithDownload: () => <div data-testid="photo-gallery" />,
+}))
+vi.mock('@/components/common/DownloadableImage', () => ({
+  DownloadableImage: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="downloadable">{children}</div>
+  ),
+}))
+
+import { buildOnboardingDocuments } from '@/lib/onboarding/create'
+import type { Conference } from '@/lib/conference/types'
+import { CFPHealthWidget } from '@/components/admin/dashboard/widgets/CFPHealthWidget'
+import { ProposalPipelineWidget } from '@/components/admin/dashboard/widgets/ProposalPipelineWidget'
+import { ScheduleEditor } from '@/components/admin/schedule/ScheduleEditor'
+import {
+  scheduleReducer,
+  initScheduleEditorState,
+  NO_SCHEDULE_DAY_ERROR,
+} from '@/lib/schedule/reducer'
+import MarketingPage from '@/app/(admin)/admin/marketing/page'
+
+/* -------------------------------------------------------------------------- */
+/* The document provisioning actually writes                                  */
+/* -------------------------------------------------------------------------- */
+
+const FRESH_HOST = 'brand-new.konf.run'
+
+function provisionedConferenceDocument() {
+  let key = 0
+  const { conference } = buildOnboardingDocuments(
+    {
+      organization: {
+        name: 'Brand New Events',
+        slug: 'brand-new-events',
+        contactEmail: 'hello@brand-new.example',
+      },
+      conference: {
+        title: 'Brand New Conf',
+        city: 'Bergen',
+        country: 'Norway',
+      },
+      organizer: { name: 'Ada Organizer', email: 'ada@brand-new.example' },
+      domains: [FRESH_HOST],
+    },
+    {
+      organizationId: 'org-fresh',
+      conferenceId: 'conf-fresh',
+      speakerId: 'speaker-fresh',
+      mintKey: () => `key-${++key}`,
+    },
+    null,
+  )
+  return conference
+}
+
+/** The same document, typed the way every admin surface consumes it. */
+const freshConference = () =>
+  provisionedConferenceDocument() as unknown as Conference
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  fetchCFPHealthMock.mockResolvedValue(null)
+  fetchProposalPipelineMock.mockResolvedValue(null)
+  getConferenceForCurrentDomainMock.mockResolvedValue({
+    conference: { ...freshConference(), sponsors: [] },
+    error: null,
+  })
+})
+
+afterEach(cleanup)
+
+describe('what provisioning actually writes', () => {
+  it('omits every date and the whole CFP window, but does seed formats', () => {
+    // Guards the premise of this entire suite: if it fails, the surfaces below
+    // are no longer being tested against an unconfigured conference and the
+    // suite should be rewritten, not patched.
+    const doc = provisionedConferenceDocument()
+    expect(doc.startDate).toBeUndefined()
+    expect(doc.endDate).toBeUndefined()
+    expect(doc.cfpStartDate).toBeUndefined()
+    expect(doc.cfpEndDate).toBeUndefined()
+    expect(doc.cfpNotifyDate).toBeUndefined()
+    expect(doc.programDate).toBeUndefined()
+    // #833 DID start seeding session formats, so an "everything is absent"
+    // premise would be wrong today. Formats are present; dates are not.
+    expect(doc.formats).toEqual([
+      'lightning_10',
+      'presentation_25',
+      'presentation_45',
+    ])
+    expect(doc.title).toBe('Brand New Conf')
+  })
+})
+
+describe('CFP Health widget on an unconfigured conference', () => {
+  it('renders no NaN countdown', async () => {
+    render(<CFPHealthWidget conference={freshConference()} />)
+
+    expect(await screen.findByText(/No CFP dates set yet/i)).toBeTruthy()
+    expect(document.body.textContent).not.toMatch(/NaN/)
+    // The countdown tiles must be gone entirely, not merely blanked.
+    expect(screen.queryByText(/Opens In/i)).toBeNull()
+    expect(screen.queryByText(/Duration/i)).toBeNull()
+  })
+
+  it('points at the setting that would fill the gap', async () => {
+    render(<CFPHealthWidget conference={freshConference()} />)
+
+    const link = await screen.findByRole('link', { name: /Set CFP dates/i })
+    expect(link.getAttribute('href')).toBe('/admin/settings')
+  })
+})
+
+describe('Proposal Pipeline widget on an unconfigured conference', () => {
+  it('does not claim the CFP is open', async () => {
+    render(<ProposalPipelineWidget conference={freshConference()} />)
+
+    expect(await screen.findByText(/No CFP dates set yet/i)).toBeTruthy()
+    // "Open" was an affirmative false statement about a CFP nobody configured.
+    expect(screen.queryByText('Open')).toBeNull()
+    expect(document.body.textContent).not.toMatch(/NaN/)
+  })
+
+  it('points at the setting that would fill the gap', async () => {
+    render(<ProposalPipelineWidget conference={freshConference()} />)
+
+    const link = await screen.findByRole('link', { name: /Set CFP dates/i })
+    expect(link.getAttribute('href')).toBe('/admin/settings')
+  })
+})
+
+describe('/admin/schedule on an unconfigured conference', () => {
+  // `getScheduleData()` builds one editor day per date between the conference
+  // start and end, so no dates means no days at all.
+  const noDays = {
+    officialSchedules: [],
+    draftSchedules: [],
+    conference: freshConference(),
+    initialProposals: [],
+  }
+
+  it('never offers a track creation that has nowhere to land', () => {
+    render(<ScheduleEditor {...noDays} />)
+
+    expect(screen.queryByRole('button', { name: /Create First Track/i })).toBe(
+      null,
+    )
+    expect(screen.queryByRole('button', { name: /Create first track/i })).toBe(
+      null,
+    )
+    expect(screen.queryByText(/No tracks created yet/i)).toBeNull()
+  })
+
+  it('says which setting is missing and links to it', () => {
+    render(<ScheduleEditor {...noDays} />)
+
+    expect(screen.getByText(/Set your conference dates first/i)).toBeTruthy()
+    const link = screen.getByRole('link', {
+      name: /conference settings/i,
+    })
+    expect(link.getAttribute('href')).toBe('/admin/settings')
+  })
+
+  it('surfaces an edit that cannot be applied instead of swallowing it', () => {
+    // Last line of defence: even if some path did dispatch an edit with no day
+    // loaded, the reducer must not silently discard it.
+    const state = initScheduleEditorState({ schedules: [], proposals: [] })
+    const next = scheduleReducer(state, {
+      type: 'addTrack',
+      track: { trackTitle: 'Main Stage', trackDescription: '', talks: [] },
+    })
+
+    expect(next.ui.error).toBe(NO_SCHEDULE_DAY_ERROR)
+    expect(next.ui.error).toMatch(/no dates yet/i)
+    expect(next.schedules).toHaveLength(0)
+  })
+})
+
+describe('/admin/marketing share assets on an unconfigured conference', () => {
+  /** Render the page, then switch to the downloadable conference promo tab. */
+  async function renderPromoTab() {
+    render((await MarketingPage()) as ReactElement)
+    fireEvent.click(screen.getByRole('tab', { name: /Conference Promo/i }))
+  }
+
+  it('never prints an invented date on a downloadable graphic', async () => {
+    await renderPromoTab()
+
+    expect(document.body.textContent).not.toContain('June 15, 2025')
+    expect(document.body.textContent).not.toMatch(/2025/)
+  })
+
+  it('omits the date line rather than leaving it blank', async () => {
+    await renderPromoTab()
+
+    // The promo card's metadata row is a date chip and a location chip sharing
+    // one span style. With no start date the card must carry the location chip
+    // ALONE — a share graphic with an empty date slot is its own defect.
+    const chips = Array.from(
+      document.querySelectorAll('span.font-inter.text-lg'),
+    )
+    expect(chips).toHaveLength(1)
+    expect(chips[0].textContent).toBe('Bergen, Norway')
+  })
+})

--- a/__tests__/app/day-one/fresh-tenant-admin-surfaces.test.tsx
+++ b/__tests__/app/day-one/fresh-tenant-admin-surfaces.test.tsx
@@ -191,6 +191,24 @@ describe('what provisioning actually writes', () => {
   })
 })
 
+/**
+ * The icons in all three new day-one states are decorative: the heading, the
+ * message and the link already carry the meaning, so an exposed icon is pure
+ * screen-reader noise. `WidgetEmptyState` hides its icon slot structurally;
+ * the schedule editor's state leans on the `aria-hidden="true"` Heroicons emit
+ * by default. This asserts the OUTCOME, so either mechanism changing is caught.
+ */
+function assertNoExposedDecorativeIcon() {
+  const svgs = Array.from(document.querySelectorAll('svg'))
+  expect(svgs.length).toBeGreaterThan(0)
+  for (const svg of svgs) {
+    const hidden =
+      svg.getAttribute('aria-hidden') === 'true' ||
+      svg.closest('[aria-hidden="true"]') !== null
+    expect(hidden).toBe(true)
+  }
+}
+
 describe('CFP Health widget on an unconfigured conference', () => {
   it('renders no NaN countdown', async () => {
     render(<CFPHealthWidget conference={freshConference()} />)
@@ -207,6 +225,13 @@ describe('CFP Health widget on an unconfigured conference', () => {
 
     const link = await screen.findByRole('link', { name: /Set CFP dates/i })
     expect(link.getAttribute('href')).toBe('/admin/settings')
+  })
+
+  it('does not announce its decorative icon', async () => {
+    render(<CFPHealthWidget conference={freshConference()} />)
+
+    await screen.findByText(/No CFP dates set yet/i)
+    assertNoExposedDecorativeIcon()
   })
 })
 
@@ -225,6 +250,13 @@ describe('Proposal Pipeline widget on an unconfigured conference', () => {
 
     const link = await screen.findByRole('link', { name: /Set CFP dates/i })
     expect(link.getAttribute('href')).toBe('/admin/settings')
+  })
+
+  it('does not announce its decorative icon', async () => {
+    render(<ProposalPipelineWidget conference={freshConference()} />)
+
+    await screen.findByText(/No CFP dates set yet/i)
+    assertNoExposedDecorativeIcon()
   })
 })
 
@@ -258,6 +290,12 @@ describe('/admin/schedule on an unconfigured conference', () => {
       name: /conference settings/i,
     })
     expect(link.getAttribute('href')).toBe('/admin/settings')
+  })
+
+  it('does not announce its decorative icons', () => {
+    render(<ScheduleEditor {...noDays} />)
+
+    assertNoExposedDecorativeIcon()
   })
 
   it('surfaces an edit that cannot be applied instead of swallowing it', () => {

--- a/__tests__/components/admin/dashboard/widget-shared.test.tsx
+++ b/__tests__/components/admin/dashboard/widget-shared.test.tsx
@@ -8,7 +8,10 @@
  */
 import { render, screen } from '@testing-library/react'
 
-import { WidgetBody } from '@/components/admin/dashboard/widgets/shared'
+import {
+  WidgetBody,
+  WidgetEmptyState,
+} from '@/components/admin/dashboard/widgets/shared'
 
 describe('WidgetBody', () => {
   it('renders children inside the scroll region', () => {
@@ -36,5 +39,26 @@ describe('WidgetBody', () => {
     const region = container.firstElementChild!
     expect(region.className).toContain('flex flex-col gap-2')
     expect(region.className).toContain('overflow-y-auto')
+  })
+})
+
+describe('WidgetEmptyState', () => {
+  it('keeps the message in the accessibility tree', () => {
+    render(<WidgetEmptyState message="No CFP dates set yet" />)
+    expect(screen.getByText('No CFP dates set yet')).toBeInTheDocument()
+  })
+
+  it('hides an ARBITRARY decorative icon, not just a Heroicon', () => {
+    // Heroicons already carry `aria-hidden="true"`, so relying on the caller's
+    // icon to hide itself only works by convention. `icon` is a ReactNode, so
+    // the guard has to live on the slot: a hand-rolled SVG must be hidden too.
+    const { container } = render(
+      <WidgetEmptyState
+        message="No CFP dates set yet"
+        icon={<svg data-testid="bare-icon" />}
+      />,
+    )
+    const icon = container.querySelector('[data-testid="bare-icon"]')!
+    expect(icon.closest('[aria-hidden="true"]')).not.toBeNull()
   })
 })

--- a/src/app/(admin)/admin/marketing/page.tsx
+++ b/src/app/(admin)/admin/marketing/page.tsx
@@ -234,9 +234,14 @@ export default async function MarketingPage() {
   const conferenceDomain = conference.domains[0]
   const qrCodeUrl = await generateQRCode(programUrl, conferenceDomain, 80)
 
+  // These cards are DOWNLOADABLE share assets, so anything printed on them can
+  // leave the product entirely. A conference provisioned without dates used to
+  // get a hardcoded 'June 15, 2025' here — an invented date on a graphic
+  // destined for social media. Undefined instead: every consumer below omits
+  // the date line rather than inventing or placeholding one.
   const eventDate = conference.startDate
     ? formatConferenceDateLong(conference.startDate)
-    : 'June 15, 2025'
+    : undefined
 
   const conferenceDescription = getFirstParagraph(conference.description)
   const fallbackDescription =
@@ -356,10 +361,12 @@ export default async function MarketingPage() {
                   {conference.title}
                 </h1>
                 <div className="mb-6 flex flex-col items-center justify-center gap-4 sm:flex-row sm:gap-8">
-                  <div className="flex items-center gap-2 text-white/90">
-                    <CalendarDaysIcon className="h-5 w-5" />
-                    <span className="font-inter text-lg">{eventDate}</span>
-                  </div>
+                  {eventDate && (
+                    <div className="flex items-center gap-2 text-white/90">
+                      <CalendarDaysIcon className="h-5 w-5" />
+                      <span className="font-inter text-lg">{eventDate}</span>
+                    </div>
+                  )}
                   <div className="flex items-center gap-2 text-white/90">
                     <MapPinIcon className="h-5 w-5" />
                     <span className="font-inter text-lg">

--- a/src/components/admin/dashboard/widgets/CFPHealthWidget.tsx
+++ b/src/components/admin/dashboard/widgets/CFPHealthWidget.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import { formatChartMonth, formatChartDay } from '@/lib/time'
 import {
   DocumentTextIcon,
@@ -54,6 +55,28 @@ export function CFPHealthWidget({ conference, config }: CFPHealthWidgetProps) {
 
   // Phase-specific views
   if (phase === 'initialization' && conference) {
+    // A freshly provisioned conference carries NO cfp window (see
+    // `buildOnboardingDocuments`), and this view is a pure countdown off those
+    // dates: `new Date(undefined).getTime()` is NaN, so the tiles below used to
+    // read "NaNd". Say the window is unset instead of computing against it.
+    if (!conference.cfpStartDate || !conference.cfpEndDate) {
+      return (
+        <WidgetEmptyState
+          message="No CFP dates set yet"
+          icon={
+            <CalendarIcon className="mx-auto mb-2 h-12 w-12 text-gray-400" />
+          }
+        >
+          <Link
+            href="/admin/settings"
+            className="mt-2 inline-block text-xs font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+          >
+            Set CFP dates
+          </Link>
+        </WidgetEmptyState>
+      )
+    }
+
     return (
       <div className="flex h-full flex-col">
         <WidgetHeader

--- a/src/components/admin/dashboard/widgets/ProposalPipelineWidget.tsx
+++ b/src/components/admin/dashboard/widgets/ProposalPipelineWidget.tsx
@@ -6,6 +6,7 @@ import {
   PaperAirplaneIcon,
   CalendarIcon,
 } from '@heroicons/react/24/outline'
+import Link from 'next/link'
 import { getCurrentPhase } from '@/lib/conference/phase'
 import { BaseWidgetProps } from '@/lib/dashboard/types'
 import { type ProposalPipelineData } from '@/lib/dashboard/data-types'
@@ -43,6 +44,29 @@ export function ProposalPipelineWidget({
 
   // Phase-specific: Initialization/Planning - Show CFP setup guidance
   if (phase === 'initialization' || phase === 'planning') {
+    // A freshly provisioned conference has no cfp window at all (see
+    // `buildOnboardingDocuments`). The countdown below is NaN then, and because
+    // `NaN > 0` is false the "CFP Opens" tile fell through to the literal
+    // string "Open" — the widget ASSERTED that a CFP nobody has configured was
+    // accepting submissions. Never derive a status from an unset window.
+    if (conference && (!conference.cfpStartDate || !conference.cfpEndDate)) {
+      return (
+        <WidgetEmptyState
+          message="No CFP dates set yet"
+          icon={
+            <CalendarIcon className="mx-auto mb-2 h-12 w-12 text-gray-400" />
+          }
+        >
+          <Link
+            href="/admin/settings"
+            className="mt-2 inline-block text-xs font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+          >
+            Set CFP dates
+          </Link>
+        </WidgetEmptyState>
+      )
+    }
+
     const now = new Date()
     const daysUntilCFP = conference
       ? Math.ceil(

--- a/src/components/admin/dashboard/widgets/__matrix__/CFPHealth.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/CFPHealth.matrix.stories.tsx
@@ -8,6 +8,7 @@ import {
 } from './mock-admin-actions'
 import {
   conferenceInPhase,
+  freshlyProvisionedConference,
   cfpHealthDense,
   cfpHealthSparse,
   cfpHealthZero,
@@ -31,6 +32,9 @@ const failing = conferenceInPhase('planning', 'cfp-health/error')
 const init = conferenceInPhase('initialization', 'cfp-health/init')
 const execution = conferenceInPhase('execution', 'cfp-health/execution')
 const post = conferenceInPhase('post-conference', 'cfp-health/post')
+// Day one: provisioning writes no CFP window, so this lands in `initialization`
+// with nothing to count down to. Used to render "Opens In: NaNd".
+const dayOne = freshlyProvisionedConference('cfp-health/day-one')
 
 setMockActionFor(dense._id, 'fetchCFPHealth', mockResolved(cfpHealthDense))
 setMockActionFor(sparse._id, 'fetchCFPHealth', mockResolved(cfpHealthSparse))
@@ -41,6 +45,7 @@ setMockActionFor(failing._id, 'fetchCFPHealth', mockFailure)
 setMockActionFor(init._id, 'fetchCFPHealth', mockResolved(cfpHealthZero))
 setMockActionFor(execution._id, 'fetchCFPHealth', mockResolved(cfpHealthDense))
 setMockActionFor(post._id, 'fetchCFPHealth', mockResolved(cfpHealthDense))
+setMockActionFor(dayOne._id, 'fetchCFPHealth', mockResolved(null))
 
 const meta = {
   title: 'Systems/Proposals/Admin/Dashboard/Matrix/CFPHealth',
@@ -107,6 +112,9 @@ export const AllStatesDefaultSize: Story = {
         <WidgetFrame label="dense" {...size}>
           <CFPHealthWidget conference={dense} />
         </WidgetFrame>
+        <WidgetFrame label="day one (no CFP dates)" {...size}>
+          <CFPHealthWidget conference={dayOne} />
+        </WidgetFrame>
         <WidgetFrame label="no conference" {...size}>
           <CFPHealthWidget />
         </WidgetFrame>
@@ -122,6 +130,9 @@ export const Phases: Story = {
       <MatrixGrid>
         <WidgetFrame label="initialization (preparing card)" {...size}>
           <CFPHealthWidget conference={init} />
+        </WidgetFrame>
+        <WidgetFrame label="initialization, day one (no CFP dates)" {...size}>
+          <CFPHealthWidget conference={dayOne} />
         </WidgetFrame>
         <WidgetFrame label="planning (operational)" {...size}>
           <CFPHealthWidget conference={dense} />

--- a/src/components/admin/dashboard/widgets/__matrix__/ProposalPipeline.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/ProposalPipeline.matrix.stories.tsx
@@ -8,6 +8,7 @@ import {
 } from './mock-admin-actions'
 import {
   conferenceInPhase,
+  freshlyProvisionedConference,
   proposalPipelineDense,
   proposalPipelineSparse,
 } from './fixtures'
@@ -33,6 +34,9 @@ const planningEarly = conferenceInPhase(
   'proposal-pipeline/planning',
 )
 const post = conferenceInPhase('post-conference', 'proposal-pipeline/post')
+// Day one: provisioning writes no CFP window. This cell used to report the CFP
+// as "Open" on a conference whose CFP had never been configured.
+const dayOne = freshlyProvisionedConference('proposal-pipeline/day-one')
 
 setMockActionFor(
   dense._id,
@@ -58,6 +62,7 @@ setMockActionFor(
   'fetchProposalPipeline',
   mockResolved(proposalPipelineDense),
 )
+setMockActionFor(dayOne._id, 'fetchProposalPipeline', mockResolved(null))
 
 const meta = {
   title: 'Systems/Proposals/Admin/Dashboard/Matrix/ProposalPipeline',
@@ -113,6 +118,9 @@ export const AllStatesDefaultSize: Story = {
         <WidgetFrame label="dense" {...size}>
           <ProposalPipelineWidget conference={dense} />
         </WidgetFrame>
+        <WidgetFrame label="day one (no CFP dates)" {...size}>
+          <ProposalPipelineWidget conference={dayOne} />
+        </WidgetFrame>
         <WidgetFrame label="no conference" {...size}>
           <ProposalPipelineWidget />
         </WidgetFrame>
@@ -128,6 +136,9 @@ export const Phases: Story = {
       <MatrixGrid>
         <WidgetFrame label="initialization (CFP setup card)" {...size}>
           <ProposalPipelineWidget conference={init} />
+        </WidgetFrame>
+        <WidgetFrame label="initialization, day one (no CFP dates)" {...size}>
+          <ProposalPipelineWidget conference={dayOne} />
         </WidgetFrame>
         <WidgetFrame label="planning + early submissions" {...size}>
           <ProposalPipelineWidget conference={planningEarly} />

--- a/src/components/admin/dashboard/widgets/__matrix__/fixtures.ts
+++ b/src/components/admin/dashboard/widgets/__matrix__/fixtures.ts
@@ -9,6 +9,7 @@
  * (counts, day totals, trend data) are fixed numbers in the data fixtures.
  */
 
+import { buildOnboardingDocuments } from '@/lib/onboarding/create'
 import type { Conference } from '@/lib/conference/types'
 import type { ConferencePhase } from '@/lib/conference/phase'
 import type {
@@ -124,6 +125,49 @@ export function conferenceInPhase(
     topics: [],
     ...PHASE_DATES[phase](),
   }
+}
+
+/**
+ * The conference a freshly provisioned tenant ACTUALLY has — built by the real
+ * `buildOnboardingDocuments`, not hand-written.
+ *
+ * Every `conferenceInPhase` fixture above supplies a full set of dates, so no
+ * matrix cell ever exercised the shape an organizer sees on day one: no
+ * `cfpStartDate`, no `cfpEndDate`, no `startDate`/`endDate`. That gap is why
+ * "Opens In: NaNd" and a CFP reported as "Open" survived the widget matrix
+ * (#838). Sourcing this from the provisioning builder means the day-one cells
+ * follow provisioning automatically — when it starts seeding a field, these
+ * cells stop testing the unconfigured state and the premise guard in
+ * `__tests__/app/day-one/fresh-tenant-admin-surfaces.test.tsx` fails loudly.
+ */
+export function freshlyProvisionedConference(id: string): Conference {
+  let key = 0
+  const { conference } = buildOnboardingDocuments(
+    {
+      organization: {
+        name: 'Brand New Events',
+        slug: 'brand-new-events',
+        contactEmail: 'hello@brand-new.example',
+      },
+      conference: {
+        title: 'Brand New Conf',
+        city: 'Bergen',
+        country: 'Norway',
+      },
+      organizer: { name: 'Ada Organizer', email: 'ada@brand-new.example' },
+      domains: ['brand-new.konf.run'],
+    },
+    {
+      organizationId: 'org-fresh',
+      conferenceId: id,
+      speakerId: 'speaker-fresh',
+      mintKey: () => `key-${++key}`,
+    },
+    null,
+  )
+  // The builder returns an untyped Sanity document stub; widgets read it as a
+  // Conference. The missing fields ARE the point of this fixture.
+  return conference as unknown as Conference
 }
 
 /* ---------- Widget data fixtures ---------- */

--- a/src/components/admin/dashboard/widgets/shared.tsx
+++ b/src/components/admin/dashboard/widgets/shared.tsx
@@ -24,6 +24,10 @@ export function WidgetSkeleton() {
 
 interface WidgetEmptyStateProps {
   message: string
+  /**
+   * DECORATIVE only — the `message` (and any children) must carry the meaning
+   * on their own, because the icon is hidden from assistive tech below.
+   */
   icon?: React.ReactNode
   children?: React.ReactNode
 }
@@ -36,7 +40,17 @@ export function WidgetEmptyState({
   return (
     <div className="flex h-full min-h-32 items-center justify-center rounded-lg bg-gray-50 p-6 text-center dark:bg-gray-800">
       <div>
-        {icon && <div className="mx-auto mb-2">{icon}</div>}
+        {/* `aria-hidden` sits on the WRAPPER, not the icon: `icon` is an
+            arbitrary ReactNode, so a caller can pass a hand-rolled SVG that
+            carries no `aria-hidden` of its own (Heroicons set theirs by
+            default, but nothing enforces Heroicons here). Hiding the container
+            makes the decorative contract structural, and covers every existing
+            and future caller for free rather than one attribute per call site. */}
+        {icon && (
+          <div className="mx-auto mb-2" aria-hidden="true">
+            {icon}
+          </div>
+        )}
         <p className="text-sm text-gray-500 dark:text-gray-400">{message}</p>
         {children}
       </div>

--- a/src/components/admin/schedule/ScheduleEditor.stories.tsx
+++ b/src/components/admin/schedule/ScheduleEditor.stories.tsx
@@ -107,6 +107,27 @@ const mockConference: Conference = {
   ],
 }
 
+/** What provisioning actually writes on day one: no dates, no CFP window. */
+const undatedConference: Conference = {
+  _id: 'conf-fresh',
+  title: 'Brand New Conf',
+  organizer: 'Brand New Events',
+  city: 'Bergen',
+  country: 'Norway',
+  cfpEmail: 'hello@brand-new.example',
+  sponsorEmail: 'hello@brand-new.example',
+  contactEmail: 'hello@brand-new.example',
+  registrationEnabled: false,
+  organizers: [],
+  domains: ['brand-new.konf.run'],
+  formats: [
+    Format.lightning_10,
+    Format.presentation_25,
+    Format.presentation_45,
+  ],
+  topics: [],
+} as unknown as Conference
+
 const scheduledProposals = [
   createMockProposal({
     _id: 'scheduled-1',
@@ -294,6 +315,25 @@ export const EmptySchedule: Story = {
       description: {
         story:
           'An empty schedule with no tracks. Shows the empty state with a prompt to create the first track. All proposals appear in the unassigned sidebar.',
+      },
+    },
+  },
+}
+
+export const NoConferenceDates: Story = {
+  args: {
+    // `getScheduleData()` builds one day per conference date, so a conference
+    // provisioned without dates yields ZERO days — the day-one shape.
+    officialSchedules: [],
+    draftSchedules: [],
+    conference: undatedConference,
+    initialProposals: allProposals,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A conference that has no start/end date yet. There is no day to build on, so the editor refuses to offer track creation at all (the old "Create First Track" button opened a modal that silently discarded the name) and points at settings instead.',
       },
     },
   },

--- a/src/components/admin/schedule/ScheduleEditor.stories.tsx
+++ b/src/components/admin/schedule/ScheduleEditor.stories.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/lib/proposal/types'
 import { toEditorSchedule } from '@/lib/schedule/types'
 import { convertStringToPortableTextBlocks } from '@/lib/proposal'
+import { buildOnboardingDocuments } from '@/lib/onboarding/create'
 
 const createMockProposal = (
   overrides: Partial<ProposalExisting> & { _id: string; title: string },
@@ -108,33 +109,45 @@ const mockConference: Conference = {
 }
 
 /**
- * A stand-in shaped like a day-one tenant — the point being the ABSENT
- * start/end dates, which is what drives this story's zero-day editor state.
- * It is hand-written, not derived from `buildOnboardingDocuments`, and omits
- * fields provisioning does write (organizer reference, `visibility`); the
- * editor never reads any of them. The provisioning-sourced fixture lives in
- * `__tests__/app/day-one/fresh-tenant-admin-surfaces.test.tsx`, which is where
- * the premise that these dates are unset is actually guarded.
+ * A day-one tenant, built by the REAL provisioning builder (same pattern as
+ * `InfoContent.stories.tsx` from #830) so the story cannot drift from what
+ * provisioning writes — no hand-written approximation to fall out of date.
+ * The absent start/end dates are what drive this story's zero-day state.
+ *
+ * FOLLOW-UP: this call is now the third copy (here, `InfoContent.stories.tsx`,
+ * and `widgets/__matrix__/fixtures.ts`). #841 is extracting the test-side
+ * equivalent to `__tests__/testdata/onboarding.ts`; the story-side copies
+ * should collapse onto one shared helper once that lands.
  */
-const undatedConference: Conference = {
-  _id: 'conf-fresh',
-  title: 'Brand New Conf',
-  organizer: 'Brand New Events',
-  city: 'Bergen',
-  country: 'Norway',
-  cfpEmail: 'hello@brand-new.example',
-  sponsorEmail: 'hello@brand-new.example',
-  contactEmail: 'hello@brand-new.example',
-  registrationEnabled: false,
-  organizers: [],
-  domains: ['brand-new.konf.run'],
-  formats: [
-    Format.lightning_10,
-    Format.presentation_25,
-    Format.presentation_45,
-  ],
-  topics: [],
-} as unknown as Conference
+function undatedConference(): Conference {
+  let key = 0
+  const { conference } = buildOnboardingDocuments(
+    {
+      organization: {
+        name: 'Brand New Events',
+        slug: 'brand-new-events',
+        contactEmail: 'hello@brand-new.example',
+      },
+      conference: {
+        title: 'Brand New Conf',
+        city: 'Bergen',
+        country: 'Norway',
+      },
+      organizer: { name: 'Ada Organizer', email: 'ada@brand-new.example' },
+      domains: ['brand-new.konf.run'],
+    },
+    {
+      organizationId: 'org-fresh',
+      conferenceId: 'conf-fresh',
+      speakerId: 'speaker-fresh',
+      mintKey: () => `key-${++key}`,
+    },
+    null,
+  )
+  // The builder returns an untyped Sanity document stub; the editor consumes a
+  // Conference. The fields it does NOT write are the point of this fixture.
+  return conference as unknown as Conference
+}
 
 const scheduledProposals = [
   createMockProposal({
@@ -334,7 +347,7 @@ export const NoConferenceDates: Story = {
     // provisioned without dates yields ZERO days — the day-one shape.
     officialSchedules: [],
     draftSchedules: [],
-    conference: undatedConference,
+    conference: undatedConference(),
     initialProposals: allProposals,
   },
   parameters: {

--- a/src/components/admin/schedule/ScheduleEditor.stories.tsx
+++ b/src/components/admin/schedule/ScheduleEditor.stories.tsx
@@ -107,7 +107,15 @@ const mockConference: Conference = {
   ],
 }
 
-/** What provisioning actually writes on day one: no dates, no CFP window. */
+/**
+ * A stand-in shaped like a day-one tenant — the point being the ABSENT
+ * start/end dates, which is what drives this story's zero-day editor state.
+ * It is hand-written, not derived from `buildOnboardingDocuments`, and omits
+ * fields provisioning does write (organizer reference, `visibility`); the
+ * editor never reads any of them. The provisioning-sourced fixture lives in
+ * `__tests__/app/day-one/fresh-tenant-admin-surfaces.test.tsx`, which is where
+ * the premise that these dates are unset is actually guarded.
+ */
 const undatedConference: Conference = {
   _id: 'conf-fresh',
   title: 'Brand New Conf',

--- a/src/components/admin/schedule/ScheduleEditor.tsx
+++ b/src/components/admin/schedule/ScheduleEditor.tsx
@@ -46,7 +46,12 @@ import { AddTrackModal } from './AddTrackModal'
 import { ScheduleProvider } from './ScheduleContext'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { api } from '@/lib/trpc/client'
-import { PlusIcon } from '@heroicons/react/24/outline'
+import {
+  PlusIcon,
+  CalendarIcon,
+  Cog6ToothIcon,
+} from '@heroicons/react/24/outline'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 
 interface ScheduleEditorProps {
@@ -147,6 +152,42 @@ const EmptyState = React.memo(
   ),
 )
 EmptyState.displayName = 'EmptyState'
+
+/**
+ * Shown when the editor has NO days at all.
+ *
+ * `getScheduleData()` builds one day per date between the conference start and
+ * end, so a conference provisioned without dates (see `buildOnboardingDocuments`)
+ * produces zero days. The board used to render its ordinary "No tracks created
+ * yet" empty state anyway, complete with a Create First Track button — which
+ * opened the modal, took a track name, and dropped it on the floor, because the
+ * reducer has no day to attach it to. This state replaces that button entirely,
+ * so the discard is unreachable rather than merely explained.
+ */
+const NoConferenceDatesState = React.memo(() => (
+  <div className="flex h-[calc(100vh-5rem)] items-center justify-center p-6">
+    <div className="max-w-md text-center">
+      <CalendarIcon className="mx-auto h-10 w-10 text-gray-400 dark:text-gray-500" />
+      <h2 className="mt-3 text-lg font-semibold text-gray-900 dark:text-white">
+        Set your conference dates first
+      </h2>
+      <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+        The schedule is built one day at a time, so there is nothing to build
+        until the conference has a start and end date. Add them in settings and
+        this page opens on day one.
+      </p>
+      <Link
+        href="/admin/settings"
+        className={`mt-5 ${PRIMARY_BUTTON}`}
+        prefetch={false}
+      >
+        <Cog6ToothIcon className="h-4 w-4" />
+        Go to conference settings
+      </Link>
+    </div>
+  </div>
+))
+NoConferenceDatesState.displayName = 'NoConferenceDatesState'
 
 const TracksGrid = ({
   tracks,
@@ -776,6 +817,13 @@ export function ScheduleEditor({
     }),
     useSensor(KeyboardSensor),
   )
+
+  // No days means no conference dates (see NoConferenceDatesState). Bail BEFORE
+  // either layout so neither the desktop board nor the mobile view can offer an
+  // edit that has nowhere to land. Every hook above has already run.
+  if (state.schedules.length === 0) {
+    return <NoConferenceDatesState />
+  }
 
   if (!isDesktop) {
     return (

--- a/src/lib/schedule/reducer.ts
+++ b/src/lib/schedule/reducer.ts
@@ -109,6 +109,26 @@ function withDayResult(
   return { ...state, schedules, dirty }
 }
 
+/**
+ * Shown when a mutating action arrives with NO day loaded — which happens on a
+ * conference that has no start/end date, because `generateConferenceDates()`
+ * then yields zero days and `schedules` is empty.
+ *
+ * Every edit case below used to `return state` in that situation, so the editor
+ * accepted a new track name and discarded it in total silence. The UI now
+ * refuses to render the editing affordances at all when there are no days (see
+ * `ScheduleEditor`), but the reducer is the last line: any path that still
+ * dispatches an edit gets a visible error rather than a no-op.
+ */
+export const NO_SCHEDULE_DAY_ERROR =
+  'This conference has no dates yet, so there is no day to put this on. Set the conference start and end dates in settings first — your change was not saved.'
+
+/** A mutating action with no active day: surface it, never swallow it. */
+function withoutActiveDay(state: ScheduleEditorState): ScheduleEditorState {
+  if (state.ui.error === NO_SCHEDULE_DAY_ERROR) return state
+  return { ...state, ui: { ...state.ui, error: NO_SCHEDULE_DAY_ERROR } }
+}
+
 export function scheduleReducer(
   state: ScheduleEditorState,
   action: ScheduleAction,
@@ -117,7 +137,7 @@ export function scheduleReducer(
 
   switch (action.type) {
     case 'moveProposal': {
-      if (!current) return state
+      if (!current) return withoutActiveDay(state)
       const otherIds = ops.scheduledProposalIdsExcludingDay(
         state.schedules,
         state.currentDayIndex,
@@ -134,7 +154,7 @@ export function scheduleReducer(
     }
 
     case 'moveService': {
-      if (!current) return state
+      if (!current) return withoutActiveDay(state)
       return withDayResult(
         state,
         ops.moveServiceSession(current, action.dragItem, action.dropPosition),
@@ -142,17 +162,17 @@ export function scheduleReducer(
     }
 
     case 'addTrack': {
-      if (!current) return state
+      if (!current) return withoutActiveDay(state)
       return withDayResult(state, ops.addTrack(current, action.track))
     }
 
     case 'removeTrack': {
-      if (!current) return state
+      if (!current) return withoutActiveDay(state)
       return withDayResult(state, ops.removeTrack(current, action.trackIndex))
     }
 
     case 'updateTrack': {
-      if (!current) return state
+      if (!current) return withoutActiveDay(state)
       return withDayResult(
         state,
         ops.updateTrack(current, action.trackIndex, action.track),
@@ -160,7 +180,7 @@ export function scheduleReducer(
     }
 
     case 'removeTalk': {
-      if (!current) return state
+      if (!current) return withoutActiveDay(state)
       return withDayResult(
         state,
         ops.removeTalk(current, action.trackIndex, action.talkIndex),
@@ -168,7 +188,7 @@ export function scheduleReducer(
     }
 
     case 'addService': {
-      if (!current) return state
+      if (!current) return withoutActiveDay(state)
       return withDayResult(
         state,
         ops.addService(current, action.trackIndex, {
@@ -180,7 +200,7 @@ export function scheduleReducer(
     }
 
     case 'resizeItem': {
-      if (!current) return state
+      if (!current) return withoutActiveDay(state)
       return withDayResult(
         state,
         ops.resizeScheduleItem(
@@ -193,7 +213,7 @@ export function scheduleReducer(
     }
 
     case 'renameService': {
-      if (!current) return state
+      if (!current) return withoutActiveDay(state)
       return withDayResult(
         state,
         ops.renameService(
@@ -206,7 +226,7 @@ export function scheduleReducer(
     }
 
     case 'duplicateService': {
-      if (!current) return state
+      if (!current) return withoutActiveDay(state)
       return withDayResult(
         state,
         ops.duplicateService(


### PR DESCRIPTION
Closes #838.

A conference provisioned by `buildOnboardingDocuments` has **no dates at all** — no `startDate`/`endDate`, no `cfpStartDate`/`cfpEndDate`. Four admin surfaces answered that silence with a confident wrong value instead of nothing. #830 fixed this class on the public site; this is the admin half.

## Each surface, before → after

| Surface | Before | After |
| --- | --- | --- |
| `CFPHealthWidget` (initialization view) | Tiles read **"Opens In: NaNd"**, **"Duration: NaNd"** — `new Date(undefined).getTime()` is `NaN` | House `WidgetEmptyState`: "No CFP dates set yet" + a **Set CFP dates** link to `/admin/settings` |
| `ProposalPipelineWidget` (initialization/planning view) | **"CFP Opens: Open"** — `NaN > 0` is false, so the widget affirmatively stated a never-configured CFP was accepting submissions; Duration read `NaNd` | Same empty state, same link |
| `/admin/schedule` "Create First Track" | Modal accepted a track name and **silently discarded it** — zero conference dates means zero days, and the reducer's `if (!current) return state` dropped it. Reachable from the dashboard's "Configure Schedule" CTA | The editor renders **"Set your conference dates first"** with a link to settings and offers no track-creation affordance at all (desktop *and* mobile) |
| `/admin/marketing` conference promo card | Hardcoded **`'June 15, 2025'`** on a *downloadable* share graphic | Date line **omitted entirely**; `SponsorThankYou` already treats `eventDate` as optional |

## Judgement calls

**1. The marketing card omits the date line rather than showing a placeholder.**
Agreed with the instinct in the issue. This is a share asset that leaves the product: an invented date is a lie, and "Date TBA" printed on a social graphic is a defect an organizer would have to notice and work around. Omitting collapses the metadata row to just the location chip, which reads as a deliberate design rather than a hole. (The adjacent `'Location TBA'` fallback is left alone — it is honest, not fabricated, and changing it is not this issue.)

**2. The silent no-op is fixed at BOTH tiers, with the UI tier doing the load-bearing work.**
The issue asked for whichever makes the discard impossible rather than merely explained, so:
- **Impossible (UI):** `ScheduleEditor` bails to `NoConferenceDatesState` when `state.schedules.length === 0`, before either the desktop board or the mobile view mounts. The `AddTrackModal` is unreachable, so there is no input to discard. `schedules.length === 0` is exactly equivalent to "no usable conference dates" — `getScheduleData()` emits one day per date and always emits at least one when the dates are valid.
- **Explained (reducer):** the ten `if (!current) return state` no-ops now return `withoutActiveDay(state)`, which sets `ui.error` (surfaced by the existing `ErrorBanner`). This is the backstop: any *future* path that dispatches an edit with no day loaded gets a visible error instead of a silent drop.

**3. Decorative empty-state icons are hidden at the SLOT, not per call site** (from review). All three shared empty-state components rely on Heroicons' default `aria-hidden="true"` — a convention, not a guarantee, since `WidgetEmptyState.icon` is an arbitrary `ReactNode`. The attribute now sits on the icon slot in `WidgetEmptyState`, covering every current and future caller. `EmptyState.tsx` / `DataTable/TableEmptyState.tsx` take a `ComponentType` and are untouched by this PR, so they were left alone.

## Why the tests missed it, and what now catches it

Every `conferenceInPhase()` matrix fixture supplies a full set of dates, so no cell ever rendered the day-one shape. Added:

- `freshlyProvisionedConference()` in `__matrix__/fixtures.ts`, built from the **real** `buildOnboardingDocuments` (same approach as #824/#830), plus day-one cells in the CFPHealth and ProposalPipeline matrices and a `NoConferenceDates` story on `ScheduleEditor` — whose fixture also calls the real builder, so no hand-written approximation exists to drift.
- `__tests__/app/day-one/fresh-tenant-admin-surfaces.test.tsx` — the admin counterpart to `fresh-tenant-public-pages.test.tsx`. Its **premise guard** asserts what is genuinely absent *today*: `startDate`, `endDate`, `cfpStartDate`, `cfpEndDate`, `cfpNotifyDate`, `programDate` — and asserts that `formats` **is** seeded, since #833 changed that. If provisioning drifts, the premise fails loudly instead of the coverage quietly evaporating.
- A `WidgetEmptyState` a11y contract test in `widget-shared.test.tsx` that passes a bare `<svg>`, so the slot-level guard is exercised rather than masked by Heroicons' own default.

Follow-up noted in-code: this is now the third story-side copy of the provisioning call (here, `InfoContent.stories.tsx`, `__matrix__/fixtures.ts`). #841 extracts the test-side equivalent to `__tests__/testdata/onboarding.ts`; the story-side copies should collapse onto one helper once that lands (it is not on `main` yet).

## Sabotage results

Each guard removed by exact string, suite re-run, restored, re-run green. **7 guards, 10 failing-test outcomes.**

| Guard removed | Failing tests |
| --- | --- |
| `CFPHealthWidget` unconfigured branch | 2 |
| `ProposalPipelineWidget` unconfigured branch | 2 (failure output confirms the literal `Open` rendering) |
| `ScheduleEditor` `schedules.length === 0` early return | 2 |
| reducer `addTrack` → `withoutActiveDay(state)` | 1 |
| marketing `: undefined` → `: 'June 15, 2025'` | 2 |
| marketing `{eventDate && …}` wrapper | 1 |
| `WidgetEmptyState` icon-slot `aria-hidden` | 1 |

## Numbers (re-derived on this branch)

| Check | Baseline (`origin/main`) | This branch |
| --- | --- | --- |
| `pnpm test` | 503 files / 7243 tests, all pass | **504 files / 7258 tests**, all pass |
| `pnpm typecheck` | clean | clean |
| `npx prettier --check .` | clean | clean |
| `npx eslint .` | 0 errors, 209 warnings | 0 errors, 209 warnings |
| `pnpm knip` | clean | clean |
| `pnpm build-storybook` | — | completes successfully |

## Visual inspection — not done, and why

`pnpm shoot` could not run here: **every** Chromium build on this machine (`chromium_headless_shell-1234`, `chromium-1234`, and a manual launch of `Google Chrome for Testing`) exits with `SIGTRAP` moments after printing `DevTools listening`, whether launched by Playwright, by hand, or under a pty. This is an environment failure, not a change in this PR — a bare `chromium.launch()` fails identically on unmodified code. Storybook itself builds and serves fine.

Compensating cover: the new states use the existing house components (`WidgetEmptyState`, which already carries the widget height contract), `pnpm build-storybook` passes, Storybook Tests and Visual Regression Tests are green in CI, and the new day-one cells are in the matrices ready to be looked at. **Please eyeball the three new cells before merging**: `Systems/Proposals/Admin/Dashboard/Matrix/CFPHealth → Phases`, `…/ProposalPipeline → Phases`, and `Systems/Program/Admin/ScheduleEditor → NoConferenceDates`.