### PR TITLE
feat(admin): put the activation checklist on the screen organizers land on

### DIFF
--- a/__tests__/testdata/onboarding.ts
+++ b/__tests__/testdata/onboarding.ts
@@ -1,0 +1,42 @@
+import { buildOnboardingDocuments } from '@/lib/onboarding/create'
+
+/**
+ * A tenant EXACTLY as provisioning creates it, built by the REAL
+ * `buildOnboardingDocuments` rather than hand-written — so "what a new
+ * organizer sees on day one" tests cannot drift away from what provisioning
+ * actually writes. Provisioning has changed under these tests before (#833
+ * started seeding the starter session formats), and a hand-written fixture
+ * would have kept asserting the old world.
+ *
+ * Callers should still PREMISE-GUARD the specific emptiness they are testing
+ * (see `src/lib/settings/activation.test.ts`): if provisioning starts seeding
+ * topics or a CFP window, the tests about those states are about a state that
+ * no longer exists and should fail loudly rather than quietly pass.
+ */
+export function buildProvisionedConference(): Record<string, unknown> {
+  let key = 0
+  const { conference } = buildOnboardingDocuments(
+    {
+      organization: {
+        name: 'Brand New Events',
+        slug: 'brand-new-events',
+        contactEmail: 'hello@brand-new.example',
+      },
+      conference: {
+        title: 'Brand New Conf',
+        city: 'Bergen',
+        country: 'Norway',
+      },
+      organizer: { name: 'Ada Organizer', email: 'ada@brand-new.example' },
+      domains: ['brand-new.konf.run'],
+    },
+    {
+      organizationId: 'org-fresh',
+      conferenceId: 'conf-fresh',
+      speakerId: 'speaker-fresh',
+      mintKey: () => `key-${++key}`,
+    },
+    null,
+  )
+  return conference
+}

--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -5,6 +5,7 @@ import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { isConferenceUnlisted } from '@/lib/conference/visibility'
 import { resolveEnabledFeaturesForConference } from '@/lib/features/enabled'
+import { resolveActivationChecklist } from '@/lib/settings/activation-server'
 
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
@@ -26,7 +27,10 @@ export default async function AdminRootLayout({
     )
   }
 
