### PR TITLE
fix(cfp): gate both submit routes behind one shared "may this become submitted?" predicate

### DIFF
--- a/__tests__/api/trpc/proposal.test.ts
+++ b/__tests__/api/trpc/proposal.test.ts
@@ -471,6 +471,52 @@ describe('proposal router', () => {
       expect(createProposal).not.toHaveBeenCalled()
     })
 
+    it('refuses a submission whose payload carries an unreadable topic entry', async () => {
+      // The fold that lets the gate read stored topics (`topicIdsOf`) DROPS
+      // entries it cannot read, so without this a payload with one good topic
+      // and one empty `_ref` would pass "strict validation" on the survivor and
+      // create a proposal with fewer topics than the caller asked for, silently.
+      // `_ref` is `z.string()` with no `.min(1)`, so an empty one gets past the
+      // input schema and reaches the gate.
+      //
+      // THE CAP IS DELIBERATELY ALREADY REACHED. `requireTopicsReferenceable`
+      // refuses this same shape with this same message further down `create`,
+      // so a test on an ordinary payload passes even with the gate's own check
+      // deleted — it proves the neighbour, not the predicate. The cap sits
+      // BETWEEN them and refuses with a different code, so reaching
+      // `Invalid topic reference` here can only be the gate: unreadable content
+      // is refused before the fairness rule is even considered.
+      vi.mocked(isCfpOpen).mockReturnValue(true)
+      vi.mocked(hasSubmittableFormats).mockReturnValue(true)
+      vi.mocked(getProposals).mockResolvedValue({
+        proposals: [
+          { ...mockProposal, _id: 'p1', status: Status.submitted },
+          { ...mockProposal, _id: 'p2', status: Status.submitted },
+          { ...mockProposal, _id: 'p3', status: Status.accepted },
+        ] as any,
+        proposalsError: null,
+      })
+      vi.mocked(createProposal).mockClear()
+
+      const caller = createAuthenticatedCaller(regularSpeaker._id)
+      await expect(
+        caller.proposal.create({
+          data: {
+            ...validProposalData,
+            topics: [
+              { _type: 'reference' as const, _ref: 'topic-1' },
+              { _type: 'reference' as const, _ref: '' },
+            ],
+          },
+          status: Status.submitted,
+        }),
+      ).rejects.toMatchObject({
+        code: 'BAD_REQUEST',
+        message: expect.stringContaining('Invalid topic reference'),
+      })
+      expect(createProposal).not.toHaveBeenCalled()
+    })
+
     it('still allows a DRAFT when the conference offers no formats', async () => {
       // Drafts are the incomplete-work path (they skip strict validation too),
       // so preparing one before the organizers announce formats is legitimate.
@@ -935,6 +981,54 @@ describe('proposal router', () => {
           action: Action.submit,
         })
         expect(result.proposalStatus).toBe(Status.submitted)
+      })
+
+      it('TOLERATES an unreadable stored topic entry, validating the survivors', async () => {
+        // The opposite call to the payload path, deliberately. A `topics[]->`
+        // projection yields `null` for a topic that was since deleted, so these
+        // entries are pre-existing data the speaker did not cause and cannot
+        // fix — refusing would strand them. The gate logs and submits on the
+        // readable ones. This pins that as a decision, not an accident.
+        draft({
+          topics: [
+            { _id: 'topic-1', title: 'Platform engineering', color: '#fff' },
+            null,
+          ],
+        })
+        vi.mocked(updateProposalStatus).mockResolvedValue({
+          proposal: { ...mockProposal, status: Status.submitted } as any,
+          err: null,
+        })
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        const caller = createAuthenticatedCaller(regularSpeaker._id)
+        const result = await caller.proposal.action({
+          id: 'proposal-1',
+          action: Action.submit,
+        })
+        expect(result.proposalStatus).toBe(Status.submitted)
+        expect(warn).toHaveBeenCalledWith(
+          expect.stringContaining('unreadable topic'),
+        )
+        warn.mockRestore()
+      })
+
+      it('still refuses a stored draft whose topics are ALL unreadable', async () => {
+        // Tolerance is not blindness: what the speaker CAN fix — having at
+        // least one usable topic — is still enforced, because the fold leaves
+        // the survivors (here, none) to strict validation.
+        draft({ topics: [null, { _id: '' }] })
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        const caller = createAuthenticatedCaller(regularSpeaker._id)
+        await expect(
+          caller.proposal.action({ id: 'proposal-1', action: Action.submit }),
+        ).rejects.toMatchObject({
+          code: 'BAD_REQUEST',
+          message: expect.stringContaining('At least one topic is required'),
+        })
+        expect(updateProposalStatus).not.toHaveBeenCalled()
+        warn.mockRestore()
       })
 
       it('does NOT validate content on other transitions', async () => {

--- a/__tests__/api/trpc/proposal.test.ts
+++ b/__tests__/api/trpc/proposal.test.ts
@@ -277,6 +277,10 @@ describe('proposal router', () => {
     })
 
     it('should reject when CFP is closed', async () => {
+      // PAIR: the `action` route has the same case ("should refuse submitting a
+      // draft after the CFP has closed"). Both refusals come from the single
+      // window condition in `assertMayBecomeSubmitted`, so removing it must
+      // fail both.
       vi.mocked(isCfpOpen).mockReturnValue(false)
 
       const caller = createAuthenticatedCaller(regularSpeaker._id)
@@ -289,6 +293,28 @@ describe('proposal router', () => {
         code: 'FORBIDDEN',
         message: expect.stringContaining('Call for Papers is currently closed'),
       })
+    })
+
+    it('still allows a DRAFT when the CFP is closed', async () => {
+      // The window gates the transition to `submitted`, not the incomplete-work
+      // path. An API/CLI caller must be able to prepare a draft before the
+      // window opens (or after it closes) — nothing is submitted by doing so.
+      vi.mocked(isCfpOpen).mockReturnValue(false)
+      vi.mocked(getProposals).mockResolvedValue({
+        proposals: [],
+        proposalsError: null,
+      })
+      vi.mocked(createProposal).mockResolvedValue({
+        proposal: { ...mockProposal, status: Status.draft } as any,
+        err: null,
+      })
+
+      const caller = createAuthenticatedCaller(regularSpeaker._id)
+      const result = await caller.proposal.create({
+        data: { title: 'Draft outside the window' },
+        status: Status.draft,
+      })
+      expect(result.status).toBe(Status.draft)
     })
 
     it('should enforce max 3 proposals per conference', async () => {
@@ -678,6 +704,75 @@ describe('proposal router', () => {
       await expect(
         caller.proposal.action({ id: 'proposal-1', action: Action.accept }),
       ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    })
+
+    it('should refuse submitting a draft after the CFP has closed', async () => {
+      // PAIR of `create`'s "should reject when CFP is closed". A draft prepared
+      // while the window was open must not be promotable a month after it shut:
+      // the deadline means nothing if the second submit route ignores it.
+      vi.mocked(isCfpOpen).mockReturnValue(false)
+      vi.mocked(hasSubmittableFormats).mockReturnValue(true)
+      vi.mocked(getProposalSanity).mockResolvedValue({
+        proposal: { ...mockProposal, status: Status.draft } as any,
+        proposalError: null,
+      })
+      vi.mocked(getProposals).mockResolvedValue({
+        proposals: [],
+        proposalsError: null,
+      })
+      vi.mocked(updateProposalStatus).mockClear()
+
+      const caller = createAuthenticatedCaller(regularSpeaker._id)
+      await expect(
+        caller.proposal.action({ id: 'proposal-1', action: Action.submit }),
+      ).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+        message: expect.stringContaining('Call for Papers is currently closed'),
+      })
+      expect(updateProposalStatus).not.toHaveBeenCalled()
+    })
+
+    it('should refuse an ORGANIZER submitting a draft after the CFP closes', async () => {
+      // No organizer carve-out on the window, matching the formats and content
+      // conditions: an out-of-window submission is wrong whoever promotes it.
+      // Organizers who want to accept late work have `unsubmit` (which they
+      // keep after the close) and the CFP end date itself.
+      vi.mocked(isCfpOpen).mockReturnValue(false)
+      vi.mocked(hasSubmittableFormats).mockReturnValue(true)
+      vi.mocked(getProposalSanity).mockResolvedValue({
+        proposal: { ...mockProposal, status: Status.draft } as any,
+        proposalError: null,
+      })
+      vi.mocked(updateProposalStatus).mockClear()
+
+      const caller = createAdminCaller()
+      await expect(
+        caller.proposal.action({ id: 'proposal-1', action: Action.submit }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+      expect(updateProposalStatus).not.toHaveBeenCalled()
+    })
+
+    it('should still allow withdrawing after the CFP has closed', async () => {
+      // The window gate is scoped to draft → submitted. Withdrawal is how a
+      // speaker exits a proposal once the CFP is over, so it must stay open.
+      vi.mocked(isCfpOpen).mockReturnValue(false)
+      vi.mocked(isWithdrawalCutoffActive).mockReturnValue(false)
+      vi.mocked(getProposalSanity).mockResolvedValue({
+        proposal: mockProposal as any,
+        proposalError: null,
+      })
+      vi.mocked(updateProposalStatus).mockResolvedValue({
+        proposal: { ...mockProposal, status: Status.withdrawn } as any,
+        err: null,
+      })
+
+      const caller = createAuthenticatedCaller(regularSpeaker._id)
+      const result = await caller.proposal.action({
+        id: 'proposal-1',
+        action: Action.withdraw,
+        reason: 'The CFP closed and my plans changed.',
+      })
+      expect(result.proposalStatus).toBe(Status.withdrawn)
     })
 
     it('should refuse submitting a draft when the conference offers no formats', async () => {

--- a/src/lib/conference/state.ts
+++ b/src/lib/conference/state.ts
@@ -48,9 +48,16 @@ export function isConferenceOver(conference: Conference): boolean {
 }
 
 /**
- * Check if the Call for Papers is currently open
+ * Check if the Call for Papers is currently open.
+ *
+ * Takes only the two dates it reads, so a caller holding a partially projected
+ * conference — or a gate that wants its signature to state exactly which fields
+ * it depends on, as `assertMayBecomeSubmitted` does — can pass one without a
+ * cast. A full `Conference` satisfies it unchanged.
  */
-export function isCfpOpen(conference: Conference): boolean {
+export function isCfpOpen(
+  conference: Pick<Conference, 'cfpStartDate' | 'cfpEndDate'>,
+): boolean {
   if (!conference.cfpStartDate || !conference.cfpEndDate) {
     return false
   }
@@ -122,12 +129,12 @@ export function hasSubmittableTopics(conference: {
  * (the public `/cfp` page and the `/cfp/proposal` submit page) pass
  * `{ topics: true }`.
  *
- * `src/server/routers/proposal.ts` does NOT project topics and so keeps the
- * narrower `hasSubmittableFormats` gate. What refuses a topic-less proposal
- * there is the STRICT CONTENT VALIDATION on both submit paths — `create`
- * parses the incoming payload, `action`'s draft → submitted transition parses
- * the stored document — not a conference-level gate. Do not read the formats
- * gate as covering topics; it does not.
+ * `src/server/routers/proposal.ts` does NOT project topics, so the submit gate
+ * both of its routes share (`assertMayBecomeSubmitted`) keeps the narrower
+ * `hasSubmittableFormats` check. What refuses a topic-less proposal there is
+ * that gate's STRICT CONTENT VALIDATION — the proposal's own topics — not a
+ * conference-level check. Do not read the formats gate as covering topics; it
+ * does not.
  */
 export function canAcceptProposals(conference: {
   formats?: Conference['formats']

--- a/src/server/proposalSubmission.ts
+++ b/src/server/proposalSubmission.ts
@@ -13,10 +13,12 @@ import type { Conference } from '@/lib/conference/types'
  * below (which validates content in either shape) and the reference-injection
  * check in `proposal.ts` (which counts ids against this org).
  *
- * Entries it cannot read are DROPPED rather than preserved, which callers rely
- * on in opposite directions: the gate sees them as missing topics, and
- * `requireTopicsReferenceable` compares the id count against the input length
- * to detect them.
+ * IT IS LOSSY: entries it cannot read are DROPPED rather than preserved. That
+ * is a silent narrowing, so every caller has to decide what a dropped entry
+ * means rather than take the survivors at face value — both of them do it the
+ * same way, by comparing the id count against the input length
+ * (`assertMayBecomeSubmitted` below, `requireTopicsReferenceable` in
+ * `proposal.ts`).
  */
 export function topicIdsOf(topics: unknown): string[] {
   if (!Array.isArray(topics)) return []
@@ -81,7 +83,7 @@ const NO_FORMATS_MESSAGE =
  * `getConferenceForCurrentDomain()` WITHOUT projecting topics, and the boundary
  * normaliser coerces the absent field to `[]`, so a topic-aware conference gate
  * here would fail CLOSED on every well-configured conference (see
- * `canAcceptProposals`). What refuses a topic-less proposal is step 3 — the
+ * `canAcceptProposals`). What refuses a topic-less proposal is step 4 — the
  * content carries its own topics — not a conference-level check. Do not widen
  * this signature without widening the projection first.
  *

--- a/src/server/proposalSubmission.ts
+++ b/src/server/proposalSubmission.ts
@@ -1,0 +1,127 @@
+import { TRPCError } from '@trpc/server'
+import { ProposalInputSchema } from '@/server/schemas/proposal'
+import { hasSubmittableFormats, isCfpOpen } from '@/lib/conference/state'
+import type { Conference } from '@/lib/conference/types'
+
+/**
+ * Fold a `topics` value — in EITHER shape — down to plain topic ids.
+ *
+ * A proposal's topics arrive as `{ _type: 'reference', _ref }` on the way IN
+ * (client payload) but come back as dereferenced documents `{ _id, title,
+ * color }` on the way OUT (`getProposal` projects `topics[]->`). Both shapes
+ * are accepted here so a single fold serves every caller: the submit gate
+ * below (which validates content in either shape) and the reference-injection
+ * check in `proposal.ts` (which counts ids against this org).
+ *
+ * Entries it cannot read are DROPPED rather than preserved, which callers rely
+ * on in opposite directions: the gate sees them as missing topics, and
+ * `requireTopicsReferenceable` compares the id count against the input length
+ * to detect them.
+ */
+export function topicIdsOf(topics: unknown): string[] {
+  if (!Array.isArray(topics)) return []
+  return topics
+    .map((topic) => {
+      if (!topic || typeof topic !== 'object') return undefined
+      const t = topic as { _ref?: unknown; _id?: unknown }
+      if (typeof t._ref === 'string') return t._ref
+      if (typeof t._id === 'string') return t._id
+      return undefined
+    })
+    .filter((id): id is string => typeof id === 'string' && id.length > 0)
+}
+
+const CFP_CLOSED_MESSAGE =
+  'The Call for Papers is currently closed. We&apos;d love to have you speak at our next conference! Please check back when the next CFP opens, or contact the organizers if you have any questions.'
+
+const NO_FORMATS_MESSAGE =
+  'The organizers have not announced any session formats yet, so proposals cannot be submitted. Please check back soon.'
+
+/**
+ * The ONE answer to "may this proposal become `submitted`?".
+ *
+ * CALLED BY BOTH SPEAKER-FACING SUBMIT ROUTES in
+ * `src/server/routers/proposal.ts`: `proposal.create` when `status` is not
+ * `draft`, and `proposal.action` on the `draft` → `submitted` transition (the
+ * path `ProposalForm` uses for an existing draft). It exists because those two
+ * drifted three times — the submittable-formats gate (#824), strict content
+ * validation (#833) and the CFP window (#837) were each added to `create` and
+ * each found missing from `action` by a separate audit. A new condition belongs
+ * HERE, where neither route can miss it.
+ *
+ * `proposal.admin.create` is a THIRD way a document reaches `submitted` and
+ * deliberately does NOT call this. It is organizer-only and sits OUTSIDE the
+ * CFP flow by design — an invited or keynote talk entered on a speaker's behalf
+ * has to be enterable after the window closes — and its input schema
+ * (`ProposalAdminCreateSchema`) is the strict one, so the content condition is
+ * already enforced at that boundary. If it ever becomes speaker-reachable, it
+ * belongs here.
+ *
+ * Refuses, in order:
+ * 1. the CFP window is closed (`FORBIDDEN`),
+ * 2. the conference announced no session format to submit into (`FORBIDDEN`),
+ * 3. the content does not satisfy strict submit validation (`BAD_REQUEST`).
+ *
+ * NO ORGANIZER CARVE-OUT, deliberately: an invalid or out-of-window submission
+ * is wrong whoever promotes it. (Contrast the neighbouring 3-proposal cap,
+ * which IS a per-speaker fairness rule an organizer may override.)
+ *
+ * WHAT IT DOES NOT COVER. It answers nothing about any other transition: the
+ * per-speaker proposal cap, withdraw, unsubmit, and organizer decisions
+ * (accept/reject/waitlist) are each gated separately by their callers, and
+ * editing an existing proposal stays on the plain {@link isCfpOpen} window.
+ * Creating a DRAFT is not a submission and is never gated here — a draft is the
+ * incomplete-work path, and an API/CLI caller must stay able to prepare one
+ * before the CFP opens or before the organizers announce their formats.
+ *
+ * WHAT IT MAY READ. The parameter type lists every conference field it looks
+ * at, and `topics` is deliberately NOT among them: the routers call
+ * `getConferenceForCurrentDomain()` WITHOUT projecting topics, and the boundary
+ * normaliser coerces the absent field to `[]`, so a topic-aware conference gate
+ * here would fail CLOSED on every well-configured conference (see
+ * `canAcceptProposals`). What refuses a topic-less proposal is step 3 — the
+ * content carries its own topics — not a conference-level check. Do not widen
+ * this signature without widening the projection first.
+ */
+export function assertMayBecomeSubmitted({
+  conference,
+  content,
+}: {
+  conference: Pick<Conference, 'cfpStartDate' | 'cfpEndDate'> & {
+    formats?: Conference['formats']
+  }
+  content: { topics?: unknown }
+}): void {
+  if (!isCfpOpen(conference)) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: CFP_CLOSED_MESSAGE })
+  }
+
+  if (!hasSubmittableFormats(conference)) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: NO_FORMATS_MESSAGE })
+  }
+
+  // `content` is either an incoming payload (`create`) or the STORED document
+  // (`action`), so two fields are folded back to what the schema describes
+  // before parsing: `speakers` is dropped (the stored document carries
+  // dereferenced speaker objects, and the incoming payload never carries
+  // speakers at all) and `topics` is folded through `topicIdsOf`, which reads
+  // both the reference and the dereferenced shape. Parsing a stored document
+  // without that fold would reject EVERY legitimate submission on `topics`.
+  const candidate = {
+    ...content,
+    speakers: undefined,
+    topics: topicIdsOf(content.topics).map((ref) => ({
+      _type: 'reference' as const,
+      _ref: ref,
+    })),
+  }
+
+  const strict = ProposalInputSchema.safeParse(candidate)
+  if (!strict.success) {
+    const fieldErrors = strict.error.issues.map((i) => i.message)
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `Please fix the following before submitting: ${fieldErrors.join('. ')}`,
+    })
+  }
+}

--- a/src/server/proposalSubmission.ts
+++ b/src/server/proposalSubmission.ts
@@ -60,7 +60,9 @@ const NO_FORMATS_MESSAGE =
  * Refuses, in order:
  * 1. the CFP window is closed (`FORBIDDEN`),
  * 2. the conference announced no session format to submit into (`FORBIDDEN`),
- * 3. the content does not satisfy strict submit validation (`BAD_REQUEST`).
+ * 3. a topic entry is unreadable AND the content came from a client payload
+ *    (`BAD_REQUEST` — see `contentSource`),
+ * 4. the content does not satisfy strict submit validation (`BAD_REQUEST`).
  *
  * NO ORGANIZER CARVE-OUT, deliberately: an invalid or out-of-window submission
  * is wrong whoever promotes it. (Contrast the neighbouring 3-proposal cap,
@@ -82,15 +84,35 @@ const NO_FORMATS_MESSAGE =
  * `canAcceptProposals`). What refuses a topic-less proposal is step 3 — the
  * content carries its own topics — not a conference-level check. Do not widen
  * this signature without widening the projection first.
+ *
+ * THE ONE ASYMMETRY, and why it is not a policy knob. `topicIdsOf` is LOSSY —
+ * it drops entries it cannot read — so validating the folded list would
+ * otherwise let a proposal through on whatever survived. `contentSource` says
+ * where the content came from, which is a fact about the call site rather than
+ * a choice, and decides what an unreadable entry means:
+ *
+ * - `'payload'`: the caller just sent it, so an entry that does not fold is a
+ *   bad request and is REFUSED. Silently dropping it would hand the caller a
+ *   proposal with fewer topics than they asked for and no error. (`_ref` is
+ *   `z.string()` with no `.min(1)`, so an empty `_ref` reaches this having
+ *   passed the input schema.)
+ * - `'stored'`: the entries are pre-existing data some earlier write produced,
+ *   and a `topics[]->` projection legitimately yields `null` for a topic that
+ *   was since deleted. They are TOLERATED and logged. Refusing here would
+ *   strand a speaker behind a data problem they did not cause and cannot fix;
+ *   what they can fix — having at least one readable topic — is still enforced
+ *   by step 4, because the fold leaves the survivors to be validated.
  */
 export function assertMayBecomeSubmitted({
   conference,
   content,
+  contentSource,
 }: {
   conference: Pick<Conference, 'cfpStartDate' | 'cfpEndDate'> & {
     formats?: Conference['formats']
   }
-  content: { topics?: unknown }
+  content: { topics?: unknown; _id?: unknown }
+  contentSource: 'payload' | 'stored'
 }): void {
   if (!isCfpOpen(conference)) {
     throw new TRPCError({ code: 'FORBIDDEN', message: CFP_CLOSED_MESSAGE })
@@ -107,10 +129,32 @@ export function assertMayBecomeSubmitted({
   // speakers at all) and `topics` is folded through `topicIdsOf`, which reads
   // both the reference and the dereferenced shape. Parsing a stored document
   // without that fold would reject EVERY legitimate submission on `topics`.
+  const topicIds = topicIdsOf(content.topics)
+
+  // The fold is LOSSY, so account for what it dropped before validating what
+  // survived — see THE ONE ASYMMETRY above.
+  const unreadableTopics = Array.isArray(content.topics)
+    ? content.topics.length - topicIds.length
+    : 0
+  if (unreadableTopics > 0) {
+    if (contentSource === 'payload') {
+      // Same wording as `requireTopicsReferenceable`, which refuses the same
+      // shape a few lines later in `create`: one client-visible message for
+      // "a topic entry in your payload is not a usable reference".
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'Invalid topic reference',
+      })
+    }
+    console.warn(
+      `Proposal ${String(content._id ?? 'unknown')} carries ${unreadableTopics} unreadable topic entr${unreadableTopics === 1 ? 'y' : 'ies'}; submitting on the readable ones.`,
+    )
+  }
+
   const candidate = {
     ...content,
     speakers: undefined,
-    topics: topicIdsOf(content.topics).map((ref) => ({
+    topics: topicIds.map((ref) => ({
       _type: 'reference' as const,
       _ref: ref,
     })),

--- a/src/server/routers/proposal.ts
+++ b/src/server/routers/proposal.ts
@@ -351,8 +351,17 @@ export const proposalRouter = router({
         // incomplete-work path (it skips strict validation for the same
         // reason), and an API/CLI caller must be able to prepare one before the
         // window opens or before the organizers announce their formats.
+        //
+        // `contentSource: 'payload'` is what makes an unreadable topic entry a
+        // refusal here rather than a silent drop — the caller sent it, so they
+        // get told. `requireTopicsReferenceable` below refuses the same shape;
+        // this fires first and with the same message.
         if (input.status !== Status.draft) {
-          assertMayBecomeSubmitted({ conference, content: input.data })
+          assertMayBecomeSubmitted({
+            conference,
+            content: input.data,
+            contentSource: 'payload',
+          })
         }
 
         const { proposals: existingProposals } = await getProposals({
@@ -785,11 +794,20 @@ export const proposalRouter = router({
         //
         // The content being promoted is already stored, so the DOCUMENT is what
         // the predicate parses — in READ shape, which it folds back itself.
-        // Applies to organizers too, deliberately: an invalid or out-of-window
+        // `contentSource: 'stored'` is what tells it these topics are
+        // pre-existing data (a `topics[]->` projection yields `null` for a
+        // since-deleted topic), so an unreadable entry is logged and tolerated
+        // rather than stranding the speaker; at least one READABLE topic is
+        // still required. Applies to organizers too, deliberately: an
+        // invalid or out-of-window
         // submission is wrong whoever promotes it. (The 3-proposal cap below is
         // the opposite call — a per-speaker fairness rule organizers override.)
         if (proposal.status === Status.draft && status === Status.submitted) {
-          assertMayBecomeSubmitted({ conference, content: proposal })
+          assertMayBecomeSubmitted({
+            conference,
+            content: proposal,
+            contentSource: 'stored',
+          })
         }
 
         // Enforce cap when submitting a draft (draft → submitted transition)

--- a/src/server/routers/proposal.ts
+++ b/src/server/routers/proposal.ts
@@ -52,6 +52,10 @@ import {
   isInvitationExpired,
 } from '@/lib/cospeaker/constants'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import {
+  assertMayBecomeSubmitted,
+  topicIdsOf,
+} from '@/server/proposalSubmission'
 import { clientWrite } from '@/lib/sanity/client'
 import { createReference, createReferenceWithKey } from '@/lib/sanity/helpers'
 import {
@@ -118,19 +122,6 @@ const COMMENT_RELAY_ACTIONS: readonly Action[] = [
  * (pre-migration-044) stays editable instead of making every save of an old
  * talk refuse. Removing such an id is always allowed; re-adding it is not.
  */
-function topicIdsOf(topics: unknown): string[] {
-  if (!Array.isArray(topics)) return []
-  return topics
-    .map((topic) => {
-      if (!topic || typeof topic !== 'object') return undefined
-      const t = topic as { _ref?: unknown; _id?: unknown }
-      if (typeof t._ref === 'string') return t._ref
-      if (typeof t._id === 'string') return t._id
-      return undefined
-    })
-    .filter((id): id is string => typeof id === 'string' && id.length > 0)
-}
-
 async function requireTopicsReferenceable(
   incoming: unknown,
   alreadyOnTalk: string[],
@@ -349,46 +340,19 @@ export const proposalRouter = router({
           })
         }
 
-        const { isCfpOpen, hasSubmittableFormats } =
-          await import('@/lib/conference/state')
-        if (!isCfpOpen(conference)) {
-          throw new TRPCError({
-            code: 'FORBIDDEN',
-            message:
-              'The Call for Papers is currently closed. We&apos;d love to have you speak at our next conference! Please check back when the next CFP opens, or contact the organizers if you have any questions.',
-          })
-        }
-        // The CFP-open-but-unsubmittable trap, refused server-side for a direct
-        // call that skipped the page and the form. Scoped to SUBMISSION,
-        // matching the strict-validation gate below — a draft is explicitly the
-        // incomplete-work path, and an API/CLI caller must stay able to prepare
-        // one before the organizers announce their formats.
+        // ONE OF TWO ROUTES TO `submitted`, and every condition it must satisfy
+        // — the CFP window, the submittable-formats gate and strict content
+        // validation — lives in `assertMayBecomeSubmitted` so the other route
+        // (`proposal.action`, below) cannot drift from it again. A new
+        // submission rule belongs in the predicate, not here.
         //
-        // THIS IS NOT THE ONLY SUBMIT ROUTE. `proposal.action` performs the
-        // draft → submitted transition and carries the SAME gate; a change
-        // here almost certainly belongs there too. Editing and unsubmitting an
-        // existing proposal stay on the plain `isCfpOpen` window.
-        if (
-          input.status !== Status.draft &&
-          !hasSubmittableFormats(conference)
-        ) {
-          throw new TRPCError({
-            code: 'FORBIDDEN',
-            message:
-              'The organizers have not announced any session formats yet, so proposals cannot be submitted. Please check back soon.',
-          })
-        }
-
-        // When submitting, enforce strict validation
+        // Scoped to SUBMISSION: creating a DRAFT stays permitted with the CFP
+        // closed and with no formats announced. A draft is explicitly the
+        // incomplete-work path (it skips strict validation for the same
+        // reason), and an API/CLI caller must be able to prepare one before the
+        // window opens or before the organizers announce their formats.
         if (input.status !== Status.draft) {
-          const result = ProposalInputSchema.safeParse(input.data)
-          if (!result.success) {
-            const fieldErrors = result.error.issues.map((i) => i.message)
-            throw new TRPCError({
-              code: 'BAD_REQUEST',
-              message: `Please fix the following before submitting: ${fieldErrors.join('. ')}`,
-            })
-          }
+          assertMayBecomeSubmitted({ conference, content: input.data })
         }
 
         const { proposals: existingProposals } = await getProposals({
@@ -811,64 +775,21 @@ export const proposalRouter = router({
           }
         }
 
-        // THE OTHER SUBMIT ROUTE. `proposal.create` is not the only way a
-        // proposal reaches `submitted` — this action performs the
+        // THE OTHER ROUTE TO `submitted`. `proposal.create` is not the only way
+        // a proposal reaches that status — this action performs the
         // draft → submitted transition, and it is the path `ProposalForm` uses
-        // for an existing draft. Gating only `create` would leave the trap wide
-        // open: prepare a draft (still legitimate), then submit it here onto a
-        // conference that offers no formats. Applies to organizers too — a
-        // submitted proposal on a formats-less conference is wrong whoever
-        // creates it, and `ProposalDraftSchema` would leave it carrying the
-        // schema default (`lightning_10`), a format the conference never
-        // offered.
+        // for an existing draft. Both routes now ask the SAME predicate, which
+        // is the point: three separate audits found three separate conditions
+        // that `create` enforced and this route did not (#824, #833, #837),
+        // because each was written twice.
+        //
+        // The content being promoted is already stored, so the DOCUMENT is what
+        // the predicate parses — in READ shape, which it folds back itself.
+        // Applies to organizers too, deliberately: an invalid or out-of-window
+        // submission is wrong whoever promotes it. (The 3-proposal cap below is
+        // the opposite call — a per-speaker fairness rule organizers override.)
         if (proposal.status === Status.draft && status === Status.submitted) {
-          const { hasSubmittableFormats } =
-            await import('@/lib/conference/state')
-          if (!hasSubmittableFormats(conference)) {
-            throw new TRPCError({
-              code: 'FORBIDDEN',
-              message:
-                'The organizers have not announced any session formats yet, so proposals cannot be submitted. Please check back soon.',
-            })
-          }
-
-          // THE OTHER HALF of what `create` enforces on submission, which this
-          // route was missing entirely. `create` strict-parses the incoming
-          // payload before letting a proposal reach `submitted`; here the
-          // content is already stored, so the DOCUMENT is what gets parsed —
-          // the `update` route's merged-content pattern with nothing to merge.
-          //
-          // Without this, the two-step path bypassed EVERY content rule
-          // `create` applies: `create({ status: draft })` accepts anything
-          // (`ProposalDraftSchema` is `.partial()`), and `action(submit)` then
-          // promoted it with no topics, no accepted terms and an empty
-          // description. Not reachable from the UI — `ProposalForm` saves via
-          // `update` first, and the submit page is gated — but wide open to a
-          // direct API/tRPC caller, which is a real population given the
-          // agent-facing CLI. Applies to organizers too, like the format gate:
-          // an invalid submitted proposal is wrong whoever promotes it.
-          //
-          // The stored document is the same content in READ shape, so two
-          // fields are folded back to what the schema describes: `speakers` is
-          // dropped (dereferenced objects, and `create` does not validate them
-          // either) and `topics` is folded from dereferenced topic documents
-          // back to references.
-          const candidate = {
-            ...proposal,
-            speakers: undefined,
-            topics: topicIdsOf(proposal.topics).map((ref) => ({
-              _type: 'reference' as const,
-              _ref: ref,
-            })),
-          }
-          const strict = ProposalInputSchema.safeParse(candidate)
-          if (!strict.success) {
-            const fieldErrors = strict.error.issues.map((i) => i.message)
-            throw new TRPCError({
-              code: 'BAD_REQUEST',
-              message: `Please fix the following before submitting: ${fieldErrors.join('. ')}`,
-            })
-          }
+          assertMayBecomeSubmitted({ conference, content: proposal })
         }
 
         // Enforce cap when submitting a draft (draft → submitted transition)
@@ -1107,6 +1028,14 @@ export const proposalRouter = router({
       }),
 
     // Create proposal (admin)
+    //
+    // A THIRD way a document reaches `submitted` (`createProposal` defaults to
+    // that status), and deliberately NOT behind `assertMayBecomeSubmitted`:
+    // this is how organizers enter an invited or keynote talk on a speaker's
+    // behalf, which has to work after the CFP window closes. Its content
+    // condition is enforced at the boundary instead — `ProposalAdminCreateSchema`
+    // is the STRICT schema, not the partial draft one. Keep it that way: if
+    // this ever becomes reachable by a speaker, route it through the predicate.
     create: adminProcedure
       .input(ProposalAdminCreateSchema)
       .mutation(async ({ input }) => {


### PR DESCRIPTION
Closes #837.

> [!IMPORTANT]
> **Behaviour change nobody explicitly asked for, called out so it is visible rather than discovered later:** `proposal.create` **no longer refuses DRAFT creation while the CFP is closed**. The owner decided "shared predicate", not "allow drafts after close" — this follows from it. The window used to be a blanket route-level refusal in `create`; making it a condition of the shared predicate, scoped to the transition to `submitted`, is what puts it in exactly one place (and is what makes deleting that one condition fail *both* routes' tests). Drafts do not count toward the 3-proposal cap, so unbounded draft creation was already possible during an open window; this extends that surface in time, not in kind. Say the word and I will keep a separate blanket window check on `create` instead — at the cost of the window existing in two places again.

## The defect

`proposal.create` refuses a submission outside the CFP window. The `draft → submitted` transition in `proposal.action` had **no window check at all**, so a draft created while the CFP was open could be promoted a month after it closed. The close was enforced in one direction only (`action` already blocks `unsubmit` after the window).

This was the **third** condition found missing from `action` that `create` had:

1. the submittable-formats gate (#824)
2. strict content validation (#833)
3. the CFP window (#837)

Three audits, one route, same shape. The defect is the duplication — patching the third instance leaves a fourth to be found.

## What this does

Extracts the whole answer to *"may this become `submitted`?"* into one predicate, `assertMayBecomeSubmitted` in `src/server/proposalSubmission.ts`, called by **both** submit routes:

| condition | refusal | previously |
| --- | --- | --- |
| CFP window closed | `FORBIDDEN` | `create` only |
| no submittable session formats | `FORBIDDEN` | both (#824) |
| unreadable topic entry in a **payload** | `BAD_REQUEST` | see below |
| content fails strict validation | `BAD_REQUEST` | both (#833) |

The predicate folds the content itself — `topics` through `topicIdsOf` (which reads **both** the `{_type, _ref}` payload shape and the dereferenced `{_id, title, color}` READ shape) and `speakers` dropped — so a stored document and an incoming payload are checked identically. `topicIdsOf` moved next to it so there is exactly one fold; the reference-injection check in the router imports it back. Parsing a stored document without that fold would reject *every* legitimate submission on `topics`, which is why it is a regression-guarded condition of its own.

Its signature names every conference field it may read, and `topics` is deliberately not among them: the routers call `getConferenceForCurrentDomain()` **without** projecting topics and the boundary normaliser coerces the absent field to `[]`, so a topic-aware conference gate here would fail CLOSED on every well-configured conference.

### The one asymmetry: a lossy fold, made deliberate

`topicIdsOf` **drops** entries it cannot read, so validating the folded list would let a proposal through on whatever survived — the gate would be claiming more than the fold delivers. `contentSource` says where the content came from (a fact about the call site, not a policy knob) and decides what an unreadable entry means:

- **`'payload'`** (`create`) — **refused.** The caller just sent it; silently dropping it hands them a proposal with fewer topics than they asked for and no error. Reachable in practice: `_ref` is `z.string()` with no `.min(1)`, so an empty `_ref` clears the input schema. Uses `requireTopicsReferenceable`'s exact wording, so no client-visible message changes.
- **`'stored'`** (`action`) — **tolerated and logged.** These entries are pre-existing data an earlier write produced, and a `topics[]->` projection legitimately yields `null` for a topic that was since deleted. Refusing would strand a speaker behind a data problem they did not cause and cannot fix. What they *can* fix — having at least one readable topic — is still enforced, because the fold leaves the survivors to strict validation.

## Carve-outs preserved

- **Draft creation stays permitted** with no formats announced *and* with the CFP closed (see the callout above).
- **`withdraw` / `unsubmit` untouched** — the gate is scoped to `draft → submitted`. The speaker `unsubmit`-after-close block and its organizer carve-out are unchanged.
- **No organizer carve-out on validity** — window, formats and content apply to organizers too, matching #833. (The neighbouring 3-proposal cap is the opposite call and keeps its organizer override.)

## Behaviour changes

1. **`action` now refuses a `draft → submitted` promotion once the CFP has closed**, for organizers as well. The soft "finish your draft, we will allow it" grace path is gone, per the decision on #837; organizers extend the CFP end date instead.
2. **`create` no longer refuses DRAFT creation while the CFP is closed** — see the callout at the top.

## A third path, deliberately left out

`proposal.admin.create` also reaches `submitted` (`createProposal` defaults to that status) and does **not** call the predicate. It is organizer-only and sits outside the CFP flow by design — an invited or keynote talk has to be enterable after the window closes — and its input is `ProposalAdminCreateSchema`, the strict schema, so the content condition is enforced at that boundary. Both facts are now written down at the route and in the predicate doc, rather than left for a fourth audit to rediscover.

## Comments corrected

- `create` claimed *"`proposal.action` … carries the SAME gate"* — false for the window at the time it was written. Both routes now describe the shared predicate instead of restating conditions.
- `canAcceptProposals` in `src/lib/conference/state.ts` described strict validation as living on "both submit paths" separately; it now points at the shared gate.
- The predicate documents plainly which routes call it, what it does not cover (the cap, withdraw, unsubmit, decisions, editing), and — after review — exactly what the lossy fold does rather than calling it strict validation full stop.

## Tests — sabotage-proven, per condition and per route

`__tests__/api/trpc/proposal.test.ts`, +7 tests (51 → 58). New: `action` refuses submit after the CFP closes (speaker **and** organizer); `create` still allows a DRAFT with the CFP closed; withdraw still works with the CFP closed; `create` refuses an unreadable payload topic; `action` tolerates an unreadable stored topic; `action` still refuses when *all* stored topics are unreadable.

Each condition was removed by exact string and the suite re-run. **One removal fails tests for both routes** for all three original conditions — the point of the extraction:

| sabotage | failing tests | routes hit |
| --- | --- | --- |
| window condition | 3 | `create` 1 + `action` 2 |
| formats condition | 3 | `create` 1 + `action` 2 |
| strict content validation | 6 | `create` 1 + `action` 5 |
| topics fold | 3 | `action` (dereferenced-shape + tolerance guards) |
| unreadable-topic accounting (whole block) | 2 | `create` 1 + `action` 1 |
| payload refusal of unreadable topics | 1 | `create` |
| stored tolerance (made to refuse both) | 2 | `action` |
| gate call in `create` | 4 | `create` |
| gate call in `action` | 10 | `action` |
| draft scoping in `create` | 3 | the draft carve-outs |

Two of those rows are worth naming. **"Payload refusal" first came back with 0 failures** — `requireTopicsReferenceable` refuses the same shape with the same message later in `create`, so the test was proving the neighbour, not the predicate. The test now runs with the 3-proposal cap already reached: the cap sits between the two guards and refuses with a different code, so reaching `Invalid topic reference` can only be the gate. And **"stored tolerance"** is sabotaged by making the gate refuse both sources, so the tolerance is pinned as a decision in both directions rather than as an absence of code.

All restored; suite green.

## Numbers

| check | baseline (`origin/main` @ 3bb3171) | this branch |
| --- | --- | --- |
| `pnpm test` | 504 files / 7344 tests passed | 504 files / **7351** tests passed |
| `pnpm typecheck` | clean | clean |
| `npx prettier --check .` | clean | clean |
| `npx eslint .` | 0 errors, 201 warnings | 0 errors, 201 warnings |
