### PR TITLE
feat(ticketing): make an operator deny a kill switch for every organizer-visible output

### DIFF
--- a/src/lib/features/badges.ts
+++ b/src/lib/features/badges.ts
@@ -63,9 +63,23 @@ import { isPlatformOrganization } from './platform'
  * either gate a security boundary: credential isolation is
  * `resolveTicketingCredentials` and the tenancy guards.
  *
- * The BADGES deny is still UI-only in the same sense — this module's own gate is
- * consumed by the badge pages and `issueBadgeForSpeaker`'s platform-org check;
- * no badge tRPC procedure composes the deny middleware today.
+ * The BADGES deny is still UI-only, and precisely so: every consumer of this
+ * module's gate is a rendering path — the `/admin/speakers` and
+ * `/admin/speakers/badge` pages, plus `./enabled.ts`, which feeds the admin
+ * layout's nav and ⌘K filtering. No badge tRPC procedure composes the deny
+ * middleware — `badge.admin.issue` is a plain `adminProcedure` — so an
+ * operator's deny does not reach the API at all.
+ *
+ * THE ISSUANCE TRIPWIRE IS NOT WHAT CLOSES THAT, and it is worth being exact
+ * about why: `src/lib/badge/issuance.ts` imports `getPlatformOrgId` from
+ * `@/lib/authz/platform` and imports NOTHING from this module, so it never
+ * consults this gate. It asks a different question — "is this the platform
+ * org?", not "did an operator switch badges off?" — and the answers coincide
+ * only in one direction. A denied NON-platform org is refused by the tripwire on
+ * the tripwire's own terms; a deny on the PLATFORM org stops at the pages, and
+ * `badge.admin.issue` still answers it. Closing that would mean composing
+ * `requireFeatureNotDenied('badges')` onto the badge router — deliberately out of
+ * scope for #836, which widened the TICKETING deny only.
  *
  * NO PLAN TIER, DELIBERATELY. `ticketing` moved to `minPlan: 'pro'` once the
  * capability became per-tenant (the customer's own provider account); badges

--- a/src/lib/features/badges.ts
+++ b/src/lib/features/badges.ts
@@ -51,17 +51,21 @@ import { isPlatformOrganization } from './platform'
  * not an absence, so it wins in both modules regardless of what the capability
  * says.
  *
- * SCOPE, SAID PRECISELY: the deny covers the ORGANIZER-FACING UI. It does not
- * reach the tRPC layer — `tickets.admin.*` (`getTicketTypes`,
- * `getDiscountCodes`, `getPaymentDetails`, `create`/`deleteDiscountCode`) are
- * plain `adminProcedure` and still answer for a denied org, and the discount
- * ones still WRITE to that tenant's own provider account. An API call is a deep
- * link; an earlier draft of this comment claimed none outlived the deny, which
- * was false. Nor does it reach the weekly Slack summary
- * (`buildTicketSection`), which keeps posting live ticket counts. Whether the
- * kill switch should mean every organizer-visible output rather than the UI
- * surface is an open owner decision — do not read this gate as a security
- * boundary in the meantime.
+ * SCOPE, SAID PRECISELY (owner decision on #836): a ticketing deny now covers
+ * every ORGANIZER-VISIBLE output, not just the UI. It reaches the organizer
+ * pages, the whole `tickets.admin.*` tRPC sub-router (via
+ * `requireFeatureNotDenied`, so the discount mutations no longer write to a
+ * switched-off tenant's provider account) and the weekly Slack summary's ticket
+ * section. It deliberately does NOT reach the ATTENDEE-facing paths (public
+ * ticket sales, workshop eligibility), the admin status probes, or
+ * speaker-ticket issuance — which still writes a discount code into a denied
+ * org's vendor account (borderline, low-harm, left knowingly). None of that makes
+ * either gate a security boundary: credential isolation is
+ * `resolveTicketingCredentials` and the tenancy guards.
+ *
+ * The BADGES deny is still UI-only in the same sense — this module's own gate is
+ * consumed by the badge pages and `issueBadgeForSpeaker`'s platform-org check;
+ * no badge tRPC procedure composes the deny middleware today.
  *
  * NO PLAN TIER, DELIBERATELY. `ticketing` moved to `minPlan: 'pro'` once the
  * capability became per-tenant (the customer's own provider account); badges

--- a/src/lib/features/ticketing.ts
+++ b/src/lib/features/ticketing.ts
@@ -55,10 +55,34 @@ import { isPlatformOrganization } from './platform'
  * absence of a decision. Swap those and you re-create the exact dead end #828
  * removed.
  *
- * NOT A SECURITY BOUNDARY, still. Credential isolation is enforced in
- * `resolveTicketingCredentials` and the tRPC tenancy guards; this decides what
- * an organizer is SHOWN. A deny is an operator's off switch for the SURFACE, not
- * a way to revoke access to a vendor account we never held.
+ * ── HOW FAR THE DENY REACHES (owner decision on #836) ───────────────────────
+ *
+ * EVERY ORGANIZER-VISIBLE OUTPUT, not just the UI #834 gated:
+ *
+ *  - the organizer nav, ⌘K, all five ticket pages, the dashboard tile and the
+ *    budget page (through `resolveTicketingAdminAccess`);
+ *  - the WHOLE `tickets.admin.*` tRPC sub-router, via the
+ *    `requireFeatureNotDenied('ticketing')` middleware — so a direct API call
+ *    from an organizer of a denied org is refused FORBIDDEN, and
+ *    `createDiscountCode` / `deleteDiscountCode` no longer write to that
+ *    tenant's own provider account. This matters because the platform is
+ *    deliberately agent-facing (`konfctl`, a planned MCP server): "hidden in the
+ *    UI" is not "switched off";
+ *  - the ticket section of the weekly Slack summary and the admin status page
+ *    (`buildTicketSection`), so a denied org stops receiving live ticket counts
+ *    on a cron with no organizer present.
+ *
+ * WHAT IT STILL DOES NOT REACH, deliberately: the ATTENDEE-facing ticket sale
+ * (`src/lib/tickets/public.ts` and the public ticket page — a deny must never
+ * break a sale mid-conference), workshop eligibility, and the admin status
+ * PROBES. Nor speaker-ticket issuance, which keeps writing a 100%-off discount
+ * into a denied org's vendor account: borderline, low-harm, and left alone
+ * knowingly rather than by omission.
+ *
+ * NOT A SECURITY BOUNDARY, still, however far it reaches. Credential isolation
+ * is enforced in `resolveTicketingCredentials` and the tRPC tenancy guards; a
+ * deny is an operator's off switch, not a way to revoke access to a vendor
+ * account we never held.
  *
  * THE PLAN TIER. The `ticketing` registry entry is `readiness: 'ga'` with
  * `minPlan: 'pro'` — the entry paid tier — because a tenant brings its own
@@ -136,4 +160,16 @@ export async function isTicketingEnabledForConference(
   conference: ConferenceTenant | null | undefined,
 ): Promise<boolean> {
   return isTicketingEnabledForOrg(conferenceOrgId(conference))
+}
+
+/**
+ * {@link isTicketingDeniedForOrg} keyed on the conference's OWNER — for the
+ * ungated background surfaces that hold a conference rather than an org id (the
+ * weekly Slack summary, `src/lib/status/summary.ts`). Same narrowness: only an
+ * operator's active `enabled: false` counts.
+ */
+export async function isTicketingDeniedForConference(
+  conference: ConferenceTenant | null | undefined,
+): Promise<boolean> {
+  return isTicketingDeniedForOrg(conferenceOrgId(conference))
 }

--- a/src/lib/status/summary.ticketing.test.ts
+++ b/src/lib/status/summary.ticketing.test.ts
@@ -1,0 +1,182 @@
+/**
+ * @vitest-environment node
+ *
+ * THE TICKETING KILL SWITCH IN THE WEEKLY SLACK SUMMARY (#836).
+ *
+ * `buildTicketSection` fed live ticket counts and revenue to two organizer
+ * outputs — the weekly Slack post (`/api/cron/weekly-update`, which runs on a
+ * schedule with no organizer present) and the admin status page — with no
+ * feature check at all. A deny that silences the UI while Slack keeps posting
+ * sales figures is not a switch-off.
+ *
+ * WHY THIS CANNOT PASS FOR THE WRONG REASON. `tickets: null` is ALSO what an
+ * unconfigured or a broken conference produces, so "the summary has no tickets"
+ * proves nothing on its own. Every denied case therefore additionally asserts
+ * that `resolveTicketingProvider` was NEVER CALLED — the conference below is
+ * fully configured and its provider resolves, so with the gate removed the
+ * resolver runs and real numbers come back. Only the gate can produce a summary
+ * where the resolver was not even reached.
+ *
+ * The gate resolves through the REAL feature modules over a mocked
+ * `getOrganizationById`, so override direction and expiry are exercised.
+ */
+
+const h = vi.hoisted(() => ({
+  getOrganizationById: vi.fn(),
+  resolveTicketingProvider: vi.fn(),
+  fetchEventTickets: vi.fn(),
+  listSponsorsForConference: vi.fn(),
+  getProposals: vi.fn(),
+  getSpeakers: vi.fn(),
+}))
+
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationById: h.getOrganizationById,
+  getOrganizationRefForCurrentConference: () => null,
+}))
+vi.mock('@/lib/tickets/provider', () => ({
+  resolveTicketingProvider: h.resolveTicketingProvider,
+}))
+vi.mock('@/lib/sponsor-crm/sanity', () => ({
+  listSponsorsForConference: h.listSponsorsForConference,
+}))
+vi.mock('@/lib/proposal/server', () => ({
+  getProposals: h.getProposals,
+}))
+vi.mock('@/lib/speaker/sanity', () => ({
+  getSpeakers: h.getSpeakers,
+}))
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Conference } from '@/lib/conference/types'
+import { buildConferenceStatusSummary } from './summary'
+
+/** The tenant this deployment runs: migration 044 gave it no plan, no overrides. */
+const ORG = 'organization-cloud-native-days'
+
+const liveOrgDocument = {
+  _id: ORG,
+  name: 'Cloud Native Days Norway',
+  slug: 'cloud-native-days',
+}
+
+const conference = {
+  _id: 'conf-cndn',
+  title: 'Cloud Native Days Bergen',
+  organization: { _ref: ORG, _type: 'reference' },
+  checkinCustomerId: 7,
+  checkinEventId: 4242,
+  organizers: [{ _id: 'o1' }],
+} as unknown as Conference
+
+function denyTicketing() {
+  h.getOrganizationById.mockResolvedValue({
+    ...liveOrgDocument,
+    featureOverrides: [{ feature: 'ticketing', enabled: false }],
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.getOrganizationById.mockResolvedValue(liveOrgDocument)
+  // A CONFIGURED conference with real sales — the section is only empty
+  // because something refused it, never because there was nothing to report.
+  h.resolveTicketingProvider.mockResolvedValue({
+    configured: true,
+    provider: { fetchEventTickets: h.fetchEventTickets },
+    eventRef: { provider: 'checkin', customerId: 7, eventId: 4242 },
+  })
+  h.fetchEventTickets.mockResolvedValue([
+    {
+      id: 1,
+      order_id: 500,
+      sum: '1000',
+      category: 'Regular',
+      order_date: '2026-01-05',
+    },
+    {
+      id: 2,
+      order_id: 501,
+      sum: '0',
+      category: 'Speaker',
+      order_date: '2026-01-06',
+    },
+  ])
+  h.listSponsorsForConference.mockResolvedValue({ sponsors: [], error: null })
+  h.getProposals.mockResolvedValue({ proposals: [] })
+  h.getSpeakers.mockResolvedValue({ speakers: [{ _id: 'sp1' }] })
+})
+
+describe('buildTicketSection honours the operator kill switch (#836)', () => {
+  it('reports NO ticket data for a denied org, and never resolves the provider', async () => {
+    denyTicketing()
+    const summary = await buildConferenceStatusSummary(conference)
+
+    expect(summary.tickets).toBeNull()
+    expect(summary.targetProgress).toBeNull()
+    // The distinguishing assertion: a denied org costs zero provider work.
+    expect(h.resolveTicketingProvider).not.toHaveBeenCalled()
+    expect(h.fetchEventTickets).not.toHaveBeenCalled()
+  })
+
+  it('switches off ticketing, not the whole weekly update', async () => {
+    denyTicketing()
+    h.getProposals.mockResolvedValue({
+      proposals: [{ status: 'submitted' }, { status: 'accepted' }],
+    })
+    const summary = await buildConferenceStatusSummary(conference)
+
+    // The other sections still report, and the deny is not an ERROR — nothing
+    // failed, so nothing should be logged as a failed section.
+    expect(summary.proposals?.total).toBe(2)
+    expect(summary.errors).toEqual([])
+  })
+})
+
+/**
+ * THE HARD CONSTRAINT: the live tenant keeps its weekly numbers. This org is
+ * NOT entitled to `ticketing` by plan (no plan → community; ticketing is
+ * `minPlan: 'pro'`), so an entitlement-shaped gate would silence its Slack post
+ * — which is exactly what must not happen.
+ */
+describe('an org without an operator deny keeps its ticket numbers', () => {
+  it('reports live counts for the un-denied live tenant', async () => {
+    const summary = await buildConferenceStatusSummary(conference)
+
+    expect(h.resolveTicketingProvider).toHaveBeenCalledTimes(1)
+    expect(summary.tickets).toMatchObject({
+      paidTickets: 1,
+      totalRevenue: 1000,
+      freeTicketsClaimed: 1,
+    })
+  })
+
+  it('is unaffected by an EXPIRED deny or a deny on another feature', async () => {
+    h.getOrganizationById.mockResolvedValue({
+      ...liveOrgDocument,
+      featureOverrides: [
+        {
+          feature: 'ticketing',
+          enabled: false,
+          expiresAt: '2020-01-01T00:00:00.000Z',
+        },
+        { feature: 'badges', enabled: false },
+      ],
+    })
+    const summary = await buildConferenceStatusSummary(conference)
+    expect(summary.tickets?.paidTickets).toBe(1)
+  })
+
+  it('keeps reporting when the organization read REJECTS — an accident is not a decision', async () => {
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {})
+    h.getOrganizationById.mockRejectedValue(new Error('sanity unavailable'))
+    const summary = await buildConferenceStatusSummary(conference)
+    expect(summary.tickets?.paidTickets).toBe(1)
+    logged.mockRestore()
+  })
+
+  it('keys the deny on the conference OWNER, not the request host', async () => {
+    await buildConferenceStatusSummary(conference)
+    expect(h.getOrganizationById).toHaveBeenCalledWith(ORG)
+  })
+})

--- a/src/lib/status/summary.ticketing.test.ts
+++ b/src/lib/status/summary.ticketing.test.ts
@@ -51,13 +51,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { Conference } from '@/lib/conference/types'
 import { buildConferenceStatusSummary } from './summary'
 
-/** The tenant this deployment runs: migration 044 gave it no plan, no overrides. */
 const ORG = 'organization-cloud-native-days'
 
-const liveOrgDocument = {
+/**
+ * THE RULE-2 SHAPE: `community` (no `plan`), no operator override. Not entitled
+ * to `ticketing` by plan — `minPlan` is `'pro'` — yet `features/ticketing.ts`
+ * rule 2 keeps its ticketing surface on its own provider credentials, so its
+ * weekly numbers must keep arriving. Not a snapshot of any live tenant;
+ * production's org carries `plan: 'pro'`, covered separately below.
+ */
+const communityOrgDocument = {
   _id: ORG,
   name: 'Cloud Native Days Norway',
-  slug: 'cloud-native-days',
+  slug: 'cloud-native-days-norway',
 }
 
 const conference = {
@@ -71,14 +77,14 @@ const conference = {
 
 function denyTicketing() {
   h.getOrganizationById.mockResolvedValue({
-    ...liveOrgDocument,
+    ...communityOrgDocument,
     featureOverrides: [{ feature: 'ticketing', enabled: false }],
   })
 }
 
 beforeEach(() => {
   vi.clearAllMocks()
-  h.getOrganizationById.mockResolvedValue(liveOrgDocument)
+  h.getOrganizationById.mockResolvedValue(communityOrgDocument)
   // A CONFIGURED conference with real sales — the section is only empty
   // because something refused it, never because there was nothing to report.
   h.resolveTicketingProvider.mockResolvedValue({
@@ -134,13 +140,15 @@ describe('buildTicketSection honours the operator kill switch (#836)', () => {
 })
 
 /**
- * THE HARD CONSTRAINT: the live tenant keeps its weekly numbers. This org is
- * NOT entitled to `ticketing` by plan (no plan → community; ticketing is
- * `minPlan: 'pro'`), so an entitlement-shaped gate would silence its Slack post
- * — which is exactly what must not happen.
+ * THE HARD CONSTRAINT: an org with no operator deny keeps its weekly numbers.
+ * The rule-2 org below is NOT entitled to `ticketing` by plan (no plan →
+ * community; ticketing is `minPlan: 'pro'`), so an entitlement-shaped gate would
+ * silence a Slack post that works today — which is exactly what must not happen.
+ * The pro case at the end is the other side of the same constraint: the shape
+ * production actually runs.
  */
 describe('an org without an operator deny keeps its ticket numbers', () => {
-  it('reports live counts for the un-denied live tenant', async () => {
+  it('reports live counts for the un-denied rule-2 org', async () => {
     const summary = await buildConferenceStatusSummary(conference)
 
     expect(h.resolveTicketingProvider).toHaveBeenCalledTimes(1)
@@ -153,7 +161,7 @@ describe('an org without an operator deny keeps its ticket numbers', () => {
 
   it('is unaffected by an EXPIRED deny or a deny on another feature', async () => {
     h.getOrganizationById.mockResolvedValue({
-      ...liveOrgDocument,
+      ...communityOrgDocument,
       featureOverrides: [
         {
           feature: 'ticketing',
@@ -178,5 +186,28 @@ describe('an org without an operator deny keeps its ticket numbers', () => {
   it('keys the deny on the conference OWNER, not the request host', async () => {
     await buildConferenceStatusSummary(conference)
     expect(h.getOrganizationById).toHaveBeenCalledWith(ORG)
+  })
+
+  /**
+   * THE SHAPE PRODUCTION ACTUALLY HAS, queried from the live dataset on
+   * 2026-08-05: `plan: 'pro'`, `featureOverrides: null`. Entitled by plan and
+   * carrying no operator decision, so its weekly post must keep its numbers.
+   * Deny-only passes it trivially — it is here as the positive control the live
+   * shape did not previously have.
+   */
+  it('reports live counts for the production shape — pro plan, no overrides', async () => {
+    h.getOrganizationById.mockResolvedValue({
+      ...communityOrgDocument,
+      plan: 'pro',
+      featureOverrides: null,
+    })
+    const summary = await buildConferenceStatusSummary(conference)
+
+    expect(h.resolveTicketingProvider).toHaveBeenCalledTimes(1)
+    expect(summary.tickets).toMatchObject({
+      paidTickets: 1,
+      totalRevenue: 1000,
+      freeTicketsClaimed: 1,
+    })
   })
 })

--- a/src/lib/status/summary.ts
+++ b/src/lib/status/summary.ts
@@ -14,6 +14,7 @@ import { listSponsorsForConference } from '@/lib/sponsor-crm/sanity'
 import { getProposals } from '@/lib/proposal/server'
 import { Status } from '@/lib/proposal/types'
 import { resolveTicketingProvider } from '@/lib/tickets/provider'
+import { isTicketingDeniedForConference } from '@/lib/features/ticketing'
 import { calculateTicketStatistics } from '@/lib/tickets/utils'
 import { calculateFreeTicketClaimRate } from '@/lib/tickets/utils'
 import { TicketSalesProcessor } from '@/lib/tickets/processor'
@@ -83,11 +84,36 @@ async function buildProposalSection(
   }
 }
 
+/**
+ * The ticket numbers in the weekly Slack update and on the admin status page.
+ *
+ * THE KILL SWITCH REACHES HERE (#836). This section is an ORGANIZER-VISIBLE
+ * OUTPUT, and the cron posts it on a schedule with no organizer present: before
+ * this gate, an org whose ticketing an operator had switched off kept receiving
+ * live ticket counts and revenue in Slack every week. A deny that only silences
+ * the UI is not a switch-off.
+ *
+ * ORDER MATCHES `resolveTicketingAdminAccess`: the deny is asked BEFORE the
+ * provider resolves, so no provider call is made on a denied org's behalf.
+ * `isTicketingDeniedForConference` is narrow on purpose — only an operator's own
+ * active `enabled: false` — so a missing org document or a flaky Sanity read
+ * leaves the section exactly as it was, rather than silently blanking a working
+ * conference's numbers for a week.
+ *
+ * A denied org returns the SAME empty shape as an unconfigured one, so both the
+ * Slack post and the status page simply omit ticket figures (they already
+ * `?? 0` every field). The rest of the summary — sponsors, proposals — is
+ * untouched: this switches off ticketing, not the weekly update.
+ */
 async function buildTicketSection(conference: Conference): Promise<{
   tickets: TicketSummary | null
   targetProgress: TargetProgress | null
   error: SectionError | null
 }> {
+  if (await isTicketingDeniedForConference(conference)) {
+    return { tickets: null, targetProgress: null, error: null }
+  }
+
   const ticketing = await resolveTicketingProvider(conference)
   if (!ticketing.configured) {
     return { tickets: null, targetProgress: null, error: null }

--- a/src/server/routers/tickets.killswitch.test.ts
+++ b/src/server/routers/tickets.killswitch.test.ts
@@ -1,0 +1,323 @@
+/**
+ * @vitest-environment node
+ *
+ * THE TICKETING KILL SWITCH AT THE tRPC LAYER (#836).
+ *
+ * #834 made an operator's `enabled: false` a hard kill switch across the
+ * organizer UI. `tickets.admin.*` was left as plain `adminProcedure`, so an
+ * authenticated organizer of a switched-off org could still call every
+ * procedure directly — and `createDiscountCode` / `deleteDiscountCode` still
+ * WROTE to that tenant's provider account. The owner decision widened the switch
+ * to every organizer-visible output; this file is the observer for the router
+ * half of it.
+ *
+ * TWO THINGS ARE UNDER TEST AND THEY PULL IN OPPOSITE DIRECTIONS:
+ *
+ *  1. EVERY procedure refuses a denied org, with no provider call and no Sanity
+ *     write. The refusal is asserted on its exact message, not merely on
+ *     FORBIDDEN: `adminProcedure`'s own waist also throws FORBIDDEN, so a
+ *     code-only assertion would still pass with the gate deleted for any case
+ *     where the waist happened to reject. Here the caller IS an organizer of the
+ *     request org, so the waist admits it — the message check makes the gate the
+ *     only thing in this file that can produce the observed error.
+ *  2. THE SAME CALLS SUCCEED for the org this deployment actually runs
+ *     (`organization-cloud-native-days`: no `plan`, no overrides — exactly what
+ *     migration 044 created). That org is NOT entitled to `ticketing` by plan,
+ *     so a gate built on `requireFeature` would 403 all of it. The
+ *     positive-control block fails if anyone tightens the gate that way.
+ *
+ * The gate resolves through the REAL `@/lib/features/platform-default` +
+ * `entitlements` over a mocked `getOrganizationById`, so override direction and
+ * expiry are exercised rather than stubbed.
+ */
+
+vi.mock('@/lib/auth', () => ({
+  getAuthSession: vi.fn().mockResolvedValue(null),
+}))
+vi.mock('@/lib/events/registry', () => ({}))
+vi.mock('next/cache', () => ({
+  revalidateTag: vi.fn(),
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
+}))
+
+const h = vi.hoisted(() => ({
+  getConference: vi.fn(),
+  getOrganizationById: vi.fn(),
+  resolveCredentials: vi.fn(),
+  listDiscounts: vi.fn(),
+  createDiscount: vi.fn(),
+  deleteDiscount: vi.fn(),
+  fetchEventTickets: vi.fn(),
+  fetchOrderPaymentDetails: vi.fn(),
+  commit: vi.fn(),
+  sanityFetch: vi.fn(),
+}))
+
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: h.getConference,
+}))
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationById: h.getOrganizationById,
+  getOrganizationRefForCurrentConference: () => null,
+}))
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: {
+    patch: () => ({ set: () => ({ commit: h.commit }) }),
+    fetch: h.sanityFetch,
+  },
+  clientReadUncached: { fetch: vi.fn() },
+}))
+vi.mock('@/lib/tickets/provider', () => ({
+  resolveTicketingCredentials: h.resolveCredentials,
+  getTicketingProvider: () => ({
+    listDiscounts: h.listDiscounts,
+    createDiscount: h.createDiscount,
+    deleteDiscount: h.deleteDiscount,
+    fetchEventTickets: h.fetchEventTickets,
+    fetchOrderPaymentDetails: h.fetchOrderPaymentDetails,
+  }),
+}))
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { initTRPC } from '@trpc/server'
+import type { Context } from '@/server/trpc'
+import { ticketsRouter, __resetOrderIdCache } from './tickets'
+
+const t = initTRPC.context<Context>().create()
+
+/** The tenant this deployment runs. Migration 044 created it with no plan. */
+const ORG = 'organization-cloud-native-days'
+const CONF = 'conf-cndn'
+const EVENT = 4242
+const CUSTOMER = 7
+
+/** The organization document as migration 044 wrote it: no plan, no overrides. */
+const liveOrgDocument = {
+  _id: ORG,
+  name: 'Cloud Native Days Norway',
+  slug: 'cloud-native-days',
+}
+
+function ctx(): Context {
+  const speaker = {
+    _id: 'sp-admin',
+    name: 'Admin',
+    isOrganizer: true,
+    organizerOrgIds: [ORG],
+  }
+  const user = { email: 'a@example.com', name: 'Admin', picture: '' }
+  return {
+    req: {
+      headers: new Headers(),
+      url: 'http://localhost:3000',
+    } as unknown as Context['req'],
+    session: {
+      expires: new Date(Date.now() + 86_400_000).toISOString(),
+      user,
+      speaker,
+    } as unknown as Context['session'],
+    speaker: speaker as unknown as Context['speaker'],
+    user,
+    workosUser: null,
+    ipAddress: '127.0.0.1',
+  } as unknown as Context
+}
+
+const tickets = () => t.createCallerFactory(ticketsRouter)(ctx())
+
+/** Switch ticketing OFF for the request org, the way an operator does. */
+function denyTicketing() {
+  h.getOrganizationById.mockResolvedValue({
+    ...liveOrgDocument,
+    featureOverrides: [{ feature: 'ticketing', enabled: false }],
+  })
+}
+
+/**
+ * Every procedure in `tickets.admin.*`, invoked with input the happy path
+ * accepts. The list is the point: the gate is one middleware on the sub-router,
+ * so a fourteenth procedure inherits it — this table proves the thirteen that
+ * exist today are all behind it.
+ */
+const PROCEDURES: Array<
+  [string, (c: ReturnType<typeof tickets>) => Promise<unknown>]
+> = [
+  ['getSettings', (c) => c.admin.getSettings()],
+  ['updateSettings', (c) => c.admin.updateSettings({ ticketCapacity: 500 })],
+  ['updateCapacity', (c) => c.admin.updateCapacity({ capacity: 500 })],
+  [
+    'updateTargets',
+    (c) =>
+      c.admin.updateTargets({
+        targets: {
+          enabled: true,
+          salesStartDate: '2026-01-01',
+          targetCurve: 'linear',
+          milestones: [],
+        },
+      }),
+  ],
+  [
+    'toggleTargetTracking',
+    (c) => c.admin.toggleTargetTracking({ enabled: true }),
+  ],
+  ['getTicketTypes', (c) => c.admin.getTicketTypes()],
+  ['getDiscountCodes', (c) => c.admin.getDiscountCodes({ eventId: EVENT })],
+  ['getDiscountCodesWithUsage', (c) => c.admin.getDiscountCodesWithUsage()],
+  [
+    'createDiscountCode',
+    (c) =>
+      c.admin.createDiscountCode({
+        eventId: EVENT,
+        discountCode: 'SPONSOR-ACME',
+        numberOfTickets: 5,
+        sponsorName: 'Acme',
+        selectedTicketTypes: [],
+      }),
+  ],
+  [
+    'deleteDiscountCode',
+    (c) => c.admin.deleteDiscountCode({ eventId: EVENT, discountCode: 'OURS' }),
+  ],
+  ['getPaymentDetails', (c) => c.admin.getPaymentDetails({ orderId: 500 })],
+  ['getPageContent', (c) => c.admin.getPageContent()],
+  [
+    'updatePageContent',
+    (c) =>
+      c.admin.updatePageContent({
+        ticketInclusions: [{ _key: 'k1', title: 'Lunch' }],
+      }),
+  ],
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  __resetOrderIdCache()
+  h.getConference.mockResolvedValue({
+    conference: {
+      _id: CONF,
+      title: 'Cloud Native Days Bergen',
+      organization: { _ref: ORG },
+      checkinEventId: EVENT,
+      checkinCustomerId: CUSTOMER,
+    },
+    domain: 'localhost',
+    error: null,
+  })
+  h.getOrganizationById.mockResolvedValue(liveOrgDocument)
+  h.resolveCredentials.mockResolvedValue({ apiKey: 'k', apiSecret: 's' })
+  h.listDiscounts.mockResolvedValue({ discounts: [], ticketTypes: [] })
+  h.createDiscount.mockResolvedValue({ id: 1 })
+  h.deleteDiscount.mockResolvedValue(true)
+  h.fetchEventTickets.mockResolvedValue([
+    { id: 1, order_id: 500, sum: '100', category: 'Regular', order_date: '' },
+  ])
+  h.fetchOrderPaymentDetails.mockResolvedValue({ id: 1, orderId: 500 })
+  h.commit.mockResolvedValue({ _id: CONF })
+  h.sanityFetch.mockResolvedValue({ _id: CONF, ticketCapacity: 400 })
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('an operator deny refuses EVERY tickets.admin procedure (#836)', () => {
+  it.each(PROCEDURES)('%s is refused', async (_name, call) => {
+    denyTicketing()
+    await expect(call(tickets())).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      // Verbatim: `adminProcedure`'s waist throws FORBIDDEN too ("Admin
+      // privileges required"), and this caller IS an organizer of the request
+      // org, so only the kill switch can produce this message.
+      message:
+        'The "ticketing" feature has been switched off for this organization',
+    })
+  })
+
+  it('makes no provider call and no Sanity write on a denied org', async () => {
+    denyTicketing()
+    for (const [, call] of PROCEDURES) {
+      await expect(call(tickets())).rejects.toThrow()
+    }
+    // Reads AND writes, at the vendor and in Sanity.
+    expect(h.resolveCredentials).not.toHaveBeenCalled()
+    expect(h.listDiscounts).not.toHaveBeenCalled()
+    expect(h.fetchEventTickets).not.toHaveBeenCalled()
+    expect(h.fetchOrderPaymentDetails).not.toHaveBeenCalled()
+    // The two that mutate the tenant's OWN provider account.
+    expect(h.createDiscount).not.toHaveBeenCalled()
+    expect(h.deleteDiscount).not.toHaveBeenCalled()
+    expect(h.commit).not.toHaveBeenCalled()
+    expect(h.sanityFetch).not.toHaveBeenCalled()
+  })
+
+  it('refuses a PAID org too — a deny beats the plan that sells ticketing', async () => {
+    h.getOrganizationById.mockResolvedValue({
+      ...liveOrgDocument,
+      plan: 'pro',
+      featureOverrides: [{ feature: 'ticketing', enabled: false }],
+    })
+    await expect(
+      tickets().admin.createDiscountCode({
+        eventId: EVENT,
+        discountCode: 'FREE',
+        numberOfTickets: 1,
+        sponsorName: 'Acme',
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('switched off'),
+    })
+    expect(h.createDiscount).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * THE HARD CONSTRAINT (owner, non-negotiable): the existing tenant must lose
+ * nothing. `organization-cloud-native-days` carries NO plan, so it resolves to
+ * `community`, and `ticketing` is `readiness: 'ga'` + `minPlan: 'pro'` — an
+ * entitlement-shaped gate (`requireFeature('ticketing')`) would refuse every
+ * call below. A deny-shaped gate does not.
+ */
+describe('the live tenant keeps full access — no override, no plan', () => {
+  it.each(PROCEDURES)('%s still answers', async (_name, call) => {
+    await expect(call(tickets())).resolves.toBeDefined()
+  })
+
+  it('still reaches the provider for reads and for writes', async () => {
+    await tickets().admin.getDiscountCodes({ eventId: EVENT })
+    expect(h.listDiscounts).toHaveBeenCalledWith(EVENT)
+
+    await tickets().admin.createDiscountCode({
+      eventId: EVENT,
+      discountCode: 'SPONSOR-ACME',
+      numberOfTickets: 5,
+      sponsorName: 'Acme',
+    })
+    expect(h.createDiscount).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: EVENT }),
+    )
+  })
+
+  it('is unaffected by an EXPIRED deny or a deny on another feature', async () => {
+    h.getOrganizationById.mockResolvedValue({
+      ...liveOrgDocument,
+      featureOverrides: [
+        {
+          feature: 'ticketing',
+          enabled: false,
+          expiresAt: '2020-01-01T00:00:00.000Z',
+        },
+        { feature: 'badges', enabled: false },
+      ],
+    })
+    await expect(
+      tickets().admin.getDiscountCodes({ eventId: EVENT }),
+    ).resolves.toMatchObject({ success: true })
+  })
+
+  it('is unaffected when the organization read REJECTS — an accident is not a decision', async () => {
+    h.getOrganizationById.mockRejectedValue(new Error('sanity unavailable'))
+    await expect(
+      tickets().admin.getDiscountCodes({ eventId: EVENT }),
+    ).resolves.toMatchObject({ success: true })
+  })
+})

--- a/src/server/routers/tickets.killswitch.test.ts
+++ b/src/server/routers/tickets.killswitch.test.ts
@@ -20,11 +20,17 @@
  *     where the waist happened to reject. Here the caller IS an organizer of the
  *     request org, so the waist admits it — the message check makes the gate the
  *     only thing in this file that can produce the observed error.
- *  2. THE SAME CALLS SUCCEED for the org this deployment actually runs
- *     (`organization-cloud-native-days`: no `plan`, no overrides — exactly what
- *     migration 044 created). That org is NOT entitled to `ticketing` by plan,
- *     so a gate built on `requireFeature` would 403 all of it. The
- *     positive-control block fails if anyone tightens the gate that way.
+ *  2. THE SAME CALLS SUCCEED for the shape `features/ticketing.ts` rule 2
+ *     protects: a `community` org with no operator decision, which is NOT
+ *     entitled to `ticketing` by plan and yet keeps the whole ticketing UI when
+ *     its own provider credentials resolve. A gate built on `requireFeature`
+ *     would 403 all of it and leave this router stricter than the UI it serves.
+ *     The positive-control block fails if anyone tightens the gate that way.
+ *
+ * A second positive control pins the shape PRODUCTION actually has today
+ * (`plan: 'pro'`, `featureOverrides: null`, verified against the live dataset
+ * 2026-08-05). It passes trivially under a deny-only gate, which is precisely
+ * what a positive control is for: it is the case that must not break silently.
  *
  * The gate resolves through the REAL `@/lib/features/platform-default` +
  * `entitlements` over a mocked `getOrganizationById`, so override direction and
@@ -83,20 +89,29 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { initTRPC } from '@trpc/server'
 import type { Context } from '@/server/trpc'
 import { ticketsRouter, __resetOrderIdCache } from './tickets'
+import { computeEntitlements } from '@/lib/features/entitlements'
 
 const t = initTRPC.context<Context>().create()
 
-/** The tenant this deployment runs. Migration 044 created it with no plan. */
 const ORG = 'organization-cloud-native-days'
 const CONF = 'conf-cndn'
 const EVENT = 4242
 const CUSTOMER = 7
 
-/** The organization document as migration 044 wrote it: no plan, no overrides. */
-const liveOrgDocument = {
+/**
+ * THE RULE-2 SHAPE: a `community` org (no `plan`) carrying no operator
+ * override. `computeEntitlements` does NOT contain `ticketing` for it —
+ * `minPlan` is `'pro'` — yet `features/ticketing.ts` rule 2 keeps its ticketing
+ * surface whenever its own provider credentials resolve, so this router must
+ * keep answering it. That is the invariant this fixture exists to pin.
+ *
+ * It is NOT a snapshot of any live tenant: production's own org carries
+ * `plan: 'pro'`, which the pro-plan positive control below covers separately.
+ */
+const communityOrgDocument = {
   _id: ORG,
   name: 'Cloud Native Days Norway',
-  slug: 'cloud-native-days',
+  slug: 'cloud-native-days-norway',
 }
 
 function ctx(): Context {
@@ -129,7 +144,7 @@ const tickets = () => t.createCallerFactory(ticketsRouter)(ctx())
 /** Switch ticketing OFF for the request org, the way an operator does. */
 function denyTicketing() {
   h.getOrganizationById.mockResolvedValue({
-    ...liveOrgDocument,
+    ...communityOrgDocument,
     featureOverrides: [{ feature: 'ticketing', enabled: false }],
   })
 }
@@ -205,7 +220,7 @@ beforeEach(() => {
     domain: 'localhost',
     error: null,
   })
-  h.getOrganizationById.mockResolvedValue(liveOrgDocument)
+  h.getOrganizationById.mockResolvedValue(communityOrgDocument)
   h.resolveCredentials.mockResolvedValue({ apiKey: 'k', apiSecret: 's' })
   h.listDiscounts.mockResolvedValue({ discounts: [], ticketTypes: [] })
   h.createDiscount.mockResolvedValue({ id: 1 })
@@ -252,7 +267,7 @@ describe('an operator deny refuses EVERY tickets.admin procedure (#836)', () => 
 
   it('refuses a PAID org too — a deny beats the plan that sells ticketing', async () => {
     h.getOrganizationById.mockResolvedValue({
-      ...liveOrgDocument,
+      ...communityOrgDocument,
       plan: 'pro',
       featureOverrides: [{ feature: 'ticketing', enabled: false }],
     })
@@ -271,13 +286,14 @@ describe('an operator deny refuses EVERY tickets.admin procedure (#836)', () => 
 })
 
 /**
- * THE HARD CONSTRAINT (owner, non-negotiable): the existing tenant must lose
- * nothing. `organization-cloud-native-days` carries NO plan, so it resolves to
- * `community`, and `ticketing` is `readiness: 'ga'` + `minPlan: 'pro'` — an
- * entitlement-shaped gate (`requireFeature('ticketing')`) would refuse every
- * call below. A deny-shaped gate does not.
+ * THE HARD CONSTRAINT (owner, non-negotiable): rule 2 must lose nothing. This
+ * org carries NO plan, so it resolves to `community`, and `ticketing` is
+ * `readiness: 'ga'` + `minPlan: 'pro'` — an entitlement-shaped gate
+ * (`requireFeature('ticketing')`) would refuse every call below, even though
+ * `features/ticketing.ts` rule 2 still hands this org the full ticketing UI on
+ * its own credentials. A deny-shaped gate does not.
  */
-describe('the live tenant keeps full access — no override, no plan', () => {
+describe('a community org with no deny keeps full access (rule 2)', () => {
   it.each(PROCEDURES)('%s still answers', async (_name, call) => {
     await expect(call(tickets())).resolves.toBeDefined()
   })
@@ -299,7 +315,7 @@ describe('the live tenant keeps full access — no override, no plan', () => {
 
   it('is unaffected by an EXPIRED deny or a deny on another feature', async () => {
     h.getOrganizationById.mockResolvedValue({
-      ...liveOrgDocument,
+      ...communityOrgDocument,
       featureOverrides: [
         {
           feature: 'ticketing',
@@ -319,5 +335,57 @@ describe('the live tenant keeps full access — no override, no plan', () => {
     await expect(
       tickets().admin.getDiscountCodes({ eventId: EVENT }),
     ).resolves.toMatchObject({ success: true })
+  })
+})
+
+/**
+ * THE SHAPE PRODUCTION ACTUALLY HAS. Queried from the live dataset on
+ * 2026-08-05: `plan: 'pro'`, `featureOverrides: null`. Unlike the rule-2 fixture
+ * above it IS entitled by plan, so it is the complement of the "refuses a PAID
+ * org too" case — pro WITHOUT a deny, which must keep everything.
+ *
+ * It passes trivially under today's deny-only gate, and that is the point: the
+ * live shape had no positive control at all, so nothing observed a change that
+ * broke it. This block does.
+ */
+describe('the production shape keeps full access — pro plan, no overrides', () => {
+  const productionOrgDocument = {
+    ...communityOrgDocument,
+    plan: 'pro',
+    featureOverrides: null,
+  }
+
+  beforeEach(() => {
+    h.getOrganizationById.mockResolvedValue(productionOrgDocument)
+  })
+
+  it('is entitled to ticketing by plan, unlike the rule-2 fixture', () => {
+    expect(
+      computeEntitlements(productionOrgDocument.plan, [], new Date()).has(
+        'ticketing',
+      ),
+    ).toBe(true)
+    expect(
+      computeEntitlements(undefined, [], new Date()).has('ticketing'),
+    ).toBe(false)
+  })
+
+  it.each(PROCEDURES)('%s still answers', async (_name, call) => {
+    await expect(call(tickets())).resolves.toBeDefined()
+  })
+
+  it('still reaches the provider for reads and for writes', async () => {
+    await tickets().admin.getDiscountCodes({ eventId: EVENT })
+    expect(h.listDiscounts).toHaveBeenCalledWith(EVENT)
+
+    await tickets().admin.createDiscountCode({
+      eventId: EVENT,
+      discountCode: 'SPONSOR-ACME',
+      numberOfTickets: 5,
+      sponsorName: 'Acme',
+    })
+    expect(h.createDiscount).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: EVENT }),
+    )
   })
 })

--- a/src/server/routers/tickets.ts
+++ b/src/server/routers/tickets.ts
@@ -329,8 +329,8 @@ async function getTicketSettings(conferenceId: string) {
  *
  * SCOPE, SAID EXACTLY. This refuses only on an ACTIVE explicit deny (see
  * `requireFeatureNotDenied`); an org that was never granted ticketing but has
- * its own credentials keeps working, which is the invariant `./ticketing.ts`
- * rule 2 protects. It also touches nothing outside this sub-router: the
+ * its own credentials keeps working, which is the invariant
+ * `@/lib/features/ticketing` rule 2 protects. It also touches nothing outside this sub-router: the
  * ATTENDEE-facing ticket sale and workshop eligibility stay ungated (a deny must
  * not break a sale mid-conference), so do the admin status PROBES, and so does
  * speaker-ticket issuance — which therefore still writes a 100%-off discount

--- a/src/server/routers/tickets.ts
+++ b/src/server/routers/tickets.ts
@@ -1,7 +1,12 @@
 import { TRPCError } from '@trpc/server'
 import { revalidateTag } from 'next/cache'
 import { conferenceTag } from '@/lib/cache/tags'
-import { router, adminProcedure, resolveConferenceId } from '../trpc'
+import {
+  router,
+  adminProcedure,
+  requireFeatureNotDenied,
+  resolveConferenceId,
+} from '../trpc'
 import {
   TicketSettingsUpdateSchema,
   CreateDiscountCodeSchema,
@@ -306,14 +311,43 @@ async function getTicketSettings(conferenceId: string) {
   }
 }
 
+/**
+ * THE ORGANIZER-FACING TICKETING API, behind the kill switch (#836).
+ *
+ * Every procedure in `tickets.admin.*` is an ORGANIZER-VISIBLE OUTPUT of the
+ * ticketing feature, so an operator's `enabled: false` override must reach all
+ * of them and not merely the pages #834 gated. Before this, an authenticated
+ * organizer of a switched-off org could still call the router directly — and
+ * `createDiscountCode` / `deleteDiscountCode` still WROTE to that tenant's own
+ * provider account. The platform is deliberately agent-facing (`konfctl`, an
+ * MCP server), so "only reachable through the API" describes a growing surface.
+ *
+ * IT IS ONE PROCEDURE, NOT A CHECK PER ENDPOINT, on purpose: the sub-router is
+ * ticketing in its entirety (13 procedures today), so the fourteenth inherits
+ * the gate by being declared here rather than by somebody remembering to add a
+ * line to it.
+ *
+ * SCOPE, SAID EXACTLY. This refuses only on an ACTIVE explicit deny (see
+ * `requireFeatureNotDenied`); an org that was never granted ticketing but has
+ * its own credentials keeps working, which is the invariant `./ticketing.ts`
+ * rule 2 protects. It also touches nothing outside this sub-router: the
+ * ATTENDEE-facing ticket sale and workshop eligibility stay ungated (a deny must
+ * not break a sale mid-conference), so do the admin status PROBES, and so does
+ * speaker-ticket issuance — which therefore still writes a 100%-off discount
+ * into a denied org's vendor account (borderline, low-harm, left knowingly).
+ */
+const ticketingAdminProcedure = adminProcedure.use(
+  requireFeatureNotDenied('ticketing'),
+)
+
 export const ticketsRouter = router({
   admin: router({
-    getSettings: adminProcedure.query(async () => {
+    getSettings: ticketingAdminProcedure.query(async () => {
       const conferenceId = await resolveConferenceId()
       return getTicketSettings(conferenceId)
     }),
 
-    updateSettings: adminProcedure
+    updateSettings: ticketingAdminProcedure
       .input(TicketSettingsUpdateSchema)
       .mutation(async ({ input }) => {
         const conferenceId = await resolveConferenceId()
@@ -359,7 +393,7 @@ export const ticketsRouter = router({
         }
       }),
 
-    updateCapacity: adminProcedure
+    updateCapacity: ticketingAdminProcedure
       .input(UpdateTicketCapacitySchema)
       .mutation(async ({ input }) => {
         const conferenceId = await resolveConferenceId()
@@ -371,7 +405,7 @@ export const ticketsRouter = router({
         return result
       }),
 
-    updateTargets: adminProcedure
+    updateTargets: ticketingAdminProcedure
       .input(UpdateTicketTargetsSchema)
       .mutation(async ({ input }) => {
         const conferenceId = await resolveConferenceId()
@@ -383,7 +417,7 @@ export const ticketsRouter = router({
         return result
       }),
 
-    toggleTargetTracking: adminProcedure
+    toggleTargetTracking: ticketingAdminProcedure
       .input(ToggleTargetTrackingSchema)
       .mutation(async ({ input }) => {
         const conferenceId = await resolveConferenceId()
@@ -404,7 +438,7 @@ export const ticketsRouter = router({
         return result
       }),
 
-    getTicketTypes: adminProcedure.query(async () => {
+    getTicketTypes: ticketingAdminProcedure.query(async () => {
       try {
         const { conference, error: conferenceError } =
           await getConferenceForCurrentDomain()
@@ -438,7 +472,7 @@ export const ticketsRouter = router({
       }
     }),
 
-    getDiscountCodes: adminProcedure
+    getDiscountCodes: ticketingAdminProcedure
       .input(GetDiscountsSchema)
       .query(async ({ input }) => {
         try {
@@ -463,7 +497,7 @@ export const ticketsRouter = router({
         }
       }),
 
-    getDiscountCodesWithUsage: adminProcedure.query(async () => {
+    getDiscountCodesWithUsage: ticketingAdminProcedure.query(async () => {
       try {
         const { conference, error: conferenceError } =
           await getConferenceForCurrentDomain()
@@ -538,7 +572,7 @@ export const ticketsRouter = router({
       }
     }),
 
-    createDiscountCode: adminProcedure
+    createDiscountCode: ticketingAdminProcedure
       .input(CreateDiscountCodeSchema)
       .mutation(async ({ input }) => {
         const {
@@ -600,7 +634,7 @@ export const ticketsRouter = router({
         }
       }),
 
-    deleteDiscountCode: adminProcedure
+    deleteDiscountCode: ticketingAdminProcedure
       .input(DeleteDiscountCodeSchema)
       .mutation(async ({ input }) => {
         try {
@@ -638,7 +672,7 @@ export const ticketsRouter = router({
         }
       }),
 
-    getPaymentDetails: adminProcedure
+    getPaymentDetails: ticketingAdminProcedure
       .input(GetPaymentDetailsSchema)
       .query(async ({ input }) => {
         const { orderId } = input
@@ -669,7 +703,7 @@ export const ticketsRouter = router({
         }
       }),
 
-    getPageContent: adminProcedure.query(async () => {
+    getPageContent: ticketingAdminProcedure.query(async () => {
       const conferenceId = await resolveConferenceId()
 
       try {
@@ -701,7 +735,7 @@ export const ticketsRouter = router({
       }
     }),
 
-    updatePageContent: adminProcedure
+    updatePageContent: ticketingAdminProcedure
       .input(UpdateTicketPageContentSchema)
       .mutation(async ({ input }) => {
         const conferenceId = await resolveConferenceId()

--- a/src/server/trpc.requireFeatureNotDenied.test.ts
+++ b/src/server/trpc.requireFeatureNotDenied.test.ts
@@ -231,7 +231,13 @@ describe('composition with the admin waist', () => {
       conference: { _id: 'conf-A' },
       error: null,
     })
-    const caller = callerFor({ _id: 'legacy-admin', isOrganizer: true })
+    // A REAL organizer of ORG, so the refusal below can ONLY be the
+    // unresolvable org. The earlier shape (`{ isOrganizer: true }`, no
+    // `organizerOrgIds`) passed for the same reason as the test above it —
+    // an absent organizer claim — and so proved nothing about the null-org
+    // path it names. `callerFor`'s argument REPLACES the default rather than
+    // merging into it, which is what made that easy to miss.
+    const caller = callerFor({ _id: 'admin', organizerOrgIds: [ORG] })
     await expect(caller.probe()).rejects.toMatchObject({
       code: 'FORBIDDEN',
       message: 'Admin privileges required',

--- a/src/server/trpc.requireFeatureNotDenied.test.ts
+++ b/src/server/trpc.requireFeatureNotDenied.test.ts
@@ -1,0 +1,206 @@
+/**
+ * @vitest-environment node
+ *
+ * `requireFeatureNotDenied` — the KILL-SWITCH gate (#836). Composed onto the
+ * org-scoped admin waist exactly as consumers use it
+ * (`adminProcedure.use(requireFeatureNotDenied(...))`) and driven through a test
+ * router.
+ *
+ * The gate's INPUT is a real read: `@/lib/features/platform-default` and
+ * `@/lib/features/entitlements` run for real over a mocked
+ * `getOrganizationById`, so these cases exercise the same override/expiry
+ * semantics the ticketing pages do rather than a stubbed boolean.
+ *
+ * The distinction under test is NARROW and load-bearing: an operator's active
+ * `enabled: false` refuses; every other shape of "not entitled" passes. Widen it
+ * to `requireFeature` semantics and this deployment's own tenant — no `plan`, so
+ * `community`, against `ticketing`'s `minPlan: 'pro'` — loses ticketing
+ * entirely. The `entitled by plan?` assertions below pin exactly that.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getOrganizationById = vi.fn()
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationById: (...args: unknown[]) => getOrganizationById(...args),
+  getOrganizationRefForCurrentConference: () => null,
+}))
+
+const getConferenceMock = vi.fn()
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    getConferenceMock(...args),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getAuthSession: vi.fn().mockResolvedValue(null),
+}))
+
+import {
+  router,
+  adminProcedure,
+  requireFeatureNotDenied,
+  type Context,
+} from './trpc'
+import { computeEntitlements } from '@/lib/features/entitlements'
+
+/** The tenant this deployment actually runs (migration 044): no plan, no overrides. */
+const CNDN_ORG = 'organization-cloud-native-days'
+const cndnDocument = {
+  _id: CNDN_ORG,
+  name: 'Cloud Native Days Norway',
+  slug: 'cloud-native-days',
+}
+
+const handler = vi.fn()
+
+const testRouter = router({
+  probe: adminProcedure
+    .use(requireFeatureNotDenied('ticketing'))
+    .query(({ ctx }) => {
+      handler()
+      return { orgId: ctx.orgId }
+    }),
+})
+
+function callerFor(
+  speaker: {
+    _id: string
+    isOrganizer?: boolean
+    organizerOrgIds?: string[]
+  } = {
+    _id: 'admin',
+    organizerOrgIds: [CNDN_ORG],
+  },
+) {
+  const session = { speaker, user: { email: 'u@x.test' } }
+  return testRouter.createCaller({
+    session,
+    speaker,
+    user: session.user,
+  } as unknown as Context)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getConferenceMock.mockResolvedValue({
+    conference: { _id: 'conf-A', organization: { _ref: CNDN_ORG } },
+    error: null,
+  })
+  getOrganizationById.mockResolvedValue(cndnDocument)
+})
+
+describe('requireFeatureNotDenied refuses ONLY an operator’s explicit deny', () => {
+  it('throws FORBIDDEN naming the feature, and the handler never runs', async () => {
+    getOrganizationById.mockResolvedValue({
+      ...cndnDocument,
+      featureOverrides: [{ feature: 'ticketing', enabled: false }],
+    })
+    await expect(callerFor().probe()).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      // Asserted verbatim so the org-scoped waist's own FORBIDDEN ("Admin
+      // privileges required") cannot satisfy this case by accident.
+      message:
+        'The "ticketing" feature has been switched off for this organization',
+    })
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('refuses even a PAID org — a deny beats the plan that sells it', async () => {
+    getOrganizationById.mockResolvedValue({
+      ...cndnDocument,
+      plan: 'pro',
+      featureOverrides: [{ feature: 'ticketing', enabled: false }],
+    })
+    await expect(callerFor().probe()).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: expect.stringContaining('switched off'),
+    })
+  })
+
+  it('keys on the REQUEST-resolved org, never on client input', async () => {
+    await callerFor().probe()
+    expect(getOrganizationById).toHaveBeenCalledWith(CNDN_ORG)
+  })
+})
+
+/**
+ * THE HARD CONSTRAINT. Gating must not remove capability from the tenant that
+ * exists. Each case below is an org the ENTITLEMENT resolver says is not
+ * entitled to `ticketing`; each must still pass this gate.
+ */
+describe('requireFeatureNotDenied passes everything that is not a deny', () => {
+  it('passes the live CNDN-shaped org, which is NOT entitled by plan', async () => {
+    // The premise, pinned: `requireFeature('ticketing')` here would 403,
+    // because this document carries no `plan` and ticketing is `minPlan: 'pro'`.
+    const entitledByPlan = computeEntitlements(
+      (cndnDocument as { plan?: string }).plan,
+      [],
+      new Date(),
+    )
+    expect(entitledByPlan.has('ticketing')).toBe(false)
+    await expect(callerFor().probe()).resolves.toEqual({ orgId: CNDN_ORG })
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes an EXPIRED deny (the override is ignored entirely)', async () => {
+    getOrganizationById.mockResolvedValue({
+      ...cndnDocument,
+      featureOverrides: [
+        {
+          feature: 'ticketing',
+          enabled: false,
+          expiresAt: '2020-01-01T00:00:00.000Z',
+        },
+      ],
+    })
+    await expect(callerFor().probe()).resolves.toEqual({ orgId: CNDN_ORG })
+  })
+
+  it('passes a deny aimed at a DIFFERENT feature', async () => {
+    getOrganizationById.mockResolvedValue({
+      ...cndnDocument,
+      featureOverrides: [{ feature: 'badges', enabled: false }],
+    })
+    await expect(callerFor().probe()).resolves.toEqual({ orgId: CNDN_ORG })
+  })
+
+  it('passes a missing org document and a REJECTED read — accidents are not decisions', async () => {
+    getOrganizationById.mockResolvedValue(null)
+    await expect(callerFor().probe()).resolves.toEqual({ orgId: CNDN_ORG })
+
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {})
+    getOrganizationById.mockRejectedValue(new Error('sanity unavailable'))
+    await expect(callerFor().probe()).resolves.toEqual({ orgId: CNDN_ORG })
+    logged.mockRestore()
+  })
+})
+
+/**
+ * THE HOLE, NAMED. This gate does not fail closed on an unresolvable org (a
+ * flaky read must not black out a working tenant). What closes it is the waist
+ * it composes onto — so the composition, not this middleware, is the thing that
+ * must not be undone.
+ */
+describe('composition with the admin waist', () => {
+  it('is never reached for a non-organizer: the waist refuses first', async () => {
+    const caller = callerFor({ _id: 'speaker', organizerOrgIds: [] })
+    await expect(caller.probe()).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Admin privileges required',
+    })
+    expect(getOrganizationById).not.toHaveBeenCalled()
+  })
+
+  it('is never reached for an unresolvable org: the waist FAILS CLOSED there', async () => {
+    getConferenceMock.mockResolvedValue({
+      conference: { _id: 'conf-A' },
+      error: null,
+    })
+    const caller = callerFor({ _id: 'legacy-admin', isOrganizer: true })
+    await expect(caller.probe()).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Admin privileges required',
+    })
+    expect(handler).not.toHaveBeenCalled()
+  })
+})

--- a/src/server/trpc.requireFeatureNotDenied.test.ts
+++ b/src/server/trpc.requireFeatureNotDenied.test.ts
@@ -13,9 +13,12 @@
  *
  * The distinction under test is NARROW and load-bearing: an operator's active
  * `enabled: false` refuses; every other shape of "not entitled" passes. Widen it
- * to `requireFeature` semantics and this deployment's own tenant — no `plan`, so
- * `community`, against `ticketing`'s `minPlan: 'pro'` — loses ticketing
- * entirely. The `entitled by plan?` assertions below pin exactly that.
+ * to `requireFeature` semantics and the shape `features/ticketing.ts` rule 2
+ * protects — a `community` org with no `plan`, against `ticketing`'s
+ * `minPlan: 'pro'`, whose own provider credentials still earn it the full
+ * ticketing UI — loses the API behind that UI entirely. The `entitled by plan?`
+ * assertions below pin exactly that, and a pro-plan positive control pins the
+ * shape production actually has.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
@@ -43,12 +46,19 @@ import {
 } from './trpc'
 import { computeEntitlements } from '@/lib/features/entitlements'
 
-/** The tenant this deployment actually runs (migration 044): no plan, no overrides. */
-const CNDN_ORG = 'organization-cloud-native-days'
-const cndnDocument = {
-  _id: CNDN_ORG,
+const ORG = 'organization-cloud-native-days'
+
+/**
+ * THE RULE-2 SHAPE: `community` (no `plan`), no operator override. Not entitled
+ * to `ticketing` — `minPlan` is `'pro'` — but `features/ticketing.ts` rule 2
+ * keeps its ticketing surface on its own provider credentials, so this gate must
+ * pass it. Not a snapshot of any live tenant; production's org carries
+ * `plan: 'pro'`, covered by its own positive control below.
+ */
+const communityOrgDocument = {
+  _id: ORG,
   name: 'Cloud Native Days Norway',
-  slug: 'cloud-native-days',
+  slug: 'cloud-native-days-norway',
 }
 
 const handler = vi.fn()
@@ -69,7 +79,7 @@ function callerFor(
     organizerOrgIds?: string[]
   } = {
     _id: 'admin',
-    organizerOrgIds: [CNDN_ORG],
+    organizerOrgIds: [ORG],
   },
 ) {
   const session = { speaker, user: { email: 'u@x.test' } }
@@ -83,16 +93,16 @@ function callerFor(
 beforeEach(() => {
   vi.clearAllMocks()
   getConferenceMock.mockResolvedValue({
-    conference: { _id: 'conf-A', organization: { _ref: CNDN_ORG } },
+    conference: { _id: 'conf-A', organization: { _ref: ORG } },
     error: null,
   })
-  getOrganizationById.mockResolvedValue(cndnDocument)
+  getOrganizationById.mockResolvedValue(communityOrgDocument)
 })
 
 describe('requireFeatureNotDenied refuses ONLY an operator’s explicit deny', () => {
   it('throws FORBIDDEN naming the feature, and the handler never runs', async () => {
     getOrganizationById.mockResolvedValue({
-      ...cndnDocument,
+      ...communityOrgDocument,
       featureOverrides: [{ feature: 'ticketing', enabled: false }],
     })
     await expect(callerFor().probe()).rejects.toMatchObject({
@@ -107,7 +117,7 @@ describe('requireFeatureNotDenied refuses ONLY an operator’s explicit deny', (
 
   it('refuses even a PAID org — a deny beats the plan that sells it', async () => {
     getOrganizationById.mockResolvedValue({
-      ...cndnDocument,
+      ...communityOrgDocument,
       plan: 'pro',
       featureOverrides: [{ feature: 'ticketing', enabled: false }],
     })
@@ -119,32 +129,32 @@ describe('requireFeatureNotDenied refuses ONLY an operator’s explicit deny', (
 
   it('keys on the REQUEST-resolved org, never on client input', async () => {
     await callerFor().probe()
-    expect(getOrganizationById).toHaveBeenCalledWith(CNDN_ORG)
+    expect(getOrganizationById).toHaveBeenCalledWith(ORG)
   })
 })
 
 /**
- * THE HARD CONSTRAINT. Gating must not remove capability from the tenant that
- * exists. Each case below is an org the ENTITLEMENT resolver says is not
- * entitled to `ticketing`; each must still pass this gate.
+ * THE HARD CONSTRAINT. Gating must not remove a capability an org already has.
+ * Each case below is an org the ENTITLEMENT resolver says is not entitled to
+ * `ticketing`; each must still pass this gate.
  */
 describe('requireFeatureNotDenied passes everything that is not a deny', () => {
-  it('passes the live CNDN-shaped org, which is NOT entitled by plan', async () => {
+  it('passes the rule-2 shape, which is NOT entitled by plan', async () => {
     // The premise, pinned: `requireFeature('ticketing')` here would 403,
     // because this document carries no `plan` and ticketing is `minPlan: 'pro'`.
     const entitledByPlan = computeEntitlements(
-      (cndnDocument as { plan?: string }).plan,
+      (communityOrgDocument as { plan?: string }).plan,
       [],
       new Date(),
     )
     expect(entitledByPlan.has('ticketing')).toBe(false)
-    await expect(callerFor().probe()).resolves.toEqual({ orgId: CNDN_ORG })
+    await expect(callerFor().probe()).resolves.toEqual({ orgId: ORG })
     expect(handler).toHaveBeenCalledTimes(1)
   })
 
   it('passes an EXPIRED deny (the override is ignored entirely)', async () => {
     getOrganizationById.mockResolvedValue({
-      ...cndnDocument,
+      ...communityOrgDocument,
       featureOverrides: [
         {
           feature: 'ticketing',
@@ -153,25 +163,50 @@ describe('requireFeatureNotDenied passes everything that is not a deny', () => {
         },
       ],
     })
-    await expect(callerFor().probe()).resolves.toEqual({ orgId: CNDN_ORG })
+    await expect(callerFor().probe()).resolves.toEqual({ orgId: ORG })
   })
 
   it('passes a deny aimed at a DIFFERENT feature', async () => {
     getOrganizationById.mockResolvedValue({
-      ...cndnDocument,
+      ...communityOrgDocument,
       featureOverrides: [{ feature: 'badges', enabled: false }],
     })
-    await expect(callerFor().probe()).resolves.toEqual({ orgId: CNDN_ORG })
+    await expect(callerFor().probe()).resolves.toEqual({ orgId: ORG })
   })
 
   it('passes a missing org document and a REJECTED read — accidents are not decisions', async () => {
     getOrganizationById.mockResolvedValue(null)
-    await expect(callerFor().probe()).resolves.toEqual({ orgId: CNDN_ORG })
+    await expect(callerFor().probe()).resolves.toEqual({ orgId: ORG })
 
     const logged = vi.spyOn(console, 'error').mockImplementation(() => {})
     getOrganizationById.mockRejectedValue(new Error('sanity unavailable'))
-    await expect(callerFor().probe()).resolves.toEqual({ orgId: CNDN_ORG })
+    await expect(callerFor().probe()).resolves.toEqual({ orgId: ORG })
     logged.mockRestore()
+  })
+
+  /**
+   * THE SHAPE PRODUCTION ACTUALLY HAS, queried from the live dataset on
+   * 2026-08-05: `plan: 'pro'`, `featureOverrides: null`. It IS entitled by plan,
+   * which makes it the complement of the "refuses even a PAID org" case above —
+   * pro WITHOUT a deny. Deny-only passes it trivially; it is here as the
+   * positive control the live shape did not previously have.
+   */
+  it('passes the production shape — pro plan, no overrides', async () => {
+    const productionOrgDocument = {
+      ...communityOrgDocument,
+      plan: 'pro',
+      featureOverrides: null,
+    }
+    // The premise, pinned in the opposite direction: `requireFeature` WOULD
+    // admit this one, so it can never be the case that tightens the gate.
+    expect(
+      computeEntitlements(productionOrgDocument.plan, [], new Date()).has(
+        'ticketing',
+      ),
+    ).toBe(true)
+    getOrganizationById.mockResolvedValue(productionOrgDocument)
+    await expect(callerFor().probe()).resolves.toEqual({ orgId: ORG })
+    expect(handler).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -240,6 +240,56 @@ export function requireFeature(featureId: FeatureId) {
   })
 }
 
+/**
+ * The KILL-SWITCH half of {@link requireFeature}: refuses a procedure when an
+ * OPERATOR has explicitly switched `featureId` OFF for the request's
+ * organization (an active `featureOverrides` entry with `enabled: false`), and
+ * for NO other reason.
+ *
+ * WHY IT IS NOT `requireFeature` (#836). `requireFeature` asks whether the org
+ * is ENTITLED, which folds "never granted" in with "switched off". Several
+ * features are deliberately reachable without an entitlement — `ticketing` is
+ * enabled for the platform org and for any org holding its OWN provider
+ * credentials, neither of which appears in `computeEntitlements` — so gating
+ * those endpoints on entitlement would REMOVE a capability that works today
+ * (concretely: this deployment's own tenant carries no `plan`, resolves to
+ * `community`, and `ticketing` is `minPlan: 'pro'`, so `requireFeature`
+ * would 403 every ticketing call it makes). This middleware honours the
+ * operator's DECISION without inventing one where none was made — the same
+ * narrow question `resolveTicketingAdminAccess` asks before it resolves a
+ * provider, so the API and the UI cannot disagree about who is switched off.
+ *
+ * WHAT IT DOES NOT DO, precisely:
+ *  - It does NOT refuse an org that merely lacks the feature. That is
+ *    {@link requireFeature}'s job, and composing both is legitimate.
+ *  - It does NOT refuse when the org cannot be resolved, when the org document
+ *    is missing, or when the Sanity read REJECTS: those are accidents, not
+ *    decisions, and `isFeatureExplicitlyDeniedForOrg` reports them as "not
+ *    denied" so one flaky read cannot black out a working tenant. THE HOLE THIS
+ *    LEAVES IS REAL: composed onto a procedure that does not itself resolve an
+ *    org, an unresolvable request passes this gate. It is closed in practice by
+ *    composing onto {@link adminProcedure}, whose waist already FAILS CLOSED on
+ *    an unresolvable org — so compose it there, not onto `publicProcedure`.
+ */
+export function requireFeatureNotDenied(featureId: FeatureId) {
+  return t.middleware(async ({ ctx, next }) => {
+    const upstreamOrgId = (ctx as { orgId?: string | null }).orgId
+    const orgId =
+      upstreamOrgId !== undefined
+        ? upstreamOrgId
+        : await resolveOrganizationId()
+    const { isFeatureExplicitlyDeniedForOrg } =
+      await import('@/lib/features/platform-default')
+    if (await isFeatureExplicitlyDeniedForOrg(orgId, featureId)) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: `The "${featureId}" feature has been switched off for this organization`,
+      })
+    }
+    return next({ ctx: { ...ctx, orgId } })
+  })
+}
+
 const CLIENT_ERROR_CODES = new Set([
   'NOT_FOUND',
   'BAD_REQUEST',

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -250,12 +250,14 @@ export function requireFeature(featureId: FeatureId) {
  * is ENTITLED, which folds "never granted" in with "switched off". Several
  * features are deliberately reachable without an entitlement — `ticketing` is
  * enabled for the platform org and for any org holding its OWN provider
- * credentials, neither of which appears in `computeEntitlements` — so gating
- * those endpoints on entitlement would REMOVE a capability that works today
- * (concretely: this deployment's own tenant carries no `plan`, resolves to
- * `community`, and `ticketing` is `minPlan: 'pro'`, so `requireFeature`
- * would 403 every ticketing call it makes). This middleware honours the
- * operator's DECISION without inventing one where none was made — the same
+ * credentials (`features/ticketing.ts` rule 2), neither of which appears in
+ * `computeEntitlements` — so gating those endpoints on entitlement would REMOVE
+ * a capability that works today. Concretely: a `community` org whose own
+ * credentials resolve keeps the entire ticketing UI by rule 2, and
+ * `requireFeature('ticketing')` on this router would 403 the API behind that
+ * UI — making the layer that serves the surface STRICTER than the surface,
+ * which is the disagreement rule 2 exists to prevent. This middleware honours
+ * the operator's DECISION without inventing one where none was made — the same
  * narrow question `resolveTicketingAdminAccess` asks before it resolves a
  * provider, so the API and the UI cannot disagree about who is switched off.
  *


### PR DESCRIPTION
Implements the decided outcome of #836: an operator `enabled: false` on `ticketing` is a HARD kill switch that reaches **every organizer-visible output**, not only the UI #834 gated.

## What changed

**1. `requireFeatureNotDenied(featureId)` (`src/server/trpc.ts`)** — a new middleware, the deny-only half of `requireFeature`. It throws `FORBIDDEN` (`The "ticketing" feature has been switched off for this organization`) on an **active operator deny** and on nothing else, resolving through the existing registry (`isFeatureExplicitlyDeniedForOrg` → `featureOverrides`). No parallel mechanism.

**2. `tickets.admin.*` (`src/server/routers/tickets.ts`)** — the middleware is composed **once**, onto a `ticketingAdminProcedure` that all **13** procedures in the sub-router use, rather than six copy-pasted checks. Procedure fourteen inherits the gate by being declared there. That covers the endpoints named in the issue (`getTicketTypes`, `getDiscountCodes`, `getDiscountCodesWithUsage`, `getPaymentDetails`, `createDiscountCode`, `deleteDiscountCode`) plus the seven settings/page-content procedures the issue did not enumerate. A denied org now makes **no provider call and no Sanity write** — including the two mutations that wrote discount codes into the tenant's own provider account.

**3. `buildTicketSection` (`src/lib/status/summary.ts`)** — gated *before* `resolveTicketingProvider`, mirroring `resolveTicketingAdminAccess`'s order, so a denied org gets no ticket numbers in its weekly Slack post (or on the admin status page) and costs zero provider work. Sponsors and proposals are untouched: this switches off ticketing, not the weekly update. Added `isTicketingDeniedForConference` alongside the existing `isTicketingEnabledForConference`.

**4. Comment corrections** in `src/lib/features/ticketing.ts` and `src/lib/features/badges.ts` — both carried a now-false scope paragraph. They now state exactly what the deny reaches and what it does not.

## Why NOT `requireFeature('ticketing')` — and the hard constraint

`requireFeature` asks whether the org is **entitled**, which folds "never granted" together with "switched off". Verified rather than assumed: `organization-cloud-native-days` was created by `migrations/044-organization-tier-backfill` with **no `plan` and no `featureOverrides`**. `effectivePlan` normalizes an absent plan to `community`, and `ticketing` is `readiness: 'ga'` + `minPlan: 'pro'`, so `computeEntitlements` does **not** contain `ticketing` for that document — its ticketing works today via the platform-org grant and its own credentials, neither of which the entitlement set expresses. **An entitlement-shaped gate would have 403'd every ticketing call CNDN makes.** A deny-shaped gate cannot: CNDN carries no override, so `isFeatureExplicitlyDeniedForOrg` is `false` for it by construction.

That is not left to reasoning. Both new test files contain a **positive-control block** driven by the real CNDN document shape: all 13 procedures still answer, the provider is still reached for reads and writes, and the Slack summary still reports live counts — including under an expired deny, a deny on another feature, and a rejected Sanity read. Tighten the gate to entitlement semantics and those blocks fail.

## Sabotage proofs (full `pnpm test` per sabotage, baseline 504 files / 7344 tests on `origin/main`)

| Sabotage | Result |
| --- | --- |
| Drop `.use(requireFeatureNotDenied('ticketing'))` from `ticketingAdminProcedure` | **15 tests fail** in 1 file (`tickets.killswitch.test.ts`) — 13 procedure cases + the no-provider-call case + the paid-org case |
| Delete the deny early-return in `buildTicketSection` | **2 tests fail** in 1 file (`summary.ticketing.test.ts`) |
| No-op the middleware body in `requireFeatureNotDenied` | **18 tests fail** in 2 files (15 router + 3 middleware) |
| All restored | 507 files / 7390 tests pass |

## How I know these do not pass for the wrong reason

- **The router deny cases assert the refusal message verbatim, not just `FORBIDDEN`.** `adminProcedure`'s own waist also throws `FORBIDDEN` (`Admin privileges required`) — a code-only assertion is exactly the trap #842 hit. In these tests the caller **is** an organizer of the request org and the org resolves, so the waist admits the call; the only thing in the file that can produce `The "ticketing" feature has been switched off…` is the gate under test. The composition tests assert the *other* message explicitly, so the two refusals cannot be confused.
- **The Slack cases assert `resolveTicketingProvider` was never called.** `tickets: null` is also what an unconfigured or a failing conference produces, so that alone proves nothing. The fixture conference is fully configured with real sales, so without the gate the resolver runs and numbers come back — a summary in which the resolver was *not reached* can only come from the gate.
- **The gate runs for real, not stubbed.** Both files mock `getOrganizationById` and let `@/lib/features/platform-default` + `entitlements` execute, so override direction and expiry are genuinely exercised.

## Numbers (baseline = `origin/main`, after = this branch)

| Check | Before | After |
| --- | --- | --- |
| `pnpm test` | 504 files / 7344 tests passed | **507 files / 7390 tests passed** |
| `pnpm typecheck` | clean | clean |
| `npx prettier --check .` | clean | clean |
| `npx eslint .` | 0 errors, 201 warnings | **0 errors, 201 warnings** |
| `pnpm knip` | 1 config hint | 1 config hint (unchanged) |

## Deliberately left alone

- **Public/attendee ticket sales, workshop eligibility, the admin status probes** — out of scope per the issue; not gated, still working.
- **Speaker-ticket issuance** (`src/lib/events/handlers/speakerTicket.ts`) — **left ungated on purpose**, as the issue allows. It still mints a 100%-off coupon in a denied org's vendor account on speaker confirmation. It is borderline but low-harm: it is triggered by a proposal-confirmation event rather than by an organizer poking a ticketing surface, the coupon is deterministic per speaker email and idempotent, and gating it would silently break comp tickets for speakers of an org whose organizers were never told ticketing went off. Both feature modules' comments now name this hole rather than implying completeness.

### The one hole in the middleware itself, stated plainly

`requireFeatureNotDenied` does **not** fail closed on an unresolvable org: `isFeatureExplicitlyDeniedForOrg` reports a nullish org id, a missing document and a rejected Sanity read as "not denied", deliberately, so one flaky read cannot black out a working tenant (the hazard #828 fixed). Composed onto a procedure that does not resolve an org, an unresolvable request would pass this gate. It is closed **by composition** — `adminProcedure`'s waist already fails closed on an unresolvable org — and two tests assert that the waist, not this gate, is what refuses there. The doc comment says to compose it on `adminProcedure`, never on `publicProcedure`.

This gate is still **not a security boundary**: credential isolation remains `resolveTicketingCredentials` plus the tenancy guards. It is an operator's off switch, now honoured everywhere an organizer can see ticketing.

Closes #836