-  const { conference } = await getConferenceForCurrentDomain({})
+  // `topics: true`: the unlisted banner's CTA depends on the activation
+  // checklist, and topics are an opt-in join that the boundary normaliser
+  // otherwise reports as `[]` — see the same note on /admin/page.tsx.
+  const { conference } = await getConferenceForCurrentDomain({ topics: true })
   const conferenceLogos = conference
     ? {
         logoBright: conference.logoBright,
@@ -48,10 +52,22 @@ export default async function AdminRootLayout({
   // re-check server-side, so this is presentation, not security.
   const enabledFeatures = await resolveEnabledFeaturesForConference(conference)
 
+  // The unlisted banner's CTA (#839): "Finish setup" onto the activation
+  // checklist while a required row is outstanding, "Go live" onto the publish
+  // switch once only the switch is left. Resolved ONLY for an unlisted
+  // conference — the banner is the sole consumer, and a live one would pay for
+  // an answer nothing renders.
+  const unlisted = isConferenceUnlisted(conference)
+  const readyToGoLive =
+    unlisted && conference
+      ? (await resolveActivationChecklist(conference)).readyToGoLive
+      : false
+
   return (
     <AdminLayout
       conferenceLogos={conferenceLogos}
-      unlisted={isConferenceUnlisted(conference)}
+      unlisted={unlisted}
+      readyToGoLive={readyToGoLive}
       enabledFeatures={enabledFeatures}
     >
       {children}

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,10 +1,18 @@
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { AdminDashboard } from '@/components/admin/dashboard/AdminDashboard'
+import { ActivationHero } from '@/components/admin/ActivationHero'
+import { resolveActivationChecklist } from '@/lib/settings/activation-server'
 
 import { Suspense } from 'react'
 
 async function DashboardContent() {
-  const { conference, error } = await getConferenceForCurrentDomain({})
+  // `topics: true` is load-bearing, not incidental: topics are an OPT-IN join
+  // and the boundary normaliser hands back `[]` when they were not projected
+  // (see @/lib/conference/sanity). Without it the activation checklist would
+  // tell every conference on earth to add its first topic.
+  const { conference, error } = await getConferenceForCurrentDomain({
+    topics: true,
+  })
 
   if (error || !conference) {
     return (
@@ -16,7 +24,18 @@ async function DashboardContent() {
     )
   }
 
-  return <AdminDashboard conference={conference} />
+  // THE ACTIVATION HERO (#839). A new organizer lands here, not on
+  // /admin/settings, so this is where "what do I do next?" has to be answered.
+  // It renders only while a required row is outstanding; a fully activated
+  // conference sees the widget grid alone, exactly as before.
+  const activation = await resolveActivationChecklist(conference)
+
+  return (
+    <>
+      {activation.allDone ? null : <ActivationHero checklist={activation} />}
+      <AdminDashboard conference={conference} />
+    </>
+  )
 }
 
 export default function AdminDashboardPage() {

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -21,7 +21,7 @@ import { CollapsibleSection } from '@/components/admin/CollapsibleSection'
 import { ActivationChecklist } from '@/components/admin/ActivationChecklist'
 import { SETTINGS_GROUPS, type SettingsGroup } from '@/lib/settings/groups'
 import { APPEARANCE_ROOT } from '@/lib/settings/appearance'
-import { buildActivationChecklist } from '@/lib/settings/activation'
+import { resolveActivationChecklist } from '@/lib/settings/activation-server'
 import {
   getAllOrganizations,
   getOrganizationById,
@@ -128,10 +128,14 @@ export default async function AdminSettings() {
       )
     : []
   const systemChecks = await buildSystemChecks(conference)
-  // "Get started" activation checklist — derived purely from the conference and
-  // the checks we already built above (no extra probing). Rendered at the top of
-  // the Configuration tier; auto-collapses once everything required is done.
-  const activation = buildActivationChecklist(conference, systemChecks)
+  // "Get started" activation checklist — derived from the conference and the
+  // checks we already built above (no extra probing; the resolver reuses them
+  // rather than collecting a second set). Rendered at the top of the
+  // Configuration tier; auto-collapses once everything required is done. The
+  // SAME resolver backs the /admin hero and the unlisted banner, so all three
+  // surfaces agree on what is outstanding and on which rows are not this
+  // tenant's to complete (#839).
+  const activation = await resolveActivationChecklist(conference, systemChecks)
   const session = await getAuthSession()
   const currentUserId = session?.speaker?._id ?? ''
   const organizerRows = (conference.organizers ?? []).map((org) => ({

--- a/src/components/admin/ActivationChecklist.stories.tsx
+++ b/src/components/admin/ActivationChecklist.stories.tsx
@@ -100,6 +100,30 @@ export const Fresh: Story = {
   ],
 }
 
+/**
+ * The SHARED-PLATFORM tenant (#839): it has no `ticketing` entitlement and the
+ * Resend key is a platform environment variable it cannot see. Both rows stay
+ * listed but are badged as not theirs and dropped from the progress rollup — a
+ * checklist that asks for the impossible teaches the organizer to ignore it.
+ */
+export const SharedPlatformTenant: Story = {
+  args: {
+    checklist: buildActivationChecklist(FRESH, [], {
+      ticketingAvailable: false,
+      emailDeliveryManagedByPlatform: true,
+    }),
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-screen bg-gray-50">
+        <Frame>
+          <Story />
+        </Frame>
+      </div>
+    ),
+  ],
+}
+
 export const NearlyDone: Story = {
   args: { checklist: buildActivationChecklist(NEARLY_DONE, emailOk) },
   decorators: [

--- a/src/components/admin/ActivationChecklist.tsx
+++ b/src/components/admin/ActivationChecklist.tsx
@@ -3,9 +3,10 @@ import { CheckCircleIcon } from '@heroicons/react/24/solid'
 import { RocketLaunchIcon } from '@heroicons/react/24/outline'
 import { CollapsibleSection } from '@/components/admin/CollapsibleSection'
 import { StatusBadge } from '@/components/StatusBadge'
-import type {
-  ActivationChecklist as ActivationChecklistData,
-  ActivationRow,
+import {
+  ACTIVATION_CHECKLIST_ANCHOR,
+  type ActivationChecklist as ActivationChecklistData,
+  type ActivationRow,
 } from '@/lib/settings/activation'
 
 /**
@@ -21,6 +22,13 @@ import type {
  * satisfied, so a fully configured conference sees only a compact "Ready to
  * launch" header. Each row deep-links to the relevant group / card anchor.
  *
+ * THE ANCHOR IS PART OF THE CONTRACT. The wrapper carries
+ * `ACTIVATION_CHECKLIST_ANCHOR`, which is where the `/admin` hero and the
+ * unlisted banner send an organizer who asks for the full list. Before #839
+ * the only setup affordance in the shell pointed at `#visibility` — an anchor
+ * BELOW this card — dropping a half-configured tenant straight onto the
+ * publish switch.
+ *
  * headingLevel={3}: the card sits directly under the Configuration `h2`, so its
  * disclosure heading is an `h3` (the grouped subsections below are also h3).
  */
@@ -29,58 +37,78 @@ export function ActivationChecklist({
 }: {
   checklist: ActivationChecklistData
 }) {
-  const { rows, done, required, allDone } = checklist
+  const { stages, done, required, allDone } = checklist
   const pct = required === 0 ? 100 : Math.round((done / required) * 100)
 
   return (
-    <CollapsibleSection
-      headingLevel={3}
-      title="Get started"
-      icon={<RocketLaunchIcon />}
-      defaultOpen={!allDone}
-      action={
-        // Compact so the "Get started" title is never squeezed to an ellipsis
-        // on a narrow (393px) viewport, where the disclosure's Hide/Show label
-        // and chevron already consume header width.
-        allDone ? (
-          <StatusBadge label="Ready" color="green" />
-        ) : (
-          <StatusBadge label={`${done}/${required}`} color="gray" />
-        )
-      }
-    >
-      <div className="space-y-4 px-6 py-4">
-        <div>
-          <div className="mb-1 flex items-center justify-between text-sm">
-            <span className="font-medium text-gray-700 dark:text-gray-300">
-              Launch readiness
-            </span>
-            <span className="text-gray-500 dark:text-gray-400">
-              {done}/{required} required steps
-            </span>
-          </div>
-          <div
-            className="h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700"
-            role="progressbar"
-            aria-valuenow={done}
-            aria-valuemin={0}
-            aria-valuemax={required}
-            aria-label="Launch readiness"
-          >
+    <div id={ACTIVATION_CHECKLIST_ANCHOR} className="scroll-mt-24">
+      <CollapsibleSection
+        headingLevel={3}
+        title="Get started"
+        icon={<RocketLaunchIcon />}
+        defaultOpen={!allDone}
+        action={
+          // Compact so the "Get started" title is never squeezed to an ellipsis
+          // on a narrow (393px) viewport, where the disclosure's Hide/Show label
+          // and chevron already consume header width.
+          allDone ? (
+            <StatusBadge label="Ready" color="green" />
+          ) : (
+            <StatusBadge label={`${done}/${required}`} color="gray" />
+          )
+        }
+      >
+        <div className="space-y-5 px-6 py-4">
+          <div>
+            <div className="mb-1 flex items-center justify-between text-sm">
+              <span className="font-medium text-gray-700 dark:text-gray-300">
+                Launch readiness
+              </span>
+              <span className="text-gray-500 dark:text-gray-400">
+                {done}/{required} required steps
+              </span>
+            </div>
             <div
-              className="h-2 rounded-full bg-indigo-600 transition-all duration-300 dark:bg-indigo-500"
-              style={{ width: `${pct}%` }}
-            />
+              className="h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700"
+              role="progressbar"
+              aria-valuenow={done}
+              aria-valuemin={0}
+              aria-valuemax={required}
+              aria-label="Launch readiness"
+            >
+              <div
+                className="h-2 rounded-full bg-indigo-600 transition-all duration-300 dark:bg-indigo-500"
+                style={{ width: `${pct}%` }}
+              />
+            </div>
           </div>
-        </div>
 
-        <ul className="space-y-1">
-          {rows.map((row) => (
-            <ActivationRowItem key={row.id} row={row} />
+          {/* Two stages, not one flat list: the CFP critical path first, the
+              rest of the launch prep after it. Same grouping the /admin hero
+              titles itself with, so the two surfaces tell one story. */}
+          {stages.map((stage) => (
+            <section key={stage.id} className="space-y-1">
+              <div className="flex flex-wrap items-baseline justify-between gap-x-3">
+                <h4 className="text-sm font-semibold text-gray-900 dark:text-white">
+                  {stage.title}
+                </h4>
+                <span className="text-xs text-gray-500 dark:text-gray-400">
+                  {stage.done}/{stage.required}
+                </span>
+              </div>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                {stage.description}
+              </p>
+              <ul className="space-y-1 pt-1">
+                {stage.rows.map((row) => (
+                  <ActivationRowItem key={row.id} row={row} />
+                ))}
+              </ul>
+            </section>
           ))}
-        </ul>
-      </div>
-    </CollapsibleSection>
+        </div>
+      </CollapsibleSection>
+    </div>
   )
 }
 
@@ -88,56 +116,88 @@ export function ActivationChecklist({
  * One checklist row — a link with a done/pending icon and a hint. A `#…` target
  * is a same-page jump (a plain anchor); a `/admin/…` target is a settings
  * sub-page and routes through `Link` so it stays a client navigation.
+ *
+ * An `unavailable` row is NOT a link. There is nothing behind the anchor this
+ * organizer can act on, and an affordance that navigates to a dead end is the
+ * failure #839 is about; it renders as a muted, badged line instead.
+ *
+ * Exported because the `/admin` activation hero renders the same rows — the
+ * hero is a different frame around this identical line, never a second
+ * rendering of the steps that could drift from this one.
  */
-function ActivationRowItem({ row }: { row: ActivationRow }) {
+export function ActivationRowItem({ row }: { row: ActivationRow }) {
+  const rowClass =
+    'group flex items-start gap-3 rounded-md px-2 py-2 transition-colors'
+  const body = (
+    <>
+      <span className="mt-0.5 shrink-0">
+        {row.done ? (
+          <CheckCircleIcon className="h-5 w-5 text-green-500 dark:text-green-400" />
+        ) : (
+          <span
+            aria-hidden="true"
+            className={`block h-5 w-5 rounded-full border-2 ${
+              row.optional || row.unavailable
+                ? 'border-dashed border-gray-300 dark:border-gray-600'
+                : 'border-gray-300 dark:border-gray-600'
+            }`}
+          />
+        )}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="flex flex-wrap items-center gap-2">
+          <span
+            className={`text-sm font-medium ${
+              row.done
+                ? 'text-gray-500 line-through dark:text-gray-500'
+                : row.unavailable
+                  ? 'text-gray-500 dark:text-gray-400'
+                  : 'text-gray-900 dark:text-white'
+            }`}
+          >
+            {row.label}
+          </span>
+          {row.unavailable ? (
+            <StatusBadge label={row.unavailable} color="gray" />
+          ) : row.optional ? (
+            <StatusBadge label="Optional" color="gray" />
+          ) : null}
+        </span>
+        {/* An outstanding row shows what to do; a done row normally shows
+            nothing — except a `note`, the advisory for a requirement that is
+            satisfied by something the organizer did not choose (the seeded
+            starter formats), where a bare strike-through would overstate. An
+            unavailable row ALWAYS shows its hint: there the hint is not an
+            instruction but the explanation of why the row is not theirs. */}
+        {row.unavailable || !row.done ? (
+          <span className="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
+            {row.hint}
+          </span>
+        ) : row.note ? (
+          <span className="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
+            {row.note}
+          </span>
+        ) : null}
+      </span>
+    </>
+  )
+
+  if (row.unavailable) {
+    return (
+      <li>
+        <div className={rowClass}>{body}</div>
+      </li>
+    )
+  }
+
   const RowLink = row.anchor.startsWith('#') ? 'a' : Link
   return (
     <li>
       <RowLink
         href={row.anchor}
-        className="group flex items-start gap-3 rounded-md px-2 py-2 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
+        className={`${rowClass} hover:bg-gray-50 dark:hover:bg-gray-800`}
       >
-        <span className="mt-0.5 shrink-0">
-          {row.done ? (
-            <CheckCircleIcon className="h-5 w-5 text-green-500 dark:text-green-400" />
-          ) : (
-            <span
-              aria-hidden="true"
-              className={`block h-5 w-5 rounded-full border-2 ${
-                row.optional
-                  ? 'border-dashed border-gray-300 dark:border-gray-600'
-                  : 'border-gray-300 dark:border-gray-600'
-              }`}
-            />
-          )}
-        </span>
-        <span className="min-w-0 flex-1">
-          <span className="flex flex-wrap items-center gap-2">
-            <span
-              className={`text-sm font-medium ${
-                row.done
-                  ? 'text-gray-500 line-through dark:text-gray-500'
-                  : 'text-gray-900 dark:text-white'
-              }`}
-            >
-              {row.label}
-            </span>
-            {row.optional && <StatusBadge label="Optional" color="gray" />}
-          </span>
-          {/* An outstanding row shows what to do; a done row normally shows
-              nothing — except a `note`, the advisory for a requirement that is
-              satisfied by something the organizer did not choose (the seeded
-              starter formats), where a bare strike-through would overstate. */}
-          {!row.done ? (
-            <span className="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
-              {row.hint}
-            </span>
-          ) : row.note ? (
-            <span className="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
-              {row.note}
-            </span>
-          ) : null}
-        </span>
+        {body}
         <span
           aria-hidden="true"
           className="mt-0.5 shrink-0 text-xs font-medium text-indigo-600 opacity-0 transition-opacity group-hover:opacity-100 dark:text-indigo-400"

--- a/src/components/admin/ActivationHero.stories.tsx
+++ b/src/components/admin/ActivationHero.stories.tsx
@@ -1,0 +1,123 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { ActivationHero } from './ActivationHero'
+import {
+  buildActivationChecklist,
+  type ActivationOptions,
+  type ConferenceForActivation,
+} from '@/lib/settings/activation'
+import { STARTER_SESSION_FORMATS } from '@/lib/onboarding/create'
+import type { SystemCheck } from '@/lib/system-status/types'
+
+/**
+ * The activation hero that opens `/admin` while setup is incomplete (#839).
+ * The stories call the REAL `buildActivationChecklist`, so the hero and the
+ * derivation stay in lockstep — and so a story cannot show a step the real
+ * checklist would never produce.
+ */
+const meta = {
+  title: 'Systems/Admin/ActivationHero',
+  component: ActivationHero,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ActivationHero>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** A shared-platform tenant: neither impossible row is theirs to complete. */
+const SHARED_TENANT: ActivationOptions = {
+  ticketingAvailable: false,
+  emailDeliveryManagedByPlatform: true,
+}
+
+const emailOk: SystemCheck[] = [
+  {
+    id: 'email.resendKey',
+    group: 'email',
+    label: 'RESEND_API_KEY',
+    status: 'ok',
+  },
+]
+
+/** A brand-new conference exactly as provisioning creates it. */
+const FRESH: ConferenceForActivation = {
+  title: 'My New Conference',
+  organizer: 'Acme Events',
+  contactEmail: 'hello@acme.example',
+  cfpEmail: 'hello@acme.example',
+  sponsorEmail: 'hello@acme.example',
+  formats: [...STARTER_SESSION_FORMATS],
+  visibility: 'unlisted',
+}
+
+/** CFP stage cleared; the launch prep is what remains. */
+const CFP_OPEN: ConferenceForActivation = {
+  ...FRESH,
+  cfpStartDate: '2026-01-01',
+  cfpEndDate: '2026-03-01',
+  topics: [{ _id: 't1', title: 'Kubernetes' }],
+}
+
+/** Everything but the switch. */
+const NEARLY_LIVE: ConferenceForActivation = {
+  ...CFP_OPEN,
+  logoBright: 'https://cdn/logo.svg',
+  venueName: 'Grieghallen',
+  startDate: '2026-05-01',
+  endDate: '2026-05-02',
+  registrationLink: 'https://tickets.example.com',
+}
+
+function Frame({ children }: { children: React.ReactNode }) {
+  return <div className="mx-auto max-w-5xl p-4">{children}</div>
+}
+
+function light(
+  conference: ConferenceForActivation,
+  checks: SystemCheck[] = [],
+) {
+  return {
+    args: {
+      checklist: buildActivationChecklist(conference, checks, SHARED_TENANT),
+    },
+    decorators: [
+      (Story: React.ComponentType) => (
+        <div className="min-h-screen bg-gray-50">
+          <Frame>
+            <Story />
+          </Frame>
+        </div>
+      ),
+    ],
+  }
+}
+
+function dark(conference: ConferenceForActivation, checks: SystemCheck[] = []) {
+  return {
+    args: {
+      checklist: buildActivationChecklist(conference, checks, SHARED_TENANT),
+    },
+    decorators: [
+      (Story: React.ComponentType) => (
+        <div className="dark min-h-screen bg-gray-950">
+          <Frame>
+            <Story />
+          </Frame>
+        </div>
+      ),
+    ],
+  }
+}
+
+/** Day one: the two steps between this tenant and a proposal in the inbox. */
+export const Fresh: Story = light(FRESH)
+
+/** Part-done: the CFP can accept proposals, so the hero moves to launch prep. */
+export const CfpOpen: Story = light(CFP_OPEN, emailOk)
+
+/** One step left, and it is the switch itself. */
+export const NearlyLive: Story = light(NEARLY_LIVE, emailOk)
+
+export const FreshDark: Story = dark(FRESH)
+
+export const NearlyLiveDark: Story = dark(NEARLY_LIVE, emailOk)

--- a/src/components/admin/ActivationHero.test.tsx
+++ b/src/components/admin/ActivationHero.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The activation hero on `/admin` (#839) — what a brand-new organizer actually
+ * sees on the screen they land on. The checklists here are built by the REAL
+ * `buildActivationChecklist` from the REAL provisioning output, so a change to
+ * either shows up as a failure here rather than as a hero quietly naming the
+ * wrong next step.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { render, cleanup, screen } from '@testing-library/react'
+
+vi.mock('next/link', () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string
+    children: React.ReactNode
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+import { ActivationHero } from './ActivationHero'
+import {
+  ACTIVATION_CHECKLIST_HREF,
+  buildActivationChecklist,
+  type ActivationOptions,
+  type ConferenceForActivation,
+} from '@/lib/settings/activation'
+import { buildProvisionedConference } from '../../../__tests__/testdata/onboarding'
+import type { SystemCheck } from '@/lib/system-status/types'
+
+/** A shared-platform tenant: neither impossible row is theirs to complete. */
+const SHARED_TENANT: ActivationOptions = {
+  ticketingAvailable: false,
+  emailDeliveryManagedByPlatform: true,
+}
+
+const CHECKS_OK: SystemCheck[] = [
+  {
+    id: 'email.resendKey',
+    group: 'email',
+    label: 'RESEND_API_KEY',
+    status: 'ok',
+  },
+  {
+    id: 'slack.botToken',
+    group: 'slack',
+    label: 'SLACK_BOT_TOKEN',
+    status: 'ok',
+  },
+]
+
+const ACTIVATED: ConferenceForActivation = {
+  title: 'Cloud Native Day',
+  organizer: 'Cloud Native Bergen',
+  logoBright: 'https://cdn/logo.svg',
+  venueName: 'Grieghallen',
+  startDate: '2026-05-01',
+  endDate: '2026-05-02',
+  cfpStartDate: '2026-01-01',
+  cfpEndDate: '2026-03-01',
+  formats: ['lightning_10'],
+  topics: [{ _id: 't1', title: 'Kubernetes' }],
+  contactEmail: 'hi@example.com',
+  cfpEmail: 'cfp@example.com',
+  sponsorEmail: 'sponsors@example.com',
+  registrationLink: 'https://tickets.example.com',
+  checkinCustomerId: 1,
+  checkinEventId: 2,
+  visibility: 'live',
+}
+
+afterEach(cleanup)
+
+describe('ActivationHero — a freshly provisioned tenant', () => {
+  const checklist = buildActivationChecklist(
+    buildProvisionedConference() as ConferenceForActivation,
+    [],
+    SHARED_TENANT,
+  )
+
+  it('leads with the CFP stage, not with branding', () => {
+    render(<ActivationHero checklist={checklist} />)
+    expect(
+      screen.getByRole('heading', { name: /open your call for papers/i }),
+    ).toBeTruthy()
+    expect(screen.queryByText(/brand logo/i)).toBeNull()
+  })
+
+  it('names the two steps that genuinely stand in the way', () => {
+    render(<ActivationHero checklist={checklist} />)
+    expect(screen.getByText('Call-for-papers window')).toBeTruthy()
+    expect(screen.getByText('At least one topic')).toBeTruthy()
+  })
+
+  it('shows no more than two steps', () => {
+    render(<ActivationHero checklist={checklist} />)
+    expect(screen.getAllByRole('listitem')).toHaveLength(2)
+  })
+
+  it('offers the way through to the full list', () => {
+    render(<ActivationHero checklist={checklist} />)
+    expect(
+      screen.getByRole('link', { name: /see the full checklist/i }),
+    ).toHaveAttribute('href', ACTIVATION_CHECKLIST_HREF)
+  })
+
+  it('reports progress the organizer can act on', () => {
+    render(<ActivationHero checklist={checklist} />)
+    const bar = screen.getByRole('progressbar', { name: /launch readiness/i })
+    expect(bar.getAttribute('aria-valuenow')).toBe(String(checklist.done))
+    expect(bar.getAttribute('aria-valuemax')).toBe(String(checklist.required))
+  })
+
+  it('never surfaces a step the tenant cannot complete', () => {
+    // The #839 prerequisite: an unentitled org cannot connect ticketing and a
+    // shared-tier tenant cannot set a platform environment variable.
+    render(<ActivationHero checklist={checklist} />)
+    expect(screen.queryByText(/ticketing connected/i)).toBeNull()
+    expect(screen.queryByText(/Resend API key/i)).toBeNull()
+  })
+
+  it('gives no way to dismiss it while a required row is outstanding', () => {
+    // It is the only signpost to the checklist in the whole shell; a dismiss
+    // control would restore the very state #839 describes.
+    render(<ActivationHero checklist={checklist} />)
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+})
+
+describe('ActivationHero — later in setup', () => {
+  it('moves on to the launch stage once the CFP one is satisfied', () => {
+    const checklist = buildActivationChecklist(
+      {
+        cfpStartDate: '2026-01-01',
+        cfpEndDate: '2026-03-01',
+        topics: [{ _id: 't1' }],
+        formats: ['lightning_10'],
+      },
+      [],
+      SHARED_TENANT,
+    )
+    render(<ActivationHero checklist={checklist} />)
+    expect(
+      screen.getByRole('heading', { name: /get ready to launch/i }),
+    ).toBeTruthy()
+    expect(screen.getByText('Name & organizer')).toBeTruthy()
+  })
+
+  it('counts down to the switch in the singular when one step is left', () => {
+    const checklist = buildActivationChecklist(
+      { ...ACTIVATED, visibility: 'unlisted' },
+      CHECKS_OK,
+      SHARED_TENANT,
+    )
+    render(<ActivationHero checklist={checklist} />)
+    expect(screen.getByText(/1 step left before you can go live/i)).toBeTruthy()
+    expect(screen.getByText('Go live')).toBeTruthy()
+  })
+})
+
+describe('ActivationHero — a fully activated conference', () => {
+  it('renders nothing at all', () => {
+    const checklist = buildActivationChecklist(
+      ACTIVATED,
+      CHECKS_OK,
+      SHARED_TENANT,
+    )
+    expect(checklist.allDone).toBe(true)
+    const { container } = render(<ActivationHero checklist={checklist} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/components/admin/ActivationHero.tsx
+++ b/src/components/admin/ActivationHero.tsx
@@ -1,0 +1,120 @@
+import Link from 'next/link'
+import { RocketLaunchIcon, ArrowRightIcon } from '@heroicons/react/24/outline'
+import { ActivationRowItem } from './ActivationChecklist'
+import {
+  ACTIVATION_CHECKLIST_HREF,
+  currentActivationStage,
+  nextActivationSteps,
+  type ActivationChecklist as ActivationChecklistData,
+} from '@/lib/settings/activation'
+
+/**
+ * The activation hero on `/admin` (#839).
+ *
+ * WHY IT EXISTS. The checklist was already well built — it was simply on
+ * `/admin/settings`, a screen a brand-new organizer has no reason to visit. The
+ * dashboard they DO land on showed seven mostly-empty widgets and the only
+ * setup prompt in the shell deep-linked past the checklist to the publish
+ * switch. Placement, not copy, was the defect; this component is the fix, and
+ * it is deliberately a FRAME around the existing derivation
+ * (`buildActivationChecklist`) and the existing row renderer
+ * (`ActivationRowItem`) rather than a second telling of the steps. Restating
+ * them here is the one thing that would make this worse than the bug.
+ *
+ * WHAT IT SHOWS. The stage the organizer is currently on, overall progress, and
+ * the next TWO outstanding required steps — no more. For a freshly provisioned
+ * tenant those two are exactly the real critical path (`cfp-window` and
+ * `topics`; `formats` is seeded by provisioning since #833), so the hero opens
+ * on the whole of what stands between them and a proposal in the inbox. A
+ * `unavailable` row can never surface here — see `nextActivationSteps`.
+ *
+ * NOT DISMISSIBLE, on purpose. While a required row is outstanding this is the
+ * only signpost to the checklist anywhere in the admin shell, so a dismiss
+ * control would restore the exact state #839 describes, with the added insult
+ * that the organizer chose it. It removes itself the moment the last required
+ * row is done, which is the honest version of dismissal — and callers render it
+ * only while `allDone` is false, so a completed tenant sees today's dashboard,
+ * unchanged.
+ */
+export function ActivationHero({
+  checklist,
+}: {
+  checklist: ActivationChecklistData
+}) {
+  const stage = currentActivationStage(checklist)
+  const steps = nextActivationSteps(checklist)
+  // Nothing outstanding: the hero has no job. Callers gate on `allDone` too;
+  // this is the belt to that pair of braces, so the component can never render
+  // an empty exhortation.
+  if (!stage || steps.length === 0) return null
+
+  const { done, required } = checklist
+  const pct = required === 0 ? 100 : Math.round((done / required) * 100)
+  const remaining = required - done
+
+  return (
+    <section
+      aria-labelledby="activation-hero-title"
+      className="mb-6 overflow-hidden rounded-lg bg-white shadow-sm ring-1 ring-indigo-500/20 dark:bg-gray-900 dark:ring-indigo-400/30"
+    >
+      <div className="space-y-4 border-l-4 border-indigo-500 p-5 sm:p-6 dark:border-indigo-400">
+        <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
+          <div className="flex min-w-0 items-start gap-3">
+            <RocketLaunchIcon
+              aria-hidden="true"
+              className="mt-0.5 h-6 w-6 shrink-0 text-indigo-600 dark:text-indigo-400"
+            />
+            <div className="min-w-0">
+              <h2
+                id="activation-hero-title"
+                className="text-lg font-semibold text-gray-900 dark:text-white"
+              >
+                {stage.title}
+              </h2>
+              <p className="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
+                {stage.description}
+              </p>
+            </div>
+          </div>
+          <span className="shrink-0 text-sm font-medium text-gray-500 tabular-nums dark:text-gray-400">
+            {done}/{required} done
+          </span>
+        </div>
+
+        <div
+          className="h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700"
+          role="progressbar"
+          aria-valuenow={done}
+          aria-valuemin={0}
+          aria-valuemax={required}
+          aria-label="Launch readiness"
+        >
+          <div
+            className="h-2 rounded-full bg-indigo-600 transition-all duration-300 dark:bg-indigo-500"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+
+        <ul className="space-y-1">
+          {steps.map((row) => (
+            <ActivationRowItem key={row.id} row={row} />
+          ))}
+        </ul>
+
+        <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 border-t border-gray-200 pt-3 dark:border-gray-700">
+          <Link
+            href={ACTIVATION_CHECKLIST_HREF}
+            className="inline-flex items-center gap-1 text-sm font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+          >
+            See the full checklist
+            <ArrowRightIcon aria-hidden="true" className="h-4 w-4" />
+          </Link>
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {remaining} step{remaining === 1 ? '' : 's'} left before you can go
+            live
+          </span>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -27,6 +27,13 @@ interface AdminLayoutProps {
    */
   unlisted?: boolean
   /**
+   * Every required activation row EXCEPT the launch switch is done (#839).
+   * Decides whether the unlisted banner offers "Finish setup" (onto the
+   * checklist) or "Go live" (onto the publish switch). Defaults to `false` so
+   * an un-resolved caller never points an unconfigured tenant at the switch.
+   */
+  readyToGoLive?: boolean
+  /**
    * Per-organization features the CURRENT org is entitled to, resolved
    * server-side. Destinations tagged with a `feature` in the admin registry are
    * hidden from the sidebar and the ⌘K palette unless listed here — an omitted
@@ -42,6 +49,7 @@ export function AdminLayout({
   children,
   conferenceLogos,
   unlisted = false,
+  readyToGoLive = false,
   enabledFeatures = NO_FEATURES,
 }: AdminLayoutProps) {
   const [paletteOpen, setPaletteOpen] = useState(false)
@@ -66,7 +74,7 @@ export function AdminLayout({
           />
         }
       >
-        {unlisted ? <UnlistedBanner /> : null}
+        {unlisted ? <UnlistedBanner readyToGoLive={readyToGoLive} /> : null}
         {children}
       </DashboardLayout>
     </NotificationProvider>

--- a/src/components/admin/UnlistedBanner.stories.tsx
+++ b/src/components/admin/UnlistedBanner.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Shown at the top of the admin shell when the current conference is unlisted (M0 trial state). Admin access is never gated on visibility; the banner just makes the state legible and links to the Visibility settings card. The "Go live" link is a placeholder for the later activation checklist.',
+          'Shown at the top of the admin shell when the current conference is unlisted (M0 trial state). Admin access is never gated on visibility; the banner makes the state legible and points at the one thing the organizer should do next. The CTA tracks activation: "Finish setup" onto the checklist while a required row is outstanding, "Go live" onto the publish switch once only the switch is left.',
       },
     },
   },
@@ -18,8 +18,30 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+/** The day-one state: setup incomplete, so the CTA leads to the checklist. */
+export const SetupIncomplete: Story = { args: { readyToGoLive: false } }
 
-export const CustomSettingsHref: Story = {
-  args: { settingsHref: '/admin/settings' },
+/** Everything required but the switch is done — now "Go live" is honest. */
+export const ReadyToGoLive: Story = { args: { readyToGoLive: true } }
+
+export const SetupIncompleteDark: Story = {
+  args: { readyToGoLive: false },
+  decorators: [
+    (Story) => (
+      <div className="dark bg-gray-950 py-4">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export const ReadyToGoLiveDark: Story = {
+  args: { readyToGoLive: true },
+  decorators: [
+    (Story) => (
+      <div className="dark bg-gray-950 py-4">
+        <Story />
+      </div>
+    ),
+  ],
 }

--- a/src/components/admin/UnlistedBanner.test.tsx
+++ b/src/components/admin/UnlistedBanner.test.tsx
@@ -22,6 +22,7 @@ vi.mock('next/link', () => ({
 }))
 
 import { UnlistedBanner } from './UnlistedBanner'
+import { ACTIVATION_CHECKLIST_HREF } from '@/lib/settings/activation'
 
 afterEach(cleanup)
 
@@ -34,15 +35,45 @@ describe('UnlistedBanner', () => {
     )
   })
 
-  it('links "Go live" to the visibility settings card by default', () => {
-    render(<UnlistedBanner />)
-    const link = screen.getByRole('link', { name: /go live/i })
-    expect(link).toHaveAttribute('href', '/admin/settings#visibility')
+  describe('while setup is incomplete', () => {
+    it('says "Finish setup" and links to the activation checklist', () => {
+      render(<UnlistedBanner readyToGoLive={false} />)
+      const link = screen.getByRole('link', { name: /finish setup/i })
+      expect(link).toHaveAttribute('href', ACTIVATION_CHECKLIST_HREF)
+    })
+
+    it('never offers "Go live"', () => {
+      // The #839 defect: the banner sent a tenant with no topics, dates, venue
+      // or logo straight to the publish switch.
+      render(<UnlistedBanner readyToGoLive={false} />)
+      expect(screen.queryByRole('link', { name: /go live/i })).toBeNull()
+      expect(
+        screen.getByRole('link', { name: /finish setup/i }),
+      ).not.toHaveAttribute('href', '/admin/settings#visibility')
+    })
+
+    it('defaults to incomplete when the caller resolved nothing', () => {
+      // Fail toward the checklist: an unresolved caller must not vouch for a
+      // conference being ready to publish.
+      render(<UnlistedBanner />)
+      expect(
+        screen.getByRole('link', { name: /finish setup/i }),
+      ).toHaveAttribute('href', ACTIVATION_CHECKLIST_HREF)
+    })
+  })
+
+  describe('once every required row but the switch is done', () => {
+    it('says "Go live" and links to the visibility card', () => {
+      render(<UnlistedBanner readyToGoLive />)
+      const link = screen.getByRole('link', { name: /go live/i })
+      expect(link).toHaveAttribute('href', '/admin/settings#visibility')
+      expect(screen.queryByRole('link', { name: /finish setup/i })).toBeNull()
+    })
   })
 
   it('honours a custom settingsHref', () => {
     render(<UnlistedBanner settingsHref="/admin/settings" />)
-    expect(screen.getByRole('link', { name: /go live/i })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /finish setup/i })).toHaveAttribute(
       'href',
       '/admin/settings',
     )

--- a/src/components/admin/UnlistedBanner.tsx
+++ b/src/components/admin/UnlistedBanner.tsx
@@ -1,20 +1,45 @@
 import Link from 'next/link'
 import { EyeSlashIcon } from '@heroicons/react/24/outline'
+import { ACTIVATION_CHECKLIST_HREF } from '@/lib/settings/activation'
 
 /**
  * Admin banner shown when the current conference is UNLISTED (M0 trial state).
  *
  * The admin area stays fully reachable regardless of visibility; this banner
- * just makes the state legible to organizers and points at the settings toggle.
- * The "Go live" affordance is a PLACEHOLDER link to the Visibility card in
- * settings — the full activation checklist arrives in a later milestone.
+ * just makes the state legible to organizers and points at the one thing they
+ * should do next.
+ *
+ * WHICH THING DEPENDS ON WHETHER THEY CAN DO IT (#839). The link used to say
+ * "Go live" unconditionally and deep-link to `/admin/settings#visibility` — an
+ * anchor BELOW the activation checklist — so a tenant with no topics, dates,
+ * venue or logo landed on the publish switch and nothing else. Now the CTA
+ * tracks `readyToGoLive`: "Finish setup" onto the checklist while a required
+ * row is outstanding, and only once they are all done does it become the
+ * "Go live" jump to the switch.
+ *
+ * `readyToGoLive`, not `allDone`: an unlisted conference has the terminal
+ * `visibility` row outstanding by definition, so `allDone` would keep the
+ * banner on "Finish setup" forever — including for the one organizer it is
+ * addressed to, whose only remaining step IS the switch.
  */
 export function UnlistedBanner({
-  settingsHref = '/admin/settings#visibility',
+  readyToGoLive = false,
+  settingsHref,
 }: {
-  /** Where the "Go live" link points (the Visibility settings card). */
+  /**
+   * Every required checklist row except the launch switch itself is done (see
+   * `ActivationChecklist.readyToGoLive`). Defaults to `false`: a caller that
+   * has not resolved the checklist should send the organizer to the checklist,
+   * never to a publish switch it cannot vouch for.
+   */
+  readyToGoLive?: boolean
+  /** Override the CTA target (the stories and tests use it). */
   settingsHref?: string
 }) {
+  const href =
+    settingsHref ??
+    (readyToGoLive ? '/admin/settings#visibility' : ACTIVATION_CHECKLIST_HREF)
+
   return (
     <div
       role="status"
@@ -26,10 +51,10 @@ export function UnlistedBanner({
         is not indexed by search engines and is only reachable by direct link.
       </span>
       <Link
-        href={settingsHref}
+        href={href}
         className="ml-auto shrink-0 font-semibold text-amber-900 underline underline-offset-2 hover:text-amber-950 dark:text-amber-100 dark:hover:text-white"
       >
-        Go live
+        {readyToGoLive ? 'Go live' : 'Finish setup'}
       </Link>
     </div>
   )

--- a/src/lib/settings/activation-server.test.ts
+++ b/src/lib/settings/activation-server.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @vitest-environment node
+ *
+ * The server seam that decides which activation rows are the organizer's to
+ * complete (#839). The platform-org contract runs FOR REAL (it is pure env);
+ * only the ticketing gate and the check registry are stubbed, because those
+ * reach Sanity and the filesystem respectively.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const isTicketingEnabledForOrg = vi.fn(async () => true)
+
+vi.mock('@/lib/features/ticketing', () => ({
+  isTicketingEnabledForOrg: (...args: unknown[]) =>
+    isTicketingEnabledForOrg(...(args as [])),
+}))
+
+vi.mock('@/lib/system-status/checks', () => ({
+  collectStaticChecks: () => [],
+}))
+
+import { resolveActivationChecklist } from './activation-server'
+import type { ConferenceForActivationResolution } from './activation-server'
+
+const PLATFORM_ORG_ID = 'org-platform'
+const TENANT_ORG_ID = 'org-tenant'
+
+function conference(
+  orgId: string | null = TENANT_ORG_ID,
+): ConferenceForActivationResolution {
+  return {
+    title: 'Conf',
+    organizer: 'Org',
+    ...(orgId ? { organization: { _ref: orgId } } : {}),
+  }
+}
+
+function row(
+  checklist: Awaited<ReturnType<typeof resolveActivationChecklist>>,
+  id: string,
+) {
+  const found = checklist.rows.find((r) => r.id === id)
+  if (!found) throw new Error(`no row ${id}`)
+  return found
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  isTicketingEnabledForOrg.mockResolvedValue(true)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('resolveActivationChecklist — the ticketing row', () => {
+  it('keeps it required for an entitled org', async () => {
+    isTicketingEnabledForOrg.mockResolvedValue(true)
+    const checklist = await resolveActivationChecklist(conference())
+    expect(row(checklist, 'ticketing').unavailable).toBeUndefined()
+  })
+
+  it('demotes it for an org without the entitlement', async () => {
+    isTicketingEnabledForOrg.mockResolvedValue(false)
+    const checklist = await resolveActivationChecklist(conference())
+    expect(row(checklist, 'ticketing').unavailable).toBe('Not on your plan')
+  })
+
+  it('asks the SAME gate the nav and the ticket pages ask', async () => {
+    // If this drifts, the checklist can demand a section the shell has hidden.
+    await resolveActivationChecklist(conference())
+    expect(isTicketingEnabledForOrg).toHaveBeenCalledWith(TENANT_ORG_ID)
+  })
+})
+
+describe('resolveActivationChecklist — the email-delivery row', () => {
+  it('stays the organizer’s job on a single-tenant deployment', async () => {
+    // No PLATFORM_ORG_ID: nobody sits above this organizer, so RESEND_API_KEY
+    // really is theirs to set and the row stays a real requirement.
+    vi.stubEnv('PLATFORM_ORG_ID', '')
+    const checklist = await resolveActivationChecklist(conference())
+    expect(row(checklist, 'email-delivery').unavailable).toBeUndefined()
+    expect(row(checklist, 'email-delivery').hint).toMatch(/Resend API key/i)
+  })
+
+  it('stays the organizer’s job for the platform org itself', async () => {
+    vi.stubEnv('PLATFORM_ORG_ID', PLATFORM_ORG_ID)
+    const checklist = await resolveActivationChecklist(
+      conference(PLATFORM_ORG_ID),
+    )
+    expect(row(checklist, 'email-delivery').unavailable).toBeUndefined()
+  })
+
+  it('becomes platform-managed for a shared-tier tenant', async () => {
+    vi.stubEnv('PLATFORM_ORG_ID', PLATFORM_ORG_ID)
+    const checklist = await resolveActivationChecklist(conference())
+    const emailRow = row(checklist, 'email-delivery')
+    expect(emailRow.unavailable).toBe('Platform-managed')
+    expect(emailRow.hint).not.toMatch(/Resend API key/i)
+  })
+
+  it('does not block a shared-tier tenant from going live', async () => {
+    vi.stubEnv('PLATFORM_ORG_ID', PLATFORM_ORG_ID)
+    const checklist = await resolveActivationChecklist(conference())
+    const outstanding = checklist.rows
+      .filter((r) => !r.done && !r.optional && !r.unavailable)
+      .map((r) => r.id)
+    expect(outstanding).not.toContain('email-delivery')
+  })
+})
+
+describe('resolveActivationChecklist — supplied checks', () => {
+  it('reuses an already-built check list rather than collecting a second', async () => {
+    // The settings page has the full `buildSystemChecks` result in hand; the
+    // resolver must not re-derive email/Slack state beside it.
+    vi.stubEnv('PLATFORM_ORG_ID', '')
+    const checklist = await resolveActivationChecklist(conference(), [
+      {
+        id: 'email.resendKey',
+        group: 'email',
+        label: 'RESEND_API_KEY',
+        status: 'ok',
+      },
+    ])
+    expect(row(checklist, 'email-delivery').done).toBe(true)
+  })
+})

--- a/src/lib/settings/activation-server.ts
+++ b/src/lib/settings/activation-server.ts
@@ -1,0 +1,98 @@
+import 'server-only'
+import { collectStaticChecks } from '@/lib/system-status/checks'
+import type { SystemCheck } from '@/lib/system-status/types'
+import type { ConferenceForSystemChecks } from '@/lib/system-status/types'
+import { resolvePlatformOrgId } from '@/lib/authz/platform'
+import { isPlatformOrganization } from '@/lib/features/platform'
+import { isTicketingEnabledForOrg } from '@/lib/features/ticketing'
+import {
+  conferenceOrgId,
+  type ConferenceTenant,
+} from '@/lib/features/platform-default'
+import {
+  buildActivationChecklist,
+  type ActivationChecklist,
+  type ConferenceForActivation,
+} from './activation'
+
+/**
+ * The SERVER seam for the activation checklist.
+ *
+ * `@/lib/settings/activation` is deliberately pure and client-safe (a Storybook
+ * story renders it), so it cannot ask the two questions that decide whether the
+ * `ticketing` and `email-delivery` rows are the organizer's to complete. This
+ * module asks them and hands the answers over as options, which keeps exactly
+ * one derivation of the checklist for all three surfaces that render it: the
+ * `/admin` activation hero, the unlisted banner in the admin shell, and the
+ * "Get started" card on `/admin/settings`.
+ */
+
+/** The conference shape this resolver needs — the union of its three readers. */
+export type ConferenceForActivationResolution = ConferenceForActivation &
+  ConferenceTenant &
+  ConferenceForSystemChecks
+
+/**
+ * Whether outbound email rides the PLATFORM's Resend credentials rather than
+ * this tenant's own — i.e. whether "configure the Resend API key" is an
+ * instruction this organizer could possibly follow.
+ *
+ * `RESEND_API_KEY` is a deployment environment variable; nothing in Sanity or
+ * the per-org secret store can override it. So the question is really "who owns
+ * this deployment's environment?", and the one signal for that already in the
+ * codebase is the platform-org contract:
+ *
+ *  - `PLATFORM_ORG_ID` UNSET → single-tenant / self-hosted. There is no
+ *    operator above the organizer; the key IS theirs to set, so the row stays a
+ *    real, achievable requirement.
+ *  - SET, and this is the platform org → the operator's own tenant. Same
+ *    answer: they hold the environment.
+ *  - SET, and this is any OTHER tenant → the shared platform. The key belongs
+ *    to the operator, the tenant cannot see it, and telling them to configure
+ *    it is the impossible step #839 is about.
+ *
+ * Fails toward "the organizer owns it" on an unresolvable org, which is the
+ * safe direction here: the worst case is a row that stays visible and
+ * actionable, not a launch requirement silently deleted.
+ */
+async function isEmailDeliveryPlatformManaged(
+  orgId: string | null,
+): Promise<boolean> {
+  if (resolvePlatformOrgId() === null) return false
+  if (!orgId) return false
+  return !(await isPlatformOrganization(orgId))
+}
+
+/**
+ * Build the activation checklist for a conference with the entitlement and
+ * platform answers already resolved.
+ *
+ * @param conference the conference document (a superset of every slice read)
+ * @param checks     an ALREADY-built `SystemCheck[]` when the caller has one
+ *                   (the settings page builds the full set for its own status
+ *                   section). Omitted, the static checks are collected here —
+ *                   the two ids the checklist reads (`email.resendKey`,
+ *                   `slack.botToken`) are both static, so the two paths agree
+ *                   by construction rather than by a second env derivation
+ *                   that could drift from the check registry.
+ */
+export async function resolveActivationChecklist(
+  conference: ConferenceForActivationResolution,
+  checks?: SystemCheck[],
+): Promise<ActivationChecklist> {
+  const orgId = conferenceOrgId(conference)
+  const [ticketingAvailable, emailDeliveryManagedByPlatform] =
+    await Promise.all([
+      isTicketingEnabledForOrg(orgId),
+      isEmailDeliveryPlatformManaged(orgId),
+    ])
+
+  return buildActivationChecklist(
+    conference,
+    checks ?? collectStaticChecks(conference),
+    {
+      ticketingAvailable,
+      emailDeliveryManagedByPlatform,
+    },
+  )
+}

--- a/src/lib/settings/activation.test.ts
+++ b/src/lib/settings/activation.test.ts
@@ -1,13 +1,22 @@
 import { describe, it, expect } from 'vitest'
 import {
+  ACTIVATION_CHECKLIST_HREF,
   buildActivationChecklist,
+  currentActivationStage,
   hasCustomDomain,
   hasTicketingBinding,
   isUntouchedStarterFormatSet,
+  nextActivationSteps,
   type ConferenceForActivation,
 } from './activation'
 import { STARTER_SESSION_FORMATS } from '@/lib/onboarding/create'
+import { buildProvisionedConference } from '../../../__tests__/testdata/onboarding'
 import type { SystemCheck } from '@/lib/system-status/types'
+
+/** A tenant EXACTLY as provisioning creates it (see the fixture's own note). */
+function provisioned(): ConferenceForActivation {
+  return buildProvisionedConference() as ConferenceForActivation
+}
 
 /** A fully configured, live conference — every required row should be done. */
 const FULLY_LIVE: ConferenceForActivation = {
@@ -390,6 +399,281 @@ describe('buildActivationChecklist', () => {
       'branding-logo',
     )
     expect(row.anchor).toBe('/admin/settings/appearance#logos')
+  })
+})
+
+describe('the two activation stages', () => {
+  it('puts exactly the CFP critical path in the cfp stage', () => {
+    // Not a matter of taste: `canAcceptProposals` is formats AND topics, and
+    // `isCfpOpen` is the window (@/lib/conference/state). Those three, nothing
+    // else — anything extra here would delay a CFP that could already open.
+    const checklist = buildActivationChecklist(FULLY_LIVE, CHECKS_OK)
+    expect(
+      checklist.rows.filter((r) => r.stage === 'cfp').map((r) => r.id),
+    ).toEqual(['cfp-window', 'topics', 'formats'])
+  })
+
+  it('orders rows stage-major with Go live still last overall', () => {
+    const stages = buildActivationChecklist(FULLY_LIVE, CHECKS_OK).rows.map(
+      (r) => r.stage,
+    )
+    expect(stages.indexOf('launch')).toBe(stages.lastIndexOf('cfp') + 1)
+    expect(
+      buildActivationChecklist(FULLY_LIVE, CHECKS_OK).rows.at(-1)?.id,
+    ).toBe('visibility')
+  })
+
+  it('groups every row into a stage and rolls each one up separately', () => {
+    const checklist = buildActivationChecklist(FULLY_LIVE, CHECKS_OK)
+    expect(checklist.stages.map((s) => s.id)).toEqual(['cfp', 'launch'])
+    expect(checklist.stages.flatMap((s) => s.rows).map((r) => r.id)).toEqual(
+      checklist.rows.map((r) => r.id),
+    )
+    expect(checklist.stages.reduce((sum, s) => sum + s.required, 0)).toBe(
+      checklist.required,
+    )
+    expect(checklist.stages.every((s) => s.allDone)).toBe(true)
+  })
+
+  it('reports the cfp stage incomplete while the window is unset', () => {
+    const checklist = buildActivationChecklist(
+      { ...FULLY_LIVE, cfpStartDate: undefined, cfpEndDate: undefined },
+      CHECKS_OK,
+    )
+    const cfp = checklist.stages.find((s) => s.id === 'cfp')
+    expect(cfp?.allDone).toBe(false)
+    expect(cfp?.done).toBe(2)
+    expect(cfp?.required).toBe(3)
+    expect(currentActivationStage(checklist)?.id).toBe('cfp')
+  })
+})
+
+describe('readyToGoLive', () => {
+  it('is true when only the launch switch itself is outstanding', () => {
+    // `allDone` cannot answer this: an unlisted conference always has the
+    // `visibility` row outstanding, so the banner would never graduate.
+    const checklist = buildActivationChecklist(
+      { ...FULLY_LIVE, visibility: 'unlisted' },
+      CHECKS_OK,
+    )
+    expect(checklist.allDone).toBe(false)
+    expect(checklist.readyToGoLive).toBe(true)
+  })
+
+  it('is false while any other required row is outstanding', () => {
+    const checklist = buildActivationChecklist(
+      { ...FULLY_LIVE, visibility: 'unlisted', venueName: undefined },
+      CHECKS_OK,
+    )
+    expect(checklist.readyToGoLive).toBe(false)
+  })
+
+  it('is true for a fully configured live conference', () => {
+    expect(buildActivationChecklist(FULLY_LIVE, CHECKS_OK).readyToGoLive).toBe(
+      true,
+    )
+  })
+})
+
+describe('rows the organizer cannot complete (#839)', () => {
+  describe('ticketing', () => {
+    it('stays a required row by default — an unresolved answer hides nothing', () => {
+      const row = rowById(buildActivationChecklist({}, []), 'ticketing')
+      expect(row.unavailable).toBeUndefined()
+      expect(row.hint).toMatch(/checkin/i)
+    })
+
+    it('is demoted to unavailable for an org without the entitlement', () => {
+      const checklist = buildActivationChecklist({}, [], {
+        ticketingAvailable: false,
+      })
+      const row = rowById(checklist, 'ticketing')
+      expect(row.unavailable).toBe('Not on your plan')
+      expect(row.hint).toMatch(/not part of your plan/i)
+    })
+
+    it('drops out of the required rollup when unavailable', () => {
+      const withTicketing = buildActivationChecklist(FULLY_LIVE, CHECKS_OK)
+      const withoutTicketing = buildActivationChecklist(FULLY_LIVE, CHECKS_OK, {
+        ticketingAvailable: false,
+      })
+      expect(withoutTicketing.required).toBe(withTicketing.required - 1)
+      // Still LISTED — an absent row would just be a surface that vanished.
+      expect(withoutTicketing.rows.map((r) => r.id)).toContain('ticketing')
+    })
+
+    it('is never offered as a next step for an unentitled org', () => {
+      // Everything else done, ticketing unbound: with the entitlement this is
+      // the next step; without it, there is nothing left to ask for.
+      const conference: ConferenceForActivation = {
+        ...FULLY_LIVE,
+        checkinCustomerId: undefined,
+        checkinEventId: undefined,
+      }
+      expect(
+        nextActivationSteps(
+          buildActivationChecklist(conference, CHECKS_OK),
+        ).map((r) => r.id),
+      ).toEqual(['ticketing'])
+      expect(
+        nextActivationSteps(
+          buildActivationChecklist(conference, CHECKS_OK, {
+            ticketingAvailable: false,
+          }),
+        ),
+      ).toEqual([])
+    })
+  })
+
+  describe('email delivery', () => {
+    it('keeps asking for the Resend key on a self-hosted deployment', () => {
+      const row = rowById(buildActivationChecklist({}, []), 'email-delivery')
+      expect(row.unavailable).toBeUndefined()
+      expect(row.hint).toMatch(/Resend API key/i)
+    })
+
+    it('never asks a shared-tier tenant to set a platform variable', () => {
+      const row = rowById(
+        buildActivationChecklist({}, [], {
+          emailDeliveryManagedByPlatform: true,
+        }),
+        'email-delivery',
+      )
+      expect(row.unavailable).toBe('Platform-managed')
+      expect(row.hint).not.toMatch(/Resend API key/i)
+      expect(row.hint).toMatch(/no key here for you to set/i)
+    })
+
+    it('drops out of the required rollup when platform-managed', () => {
+      const own = buildActivationChecklist(FULLY_LIVE, CHECKS_OK)
+      const managed = buildActivationChecklist(FULLY_LIVE, CHECKS_OK, {
+        emailDeliveryManagedByPlatform: true,
+      })
+      expect(managed.required).toBe(own.required - 1)
+      expect(managed.rows.map((r) => r.id)).toContain('email-delivery')
+    })
+
+    it('stops blocking go-live for a tenant that cannot set the key', () => {
+      // The platform key is unset (no checks passed) — on the shared platform
+      // that is the operator's problem, not a launch blocker for the tenant.
+      const conference = { ...FULLY_LIVE, visibility: 'unlisted' }
+      expect(buildActivationChecklist(conference, []).readyToGoLive).toBe(false)
+      expect(
+        buildActivationChecklist(conference, [], {
+          emailDeliveryManagedByPlatform: true,
+        }).readyToGoLive,
+      ).toBe(true)
+    })
+  })
+})
+
+describe('nextActivationSteps', () => {
+  it('returns at most two rows, from the first incomplete stage only', () => {
+    const steps = nextActivationSteps(buildActivationChecklist({}, []))
+    expect(steps).toHaveLength(2)
+    expect(steps.every((r) => r.stage === 'cfp')).toBe(true)
+  })
+
+  it('honours an explicit limit', () => {
+    expect(
+      nextActivationSteps(buildActivationChecklist({}, []), 1),
+    ).toHaveLength(1)
+  })
+
+  it('moves on to the launch stage once the CFP one is satisfied', () => {
+    const checklist = buildActivationChecklist(
+      {
+        cfpStartDate: '2026-01-01',
+        cfpEndDate: '2026-03-01',
+        topics: [{ _id: 't1' }],
+        formats: ['lightning_10'],
+      },
+      [],
+    )
+    expect(currentActivationStage(checklist)?.id).toBe('launch')
+    expect(nextActivationSteps(checklist).map((r) => r.id)).toEqual([
+      'basics',
+      'dates',
+    ])
+  })
+
+  it('never returns an optional row', () => {
+    const checklist = buildActivationChecklist(FULLY_LIVE, [])
+    // Slack and custom-domain are unsatisfied here; neither may surface.
+    for (const row of nextActivationSteps(checklist, 99)) {
+      expect(row.optional).toBeUndefined()
+    }
+  })
+
+  it('is empty for a fully activated conference', () => {
+    const checklist = buildActivationChecklist(FULLY_LIVE, CHECKS_OK)
+    expect(checklist.allDone).toBe(true)
+    expect(currentActivationStage(checklist)).toBeNull()
+    expect(nextActivationSteps(checklist)).toEqual([])
+  })
+})
+
+describe('a freshly provisioned tenant — day one on /admin', () => {
+  const fresh = provisioned()
+
+  it('provisioning really does leave the CFP window and topics unset', () => {
+    // PREMISE GUARD. If provisioning starts seeding either, the expectations
+    // below are about a state that no longer exists.
+    expect(fresh.cfpStartDate).toBeUndefined()
+    expect(fresh.cfpEndDate).toBeUndefined()
+    expect(fresh.topics).toBeUndefined()
+    expect(fresh.startDate).toBeUndefined()
+    expect(fresh.endDate).toBeUndefined()
+    // ...and that it DOES seed formats (#833), so the CFP stage is 1/3 done.
+    expect(fresh.formats).toEqual([...STARTER_SESSION_FORMATS])
+    expect(fresh.visibility).toBe('unlisted')
+  })
+
+  it('offers exactly the real critical path as the next steps', () => {
+    // Shared-platform tenant: no ticketing entitlement, no email key of its
+    // own — the two rows it could never tick.
+    const checklist = buildActivationChecklist(fresh, [], {
+      ticketingAvailable: false,
+      emailDeliveryManagedByPlatform: true,
+    })
+    expect(currentActivationStage(checklist)?.title).toBe(
+      'Open your call for papers',
+    )
+    expect(nextActivationSteps(checklist).map((r) => r.id)).toEqual([
+      'cfp-window',
+      'topics',
+    ])
+  })
+
+  it('shows the hero — it is neither done nor ready to publish', () => {
+    const checklist = buildActivationChecklist(fresh, [], {
+      ticketingAvailable: false,
+      emailDeliveryManagedByPlatform: true,
+    })
+    expect(checklist.allDone).toBe(false)
+    expect(checklist.readyToGoLive).toBe(false)
+    expect(checklist.done).toBeGreaterThan(0)
+  })
+
+  it('asks it for nothing it cannot do', () => {
+    const checklist = buildActivationChecklist(fresh, [], {
+      ticketingAvailable: false,
+      emailDeliveryManagedByPlatform: true,
+    })
+    const outstanding = checklist.rows
+      .filter((r) => !r.done && !r.optional && !r.unavailable)
+      .map((r) => r.id)
+    expect(outstanding).not.toContain('ticketing')
+    expect(outstanding).not.toContain('email-delivery')
+  })
+})
+
+describe('the checklist anchor', () => {
+  it('points at the card, not at the publish switch', () => {
+    // The #839 regression in one assertion: the shell's setup affordance used
+    // to deep-link to `#visibility`, an anchor BELOW the checklist.
+    expect(ACTIVATION_CHECKLIST_HREF).toBe('/admin/settings#get-started')
+    expect(ACTIVATION_CHECKLIST_HREF).not.toContain('visibility')
   })
 })
 

--- a/src/lib/settings/activation.ts
+++ b/src/lib/settings/activation.ts
@@ -2,16 +2,47 @@
  * "Get started" activation checklist (onboarding S4).
  *
  * Pure, server-safe AND client-safe derivation of "what do I still need to
- * configure to launch?" for the admin Settings page. Every row is computed from
- * TWO sources:
+ * configure to launch?" — rendered as a card on the admin Settings page and as
+ * the activation hero on `/admin` itself. Every row is computed from THREE
+ * sources:
  *
  *   1. Required-field emptiness on the conference document (pure — no I/O).
  *   2. A SELECTIVE read of the already-built system checks
  *      (`buildSystemChecks`) where a wiring state overlaps launch-readiness
  *      (email delivery, Slack). This module NEVER re-probes — it only inspects
  *      the flat `SystemCheck[]` the caller already assembled.
+ *   3. {@link ActivationOptions} — the caller's already-resolved answers to the
+ *      two questions this module cannot ask without a server import: is this
+ *      tenant entitled to ticketing, and does it even own the email key. See
+ *      "rows the organizer cannot complete" below.
  *
- * The terminal row is `visibility` ("Go live"), the launch switch itself.
+ * ── TWO STAGES, NOT ONE FLAT LIST ──────────────────────────────────────────
+ *
+ * Rows carry a {@link ActivationStage}, and the order is stage-major:
+ *
+ *   `cfp`    — the CFP window plus the two things `canAcceptProposals`
+ *              (`@/lib/conference/state`) actually requires: formats and
+ *              topics. Nothing else stops a speaker submitting, so nothing
+ *              else belongs here.
+ *   `launch` — everything the public site wants before it is published,
+ *              terminating in `visibility` ("Go live"), the switch itself.
+ *
+ * The split exists because the hero on `/admin` names the organizer's NEXT
+ * step, and "next" is only meaningful against a critical path. A flat list in
+ * settings-card order would have opened a fresh tenant's onboarding with
+ * "Brand logo" while its CFP sat closed.
+ *
+ * ── ROWS THE ORGANIZER CANNOT COMPLETE (#839) ──────────────────────────────
+ *
+ * A checklist containing steps the user cannot complete teaches the user to
+ * ignore the checklist, so two rows are conditionally NOT theirs to do:
+ * `ticketing` for an org without the entitlement, and `email-delivery` for a
+ * tenant on the shared platform, whose Resend key is a platform environment
+ * variable it can neither see nor set. Both are marked
+ * {@link ActivationRow.unavailable} — still listed, so the surface is not
+ * silently missing, but excluded from the progress rollup and never offered as
+ * a next step. The caller resolves both booleans (see
+ * `@/lib/settings/activation-server`); this module stays pure.
  *
  * IMPORTANT — this module is imported by a Storybook story, so it must stay free
  * of any `server-only` / `next/cache` transitive import. Two tiny pure predicates
@@ -29,10 +60,62 @@ import { APPEARANCE_SECTION } from '@/lib/settings/appearance'
 import { STARTER_SESSION_FORMATS } from '@/lib/onboarding/create'
 import { formats as FORMAT_TITLES } from '@/lib/proposal/types'
 
+/**
+ * Which half of activation a row belongs to. `cfp` is the critical path to a
+ * CFP that can actually receive a proposal; `launch` is everything the public
+ * site wants before it goes live. See the module header.
+ */
+export type ActivationStage = 'cfp' | 'launch'
+
+/** Display metadata for one stage — the heading the card and the hero share. */
+export interface ActivationStageMeta {
+  id: ActivationStage
+  /** Imperative heading ("Open your call for papers"). */
+  title: string
+  /** One line saying what being short of this stage costs the organizer. */
+  description: string
+}
+
+/** The stages in order. The first one with outstanding work is "what's next". */
+export const ACTIVATION_STAGES: readonly ActivationStageMeta[] = [
+  {
+    id: 'cfp',
+    title: 'Open your call for papers',
+    description:
+      'Until these are set a speaker cannot submit a proposal at all.',
+  },
+  {
+    id: 'launch',
+    title: 'Get ready to launch',
+    description:
+      'The rest of the setup, ending with the switch that publishes your site.',
+  },
+]
+
+/**
+ * The id of the terminal row — the launch switch. Excluded from
+ * {@link ActivationChecklist.readyToGoLive} because that flag exists to answer
+ * "may this organizer flip the switch yet?", and the switch cannot be its own
+ * precondition.
+ */
+export const ACTIVATION_LAUNCH_ROW_ID = 'visibility'
+
+/**
+ * The DOM id the full checklist card carries on the Settings page, and the
+ * href that lands on it. Single-sourced here so the `/admin` hero and the
+ * unlisted banner cannot drift from the anchor the card actually renders
+ * (`ActivationChecklist.tsx`) — the bug #839 opens on, where "Go live" pointed
+ * at `#visibility`, an anchor BELOW the checklist.
+ */
+export const ACTIVATION_CHECKLIST_ANCHOR = 'get-started'
+export const ACTIVATION_CHECKLIST_HREF = `/admin/settings#${ACTIVATION_CHECKLIST_ANCHOR}`
+
 /** A single checklist line. */
 export interface ActivationRow {
   /** Stable id (test + React key). */
   id: string
+  /** Which stage the row belongs to; also fixes its position in `rows`. */
+  stage: ActivationStage
   /** Short imperative label ("Set conference dates"). */
   label: string
   /** Whether the requirement is satisfied. */
@@ -60,18 +143,51 @@ export interface ActivationRow {
    * from the progress numerator/denominator and rendered in a muted style.
    */
   optional?: boolean
+  /**
+   * Set when the row is NOT this organizer's to complete — the string is the
+   * short badge text saying why ("Not on your plan", "Platform-managed").
+   *
+   * Excluded from the progress rollup exactly like `optional`, and never
+   * returned by {@link nextActivationSteps}: a checklist that asks for
+   * something the user cannot do teaches them to ignore the checklist (#839).
+   * Distinct from `optional`, which is a real choice they declined; this is an
+   * absence of agency, and the two must not read the same.
+   */
+  unavailable?: string
+}
+
+/** One stage's rows plus its own rollup. */
+export interface ActivationStageGroup extends ActivationStageMeta {
+  /** The stage's rows in display order. */
+  rows: ActivationRow[]
+  /** Required rows in this stage that are done. */
+  done: number
+  /** Total required rows in this stage. */
+  required: number
+  /** True when every required row in this stage is done. */
+  allDone: boolean
 }
 
 /** The derived checklist plus its progress rollup. */
 export interface ActivationChecklist {
-  /** All rows in display order (required first, then optional, `visibility` last). */
+  /** All rows in display order (stage-major; `visibility` always last). */
   rows: ActivationRow[]
+  /** The same rows grouped by stage, in stage order. */
+  stages: ActivationStageGroup[]
   /** Required rows that are done. */
   done: number
-  /** Total required rows (optional rows excluded). */
+  /** Total required rows (optional and unavailable rows excluded). */
   required: number
   /** True when every REQUIRED row is done — the card collapses in this state. */
   allDone: boolean
+  /**
+   * Every required row EXCEPT the terminal launch switch is done: the
+   * conference is ready to be published. This — not `allDone` — is what the
+   * unlisted banner keys on, because an unlisted conference by definition has
+   * the `visibility` row outstanding, so `allDone` would be false forever and
+   * the banner could never graduate from "Finish setup" to "Go live".
+   */
+  readyToGoLive: boolean
 }
 
 /**
@@ -115,6 +231,27 @@ export interface ActivationOptions {
    * falls back to "more than the single auto-provisioned platform subdomain".
    */
   platformDomainSuffix?: string
+  /**
+   * Whether this tenant may use the ticketing surfaces at all (#828/#834 —
+   * `isTicketingEnabledForOrg`). `false` turns the `ticketing` row into an
+   * unavailable one: an org without the entitlement has no way to make those
+   * ids work, so counting them as a launch blocker asks for the impossible.
+   *
+   * DEFAULTS TO TRUE — "we did not resolve it" must not hide a step the tenant
+   * can in fact take. Only a resolved, negative answer demotes the row.
+   */
+  ticketingAvailable?: boolean
+  /**
+   * Whether outbound email is sent with the PLATFORM's credentials rather than
+   * this tenant's own. `true` turns `email-delivery` into an unavailable row:
+   * `RESEND_API_KEY` is a deployment environment variable, so on the shared
+   * platform the row was telling every tenant to configure a secret it cannot
+   * see, let alone set.
+   *
+   * DEFAULTS TO FALSE — the single-tenant / self-hosted deployment, where the
+   * organizer IS the operator and the key really is theirs to set.
+   */
+  emailDeliveryManagedByPlatform?: boolean
 }
 
 /** Non-empty string / present number. Trims strings; a 0 id counts as absent. */
@@ -230,41 +367,34 @@ export function buildActivationChecklist(
   // and stays "to do" until an organizer flips the switch.
   const isLive = conference.visibility !== 'unlisted'
 
-  const rows: ActivationRow[] = [
-    {
-      id: 'basics',
-      label: 'Name & organizer',
-      done: present(conference.title) && present(conference.organizer),
-      anchor: '#identity-brand',
-      hint: 'Set the conference name and the organizing body.',
-    },
-    {
-      id: 'branding-logo',
-      label: 'Brand logo',
-      done: hasLogo,
-      anchor: APPEARANCE_SECTION.logos.href,
-      hint: 'Upload a logo so the site and emails carry your brand.',
-    },
-    {
-      id: 'venue',
-      label: 'Venue',
-      done: present(conference.venueName),
-      anchor: '#identity-brand',
-      hint: 'Name the venue so attendees know where to go.',
-    },
-    {
-      id: 'dates',
-      label: 'Conference dates',
-      done: present(conference.startDate) && present(conference.endDate),
-      anchor: '#schedule',
-      hint: 'Set the start and end dates of the event.',
-    },
+  // Ticketing is gated per organization (#828/#834). Only a RESOLVED "no"
+  // demotes the row — see `ActivationOptions.ticketingAvailable`.
+  const ticketingAvailable = options.ticketingAvailable !== false
+  const emailManagedByPlatform = options.emailDeliveryManagedByPlatform === true
+
+  // STAGE 1 — the CFP critical path, and nothing else. Membership is not a
+  // matter of taste: `canAcceptProposals` (@/lib/conference/state) is formats
+  // AND topics, and `isCfpOpen` is the window. Those three predicates are what
+  // the public CFP page and both submit routes actually enforce, so those three
+  // rows are what stands between a new tenant and a proposal in the inbox.
+  // Dates, branding and venue deliberately sit in `launch`: a CFP with "dates
+  // TBA" is a normal conference, a CFP with no topics is a broken form.
+  const cfpRows: ActivationRow[] = [
     {
       id: 'cfp-window',
+      stage: 'cfp',
       label: 'Call-for-papers window',
       done: present(conference.cfpStartDate) && present(conference.cfpEndDate),
       anchor: '#schedule',
       hint: 'Open the CFP by setting its start and end dates.',
+    },
+    {
+      id: 'topics',
+      stage: 'cfp',
+      label: 'At least one topic',
+      done: Array.isArray(conference.topics) && conference.topics.length > 0,
+      anchor: '#team-content',
+      hint: 'Add topics so speakers can categorise their proposals.',
     },
     {
       // REQUIRED to submit, not cosmetic: a proposal must carry a format
@@ -278,6 +408,7 @@ export function buildActivationChecklist(
       // saying whose choice it was, since a bare strike-through would read as
       // "you picked these".
       id: 'formats',
+      stage: 'cfp',
       label: 'Session formats',
       done: Array.isArray(conference.formats) && conference.formats.length > 0,
       anchor: '#team-content',
@@ -288,15 +419,45 @@ export function buildActivationChecklist(
           }
         : {}),
     },
+  ]
+
+  // STAGE 2 — everything the published site wants, terminating in the switch.
+  const launchRows: ActivationRow[] = [
     {
-      id: 'topics',
-      label: 'At least one topic',
-      done: Array.isArray(conference.topics) && conference.topics.length > 0,
-      anchor: '#team-content',
-      hint: 'Add topics so speakers can categorise their proposals.',
+      id: 'basics',
+      stage: 'launch',
+      label: 'Name & organizer',
+      done: present(conference.title) && present(conference.organizer),
+      anchor: '#identity-brand',
+      hint: 'Set the conference name and the organizing body.',
+    },
+    {
+      id: 'dates',
+      stage: 'launch',
+      label: 'Conference dates',
+      done: present(conference.startDate) && present(conference.endDate),
+      anchor: '#schedule',
+      hint: 'Set the start and end dates of the event.',
+    },
+    {
+      id: 'venue',
+      stage: 'launch',
+      label: 'Venue',
+      done: present(conference.venueName),
+      anchor: '#identity-brand',
+      hint: 'Name the venue so attendees know where to go.',
+    },
+    {
+      id: 'branding-logo',
+      stage: 'launch',
+      label: 'Brand logo',
+      done: hasLogo,
+      anchor: APPEARANCE_SECTION.logos.href,
+      hint: 'Upload a logo so the site and emails carry your brand.',
     },
     {
       id: 'emails',
+      stage: 'launch',
       label: 'Contact, CFP & sponsor emails',
       done:
         present(conference.contactEmail) &&
@@ -307,31 +468,48 @@ export function buildActivationChecklist(
     },
     {
       id: 'registration',
+      stage: 'launch',
       label: 'Registration link',
       done: present(conference.registrationLink),
       anchor: '#tickets-registration',
       hint: 'Link out to where attendees buy tickets or register.',
     },
     {
+      // ENTITLEMENT-AWARE (#839). Without the `ticketing` entitlement there are
+      // no credentials to resolve against (#820/#828), so however many ids the
+      // organizer types the surface stays unusable — a hard-required row they
+      // could never tick.
       id: 'ticketing',
+      stage: 'launch',
       label: 'Ticketing connected',
       done: hasTicketingBinding(conference),
       anchor: '#tickets-registration',
-      hint: ticketingHint,
+      hint: ticketingAvailable
+        ? ticketingHint
+        : 'Ticketing is not part of your plan, so there is nothing to connect here.',
+      ...(ticketingAvailable ? {} : { unavailable: 'Not on your plan' }),
     },
     {
       // Reused from the system checks — email delivery is a hard launch
-      // requirement (its check reports `error` when unset).
+      // requirement (its check reports `error` when unset) WHEREVER the key is
+      // the organizer's to set. On the shared platform it is not: the key is a
+      // deployment environment variable, so the row becomes informational and
+      // says who owns it instead of asking for something impossible (#839).
       id: 'email-delivery',
+      stage: 'launch',
       label: 'Email delivery configured',
       done: checkOk(checks, 'email.resendKey'),
       anchor: '#system-status',
-      hint: 'Configure the Resend API key so outbound email can send.',
+      hint: emailManagedByPlatform
+        ? 'Outbound email is sent for you on the platform account — there is no key here for you to set.'
+        : 'Configure the Resend API key so outbound email can send.',
+      ...(emailManagedByPlatform ? { unavailable: 'Platform-managed' } : {}),
     },
     {
       // Reused from the system checks — Slack is an optional integration (its
       // check reports `off`, not `error`, when unset).
       id: 'slack',
+      stage: 'launch',
       label: 'Slack notifications',
       done: checkOk(checks, 'slack.botToken'),
       anchor: '#system-status',
@@ -340,6 +518,7 @@ export function buildActivationChecklist(
     },
     {
       id: 'custom-domain',
+      stage: 'launch',
       label: 'Custom domain',
       done: hasCustomDomain(conference.domains, options.platformDomainSuffix),
       anchor: '#team-content',
@@ -350,7 +529,8 @@ export function buildActivationChecklist(
     // line. FUTURE: the paid-activation / billing gate (a "Complete payment"
     // step) will slot in immediately BEFORE this row once CaaS billing lands.
     {
-      id: 'visibility',
+      id: ACTIVATION_LAUNCH_ROW_ID,
+      stage: 'launch',
       label: 'Go live',
       done: isLive,
       anchor: '#visibility',
@@ -360,13 +540,66 @@ export function buildActivationChecklist(
     },
   ]
 
-  const requiredRows = rows.filter((r) => !r.optional)
+  const rows = [...cfpRows, ...launchRows]
+  const requiredRows = rows.filter(isRequired)
   const done = requiredRows.filter((r) => r.done).length
+
+  const stages: ActivationStageGroup[] = ACTIVATION_STAGES.map((meta) => {
+    const stageRows = rows.filter((r) => r.stage === meta.id)
+    const stageRequired = stageRows.filter(isRequired)
+    const stageDone = stageRequired.filter((r) => r.done).length
+    return {
+      ...meta,
+      rows: stageRows,
+      done: stageDone,
+      required: stageRequired.length,
+      allDone: stageDone === stageRequired.length,
+    }
+  })
 
   return {
     rows,
+    stages,
     done,
     required: requiredRows.length,
     allDone: done === requiredRows.length,
+    readyToGoLive: requiredRows
+      .filter((r) => r.id !== ACTIVATION_LAUNCH_ROW_ID)
+      .every((r) => r.done),
   }
+}
+
+/**
+ * A row that counts toward progress: the organizer's to do, and possible for
+ * them to do. `optional` and `unavailable` are excluded for different reasons
+ * (a declined choice vs. no agency) but share this consequence.
+ */
+function isRequired(row: ActivationRow): boolean {
+  return !row.optional && !row.unavailable
+}
+
+/**
+ * The outstanding required rows to put in front of the organizer RIGHT NOW —
+ * the hero on `/admin` renders exactly this.
+ *
+ * Drawn from the FIRST stage with outstanding work and never spilling into the
+ * next one: the hero titles itself with that stage, so mixing in a launch row
+ * under "Open your call for papers" would misfile it. `unavailable` and
+ * `optional` rows can never appear here — that is the whole point of both
+ * flags.
+ */
+export function nextActivationSteps(
+  checklist: ActivationChecklist,
+  limit = 2,
+): ActivationRow[] {
+  const stage = checklist.stages.find((s) => !s.allDone)
+  if (!stage) return []
+  return stage.rows.filter((r) => isRequired(r) && !r.done).slice(0, limit)
+}
+
+/** The stage the organizer is currently working through, or `null` when done. */
+export function currentActivationStage(
+  checklist: ActivationChecklist,
+): ActivationStageGroup | null {
+  return checklist.stages.find((s) => !s.allDone) ?? null
 }


### PR DESCRIPTION
Closes #839.

## The defect

A new organizer lands on `/admin` — seven mostly-empty widgets — with **no reference anywhere to the activation checklist**. The checklist is well built; it just lives on `/admin/settings`, a screen they have no reason to visit yet. The only setup prompt in the shell was `UnlistedBanner`'s "Go live", deep-linking to `/admin/settings#visibility` — an anchor **below** the checklist — dropping a tenant with no topics, dates, venue or logo straight onto the publish switch. Placement, not copy: the artefact existed, it was in the wrong place.

## What a fresh organizer now sees on `/admin`

An **activation hero** above the widget grid:

> 🚀 **Open your call for papers** — 1/9 done
> _Until these are set a speaker cannot submit a proposal at all._
> ▓░░░░░░░░
> ○ **Call-for-papers window** — Open the CFP by setting its start and end dates.
> ○ **At least one topic** — Add topics so speakers can categorise their proposals.
> [See the full checklist →] · 8 steps left before you can go live

It renders only while a required row is outstanding. Once they are all done the hero is gone and `/admin` is exactly the dashboard it is today.

The hero is a **frame** around `buildActivationChecklist` and the existing `ActivationRowItem` — not a second telling of the steps that could drift from the card.

## The three judgement calls

**1. One next step or two? → Two.** For a freshly provisioned tenant those two are the whole real critical path (`cfp-window` + `topics`; `formats` is seeded by provisioning since #833), so the hero opens on everything standing between the organizer and a proposal in the inbox — and still stays short.

**2. Two-tier the checklist now? → Yes, and it was a prerequisite rather than a nice-to-have.** The hero names "your next step", and "next" is only meaningful against a critical path. Flat, in settings-card order, the first two outstanding rows for a fresh tenant are *Brand logo* and *Venue* — a signpost pointing at cosmetics while the CFP sits closed. The split is not a matter of taste: stage `cfp` is exactly what `canAcceptProposals` (formats + topics) and `isCfpOpen` (the window) already enforce on the public CFP page and both submit routes; stage `launch` is everything else, ending in the switch. Conference dates deliberately sit in `launch` — a CFP with "dates TBA" is a normal conference; a CFP with no topics is a broken form.

**3. Dismissible? → No.** While a required row is outstanding the hero is the only signpost to the checklist anywhere in the shell, so a dismiss control would restore the exact state this issue describes, with the added insult that the organizer chose it. It removes itself when the last required row is done — the honest version of dismissal. A test asserts there is no button.

## The two impossible rows

A checklist containing steps the user cannot complete teaches the user to ignore the checklist, so the hero must never surface one.

- **`ticketing`** — without the entitlement there are no credentials to resolve against (#820/#828), so however many ids the organizer types the surface stays unusable. The row is now demoted via the same gate the nav and the ticket pages ask (`isTicketingEnabledForOrg`).
- **`email-delivery`** — `RESEND_API_KEY` is a *deployment environment variable*. On the shared platform the tenant can neither see nor set it. Resolved from the platform-org contract: `PLATFORM_ORG_ID` unset (self-hosted) or this *is* the platform org → the key really is theirs, row unchanged; any other tenant on a shared deployment → platform-managed.

Both stay **listed and badged** ("Not on your plan" / "Platform-managed") rather than deleted — a silently missing surface is its own confusion — but they leave the progress rollup and can never be returned by `nextActivationSteps`. Unavailable rows also stop being links: there is nothing behind the anchor for that organizer.

## Shape

- `ActivationRow` gains `stage` and `unavailable?: string` (badge text; excluded from the rollup for a *different reason* than `optional`, and the two must not read the same).
- `ActivationChecklist` gains `stages[]` and `readyToGoLive` — the banner keys on the latter, not `allDone`, because an unlisted conference has the `visibility` row outstanding by definition and `allDone` would keep it on "Finish setup" forever.
- New `src/lib/settings/activation-server.ts` resolves the entitlement and platform answers once; `/admin`, the admin layout and `/admin/settings` all go through it, so the three surfaces cannot disagree. `activation.ts` stays pure and client-safe (a Storybook story renders it).
- `ACTIVATION_CHECKLIST_HREF` single-sources the anchor the card actually renders, so the "point past the checklist" bug cannot come back by drift.
- Both `/admin` and the admin layout now project `topics: true` — topics are an opt-in join and the boundary normaliser returns `[]` without it, which would have told every conference on earth to add its first topic.

## Sabotage-proven

Each guard removed by exact string, matching tests confirmed failing, restored, confirmed green:

| # | Guard removed | Result |
|---|---|---|
| 1 | hero's `if (!stage \|\| steps.length === 0) return null` | 1 test fails |
| 2 | banner CTA label ternary | 4 tests fail |
| 3 | banner CTA target ternary | 1 test fails |
| 4 | `unavailable: 'Not on your plan'` on the ticketing row | 5 tests fail |
| 5 | platform-aware email hint | 2 tests fail |
| 6 | `!(await isPlatformOrganization(orgId))` in the server seam | 2 tests fail |
| 7 | `&& !row.unavailable` in `isRequired` | 4 tests fail |
| 8 | stage confinement + `slice(0, limit)` in `nextActivationSteps` | 6 tests fail |

The day-one fixture is built by the real `buildOnboardingDocuments` (`__tests__/testdata/onboarding.ts`) and premise-guards what is genuinely unset today — dates, CFP window and topics — while asserting that formats *are* seeded, so a provisioning change fails loudly instead of quietly.

## Numbers

| | before | after |
|---|---|---|
| `pnpm test` | 503 files / 7243 tests | **505 files / 7289 tests**, all passing |
| `pnpm typecheck` | clean | clean |
| `npx prettier --check .` | clean | clean |
| `npx eslint .` | 0 errors, 209 warnings | 0 errors, 209 warnings |
| `pnpm knip` | 1 pre-existing config hint | unchanged |

## ⚠️ Visual inspection could not be run

`pnpm shoot` is blocked in this environment: every Playwright browser (chromium, headless shell, webkit) dies at launch with `SIGTRAP` / `kill EPERM`, from both this worktree and the main checkout, and no system Chrome is installed. Storybook itself starts fine and all stories index, so the stories compile — but **the hero has not been looked at**. Stories are provided for that purpose and should be shot before merge:

- `systems-admin-activationhero--fresh` / `--cfp-open` / `--nearly-live` / `--fresh-dark` / `--nearly-live-dark`
- `systems-admin-settings-activationchecklist--shared-platform-tenant` (the two badged unavailable rows)
- `systems-admin-unlistedbanner--setup-incomplete` / `--ready-to-go-live` (+ dark)