### PR TITLE
docs(migrations): make each module header state the run state that evidence supports

### DIFF
--- a/migrations/041-weak-messaging-refs/README.md
+++ b/migrations/041-weak-messaging-refs/README.md
@@ -13,8 +13,9 @@ so no follow-up backfill is needed for it. (Re-verified 2026-08-05: the one stor
 ## ⚠️ The trap has REOPENED — a re-run is not the fix
 
 Verified against production on 2026-08-05. The migration's own effect held: **no**
-strong ref predating the 2026-07-19 run survives. But **802 new strong speaker refs
-have accumulated since**, on the very fields this migration weakened:
+strong ref predating the 2026-07-19 run survives. But **802 new strong speaker
+references have accumulated since, across 428 documents**, on the very fields this
+migration weakened:
 
 | Field                         | Strong refs today | Created before the run |
 | ----------------------------- | ----------------: | ---------------------: |
@@ -25,6 +26,10 @@ have accumulated since**, on the very fields this migration weakened:
 | `conversation.subjectSpeaker` |                 1 |                      0 |
 
 Oldest 2026-07-19T17:47Z (nine hours after the run); newest 2026-08-05.
+
+The column sums to 802 **references**, which live in 428 **documents** — 373
+notifications hold a strong `recipient` and a strong `actor` at once. The two
+verification queries below report these two different units; see "Mind the unit".
 
 **Cause.** Schema `weak: true` governs Studio writes and validation, not API
 writes. `createReference()` (`src/lib/sanity/helpers.ts`) returns
@@ -102,19 +107,42 @@ pnpm sanity migration run 041-weak-messaging-refs \
 
 ## Verification
 
-After running, confirm no strong messaging refs remain:
+After running, confirm no strong messaging refs remain.
+
+**Both queries below return 0 immediately after an apply, and neither stays 0** —
+the write path keeps creating strong refs (see "The trap has REOPENED" above). A
+non-zero result today is EXPECTED and is **not** evidence that the migration
+failed to apply.
+
+**Mind the unit.** These two count different things and are supposed to disagree:
+a single `notification` can hold two strong refs (`recipient` **and** `actor`), so
+the reference total exceeds the document total. Measured 2026-08-05: **428
+documents** holding **802 references**, none predating the 2026-07-19 run.
 
 ```bash
-# Returns 0 immediately after an apply. It does NOT stay 0: the write path keeps
-# creating strong refs (see "The trap has REOPENED" above) — this returned 802 on
-# 2026-08-05, none of them predating the 2026-07-19 run. A non-zero result here is
-# expected today and is NOT evidence that the migration failed to apply.
-npx sanity documents query 'count(*[
+# (a) DOCUMENTS holding at least one strong ref → 428 on 2026-08-05.
+npx sanity documents query '{"documents": count(*[
   (_type == "message" && defined(author._ref) && author._weak != true) ||
   (_type == "conversation" && ((defined(createdBy._ref) && createdBy._weak != true) || (defined(subjectSpeaker._ref) && subjectSpeaker._weak != true))) ||
   (_type == "notification" && ((defined(recipient._ref) && recipient._weak != true) || (defined(actor._ref) && actor._weak != true)))
-])'
+])}'
+
+# (b) REFERENCES per field → 408 + 373 + 13 + 7 + 1 = 802 on 2026-08-05.
+#     (373 notifications carry BOTH a strong recipient and a strong actor, which
+#     is the whole of the gap between 802 references and 428 documents.)
+npx sanity documents query '{
+  "notificationRecipient": count(*[_type == "notification" && !(_id in path("drafts.**")) && defined(recipient._ref) && recipient._weak != true]),
+  "notificationActor":     count(*[_type == "notification" && !(_id in path("drafts.**")) && defined(actor._ref) && actor._weak != true]),
+  "messageAuthor":         count(*[_type == "message" && !(_id in path("drafts.**")) && defined(author._ref) && author._weak != true]),
+  "conversationCreatedBy": count(*[_type == "conversation" && !(_id in path("drafts.**")) && defined(createdBy._ref) && createdBy._weak != true]),
+  "conversationSubject":   count(*[_type == "conversation" && !(_id in path("drafts.**")) && defined(subjectSpeaker._ref) && subjectSpeaker._weak != true])
+}'
 ```
+
+**Both are wrapped in `{ … }` deliberately.** A bare `count(…)` evaluating to 0
+makes the Sanity CLI fail with `Query returned no results` and exit 1 — so the
+success case looks like a broken query. Wrapping the count in an object prints
+`{"documents": 0}` instead.
 
 ## Rollback
 

--- a/migrations/041-weak-messaging-refs/README.md
+++ b/migrations/041-weak-messaging-refs/README.md
@@ -3,9 +3,39 @@
 ## ✅ APPLIED to production (2026-07-19)
 
 This migration was run against the `production` dataset on 2026-07-19 (maintainer-authorized;
-GitHub Actions run 29679682997: backup → dry-run → apply, 1 transaction committed).
+GitHub Actions run 29679682997: backup → dry-run → apply, 24 documents processed,
+24 mutations, 1 transaction committed).
 Note: `conversation.assignedTo` postdates this migration and has never had strong refs,
-so no follow-up backfill is needed for it.
+so no follow-up backfill is needed for it. (Re-verified 2026-08-05: the one stored
+`assignedTo` ref is weak — `src/lib/messaging/sanity.ts` writes it as
+`{ ...createReference(id), _weak: true }`.)
+
+## ⚠️ The trap has REOPENED — a re-run is not the fix
+
+Verified against production on 2026-08-05. The migration's own effect held: **no**
+strong ref predating the 2026-07-19 run survives. But **802 new strong speaker refs
+have accumulated since**, on the very fields this migration weakened:
+
+| Field                         | Strong refs today | Created before the run |
+| ----------------------------- | ----------------: | ---------------------: |
+| `notification.recipient`      |               408 |                      0 |
+| `notification.actor`          |               373 |                      0 |
+| `message.author`              |                13 |                      0 |
+| `conversation.createdBy`      |                 7 |                      0 |
+| `conversation.subjectSpeaker` |                 1 |                      0 |
+
+Oldest 2026-07-19T17:47Z (nine hours after the run); newest 2026-08-05.
+
+**Cause.** Schema `weak: true` governs Studio writes and validation, not API
+writes. `createReference()` (`src/lib/sanity/helpers.ts`) returns
+`{ _type: 'reference', _ref }` with no `_weak`, so application writes are strong.
+In `src/lib/notification/sanity.ts` the same object literal sets `relatedProposal`
+weak (with a comment explaining why) while `recipient` and `actor` — the two
+speaker refs this migration exists to weaken — are left strong.
+
+**Do not respond by re-running this migration.** It would clear the backlog and
+the backlog would rebuild. The fix belongs at the write path; until it lands, the
+GDPR erasure trap is open again. Tracked separately from this migration.
 
 Original run instructions kept below for other datasets. Running
 it is a deliberate maintainer action via the
@@ -28,10 +58,13 @@ conversation, or received/triggered a notification could **never be deleted** �
 a GDPR erasure trap.
 
 The schema now declares these fields `weak: true` (see the `weak: true` edits in
-`sanity/schemaTypes/{message,conversation,notification}.ts`). That fixes new
-writes, but **reference strength is stored per ref object** (`_weak`), not on the
-schema, so **existing documents keep their strong refs** until rewritten. This
-migration rewrites them.
+`sanity/schemaTypes/{message,conversation,notification}.ts`). **Reference strength
+is stored per ref object** (`_weak`), not on the schema, so **existing documents
+keep their strong refs** until rewritten. This migration rewrites them.
+
+That schema change was assumed to also fix **new** writes. It does not — schema
+`weak: true` governs Studio writes and validation, not writes made through the
+API. See "The trap has REOPENED" above.
 
 ## What it does
 
@@ -72,7 +105,10 @@ pnpm sanity migration run 041-weak-messaging-refs \
 After running, confirm no strong messaging refs remain:
 
 ```bash
-# Should return 0 once the migration has applied.
+# Returns 0 immediately after an apply. It does NOT stay 0: the write path keeps
+# creating strong refs (see "The trap has REOPENED" above) — this returned 802 on
+# 2026-08-05, none of them predating the 2026-07-19 run. A non-zero result here is
+# expected today and is NOT evidence that the migration failed to apply.
 npx sanity documents query 'count(*[
   (_type == "message" && defined(author._ref) && author._weak != true) ||
   (_type == "conversation" && ((defined(createdBy._ref) && createdBy._weak != true) || (defined(subjectSpeaker._ref) && subjectSpeaker._weak != true))) ||

--- a/migrations/041-weak-messaging-refs/README.md
+++ b/migrations/041-weak-messaging-refs/README.md
@@ -27,9 +27,17 @@ migration weakened:
 
 Oldest 2026-07-19T17:47Z (nine hours after the run); newest 2026-08-05.
 
-The column sums to 802 **references**, which live in 428 **documents** — 373
-notifications hold a strong `recipient` and a strong `actor` at once. The two
-verification queries below report these two different units; see "Mind the unit".
+The column sums to 802 **references**, which live in 428 **documents**. The
+374-reference difference is made of documents holding two strong refs at once,
+measured 2026-08-05 (query (c) below):
+
+- **373** notifications hold a strong `recipient` **and** a strong `actor`
+- **1** conversation holds a strong `createdBy` **and** a strong `subjectSpeaker`
+- messages contribute **0**: their document and reference counts both measured 13
+
+373 + 1 = 374, and 802 − 428 = 374. The verification queries below report each of
+these figures separately — documents, references, and the overlap — so the
+reconciliation can be re-run rather than trusted; see "Mind the unit".
 
 **Cause.** Schema `weak: true` governs Studio writes and validation, not API
 writes. `createReference()` (`src/lib/sanity/helpers.ts`) returns
@@ -114,10 +122,13 @@ the write path keeps creating strong refs (see "The trap has REOPENED" above). A
 non-zero result today is EXPECTED and is **not** evidence that the migration
 failed to apply.
 
-**Mind the unit.** These two count different things and are supposed to disagree:
-a single `notification` can hold two strong refs (`recipient` **and** `actor`), so
-the reference total exceeds the document total. Measured 2026-08-05: **428
-documents** holding **802 references**, none predating the 2026-07-19 run.
+**Mind the unit.** (a) and (b) count different things and are supposed to
+disagree: one document can hold two strong refs — a `notification` via
+`recipient` + `actor`, a `conversation` via `createdBy` + `subjectSpeaker` — so
+the reference total runs ahead of the document total. Query (c) measures that
+overlap so the difference can be checked rather than assumed. Measured
+2026-08-05: **428 documents** holding **802 references**, none predating the
+2026-07-19 run.
 
 ```bash
 # (a) DOCUMENTS holding at least one strong ref → 428 on 2026-08-05.
@@ -128,8 +139,6 @@ npx sanity documents query '{"documents": count(*[
 ])}'
 
 # (b) REFERENCES per field → 408 + 373 + 13 + 7 + 1 = 802 on 2026-08-05.
-#     (373 notifications carry BOTH a strong recipient and a strong actor, which
-#     is the whole of the gap between 802 references and 428 documents.)
 npx sanity documents query '{
   "notificationRecipient": count(*[_type == "notification" && !(_id in path("drafts.**")) && defined(recipient._ref) && recipient._weak != true]),
   "notificationActor":     count(*[_type == "notification" && !(_id in path("drafts.**")) && defined(actor._ref) && actor._weak != true]),
@@ -137,9 +146,17 @@ npx sanity documents query '{
   "conversationCreatedBy": count(*[_type == "conversation" && !(_id in path("drafts.**")) && defined(createdBy._ref) && createdBy._weak != true]),
   "conversationSubject":   count(*[_type == "conversation" && !(_id in path("drafts.**")) && defined(subjectSpeaker._ref) && subjectSpeaker._weak != true])
 }'
+
+# (c) OVERLAP — documents holding two strong refs at once. This is what makes (b)
+#     larger than (a); run it rather than inferring it.
+#     On 2026-08-05: notificationBoth 373, conversationBoth 1 → 802 - 428 = 374.
+npx sanity documents query '{
+  "notificationBoth": count(*[_type == "notification" && !(_id in path("drafts.**")) && defined(recipient._ref) && recipient._weak != true && defined(actor._ref) && actor._weak != true]),
+  "conversationBoth": count(*[_type == "conversation" && !(_id in path("drafts.**")) && defined(createdBy._ref) && createdBy._weak != true && defined(subjectSpeaker._ref) && subjectSpeaker._weak != true])
+}'
 ```
 
-**Both are wrapped in `{ … }` deliberately.** A bare `count(…)` evaluating to 0
+**All three are wrapped in `{ … }` deliberately.** A bare `count(…)` evaluating to 0
 makes the Sanity CLI fail with `Query returned no results` and exit 1 — so the
 success case looks like a broken query. Wrapping the count in an object prints
 `{"documents": 0}` instead.

--- a/migrations/041-weak-messaging-refs/index.ts
+++ b/migrations/041-weak-messaging-refs/index.ts
@@ -2,7 +2,11 @@ import { defineMigration, at, patch, set } from 'sanity/migrate'
 import type { SanityDocument } from '@sanity/types'
 
 /**
- * ⚠️ MIGRATION NOT RUN — MAINTAINER DECISION REQUIRED. ⚠️
+ * ✅ RUN IN PRODUCTION — 2026-07-19 (GitHub Actions run 29679682997).
+ *
+ * Do NOT re-run against `production` as a matter of course. It is idempotent
+ * (already-weak refs are skipped), but a re-run is still an unnecessary
+ * production write. See README.md.
  *
  * Backfill `_weak: true` onto the speaker references that the messaging system
  * newly declares `weak` in the schema (see the matching `weak: true` edits in
@@ -26,10 +30,11 @@ import type { SanityDocument } from '@sanity/types'
  * is a no-op (already-weak refs are skipped). It never changes `_ref` targets,
  * never deletes anything, and preserves any extra keys on the ref object.
  *
- * NOT RUN: run intentionally, after review, via the "Run Sanity Migration"
- * workflow (`.github/workflows/run-migration.yml`) with migration id
+ * HOW IT WAS RUN, and how to run it against ANOTHER dataset: intentionally,
+ * after review, via the "Run Sanity Migration" workflow
+ * (`.github/workflows/run-migration.yml`) with migration id
  * `041-weak-messaging-refs`. The workflow exports a dataset backup and performs
- * a dry run first.
+ * a dry run first. `production` has already had this applied (see above).
  */
 
 interface RefObject {
@@ -71,8 +76,9 @@ export default defineMigration({
   description:
     'Adds _weak:true to message.author, conversation.createdBy/subjectSpeaker, ' +
     'and notification.recipient/actor on existing documents so a speaker who ' +
-    'ever messaged can be erased. Idempotent; NOT RUN by default — run via the ' +
-    'Run Sanity Migration workflow after maintainer review.',
+    'ever messaged can be erased. Idempotent; APPLIED to production on ' +
+    '2026-07-19 — run against another dataset via the Run Sanity Migration ' +
+    'workflow after maintainer review.',
   documentTypes: ['message', 'conversation', 'notification'],
 
   async *migrate(documents) {

--- a/migrations/041-weak-messaging-refs/index.ts
+++ b/migrations/041-weak-messaging-refs/index.ts
@@ -3,6 +3,26 @@ import type { SanityDocument } from '@sanity/types'
 
 /**
  * ✅ RUN IN PRODUCTION — 2026-07-19 (GitHub Actions run 29679682997).
+ * It did its job: 24 documents processed, 24 mutations, 1 transaction committed,
+ * and NO strong ref predating that run survives in production today.
+ *
+ * ⚠️ BUT THE TRAP HAS REOPENED — the backfill is NOT self-sustaining. ⚠️
+ *
+ * As of 2026-08-05 production again holds 802 STRONG speaker refs on these very
+ * fields (notification.recipient 408, notification.actor 373, message.author 13,
+ * conversation.createdBy 7, conversation.subjectSpeaker 1). EVERY one was created
+ * AFTER this migration ran — the oldest 2026-07-19T17:47Z, nine hours later; the
+ * newest the day before this note.
+ *
+ * WHY the "fixed going forward" assumption below is WRONG: schema `weak: true`
+ * governs Studio writes and validation, NOT writes made through the API. The
+ * shared `createReference()` helper (`src/lib/sanity/helpers.ts`) returns
+ * `{ _type: 'reference', _ref }` with no `_weak`, so every ref the application
+ * writes is STRONG regardless of the schema. Re-running this migration would
+ * clean the backlog and then the backlog would rebuild.
+ *
+ * DO NOT treat a re-run as the fix. The fix is at the write path; until it lands,
+ * the GDPR erasure trap this migration was written to clear is open again.
  *
  * Do NOT re-run against `production` as a matter of course. It is idempotent
  * (already-weak refs are skipped), but a re-run is still an unnecessary
@@ -20,10 +40,13 @@ import type { SanityDocument } from '@sanity/types'
  *
  * WHY: these were STRONG references, so Sanity refused to delete any speaker who
  * had ever sent a message, created/was the subject of a conversation, or
- * received/triggered a notification — a GDPR erasure trap. Marking the fields
- * `weak` in the schema fixes it going FORWARD, but reference strength lives on
- * each stored ref object (`_weak`), not the schema, so EXISTING documents keep
- * their strong refs until rewritten. This migration rewrites them.
+ * received/triggered a notification — a GDPR erasure trap. Reference strength
+ * lives on each stored ref object (`_weak`), not the schema, so EXISTING
+ * documents keep their strong refs until rewritten. This migration rewrites them.
+ *
+ * Marking the fields `weak` in the schema was ASSUMED to fix it going FORWARD.
+ * It does not — see the reopened-trap note above. That assumption is the reason
+ * this was scoped as a one-shot backfill rather than a write-path change.
  *
  * SAFETY / IDEMPOTENCY: read-only-ish — it only adds `_weak: true` to ref
  * objects that already point at a speaker and don't already carry it. Re-running

--- a/migrations/041-weak-messaging-refs/index.ts
+++ b/migrations/041-weak-messaging-refs/index.ts
@@ -8,9 +8,12 @@ import type { SanityDocument } from '@sanity/types'
  *
  * ⚠️ BUT THE TRAP HAS REOPENED — the backfill is NOT self-sustaining. ⚠️
  *
- * As of 2026-08-05 production again holds 802 STRONG speaker refs on these very
- * fields (notification.recipient 408, notification.actor 373, message.author 13,
- * conversation.createdBy 7, conversation.subjectSpeaker 1). EVERY one was created
+ * As of 2026-08-05 production again holds 802 STRONG speaker REFERENCES on these
+ * very fields (notification.recipient 408, notification.actor 373,
+ * message.author 13, conversation.createdBy 7, conversation.subjectSpeaker 1),
+ * spread across 428 DOCUMENTS — fewer documents than references because 373
+ * notifications carry a strong `recipient` AND a strong `actor`. Mind which unit
+ * a given verification query returns; README.md gives both. EVERY one was created
  * AFTER this migration ran — the oldest 2026-07-19T17:47Z, nine hours later; the
  * newest the day before this note.
  *

--- a/migrations/041-weak-messaging-refs/index.ts
+++ b/migrations/041-weak-messaging-refs/index.ts
@@ -11,9 +11,11 @@ import type { SanityDocument } from '@sanity/types'
  * As of 2026-08-05 production again holds 802 STRONG speaker REFERENCES on these
  * very fields (notification.recipient 408, notification.actor 373,
  * message.author 13, conversation.createdBy 7, conversation.subjectSpeaker 1),
- * spread across 428 DOCUMENTS — fewer documents than references because 373
- * notifications carry a strong `recipient` AND a strong `actor`. Mind which unit
- * a given verification query returns; README.md gives both. EVERY one was created
+ * spread across 428 DOCUMENTS. Documents are fewer than references because 374
+ * documents hold two strong refs at once: 373 notifications with both a
+ * `recipient` and an `actor`, and 1 conversation with both a `createdBy` and a
+ * `subjectSpeaker` (measured, not inferred — README.md gives the query). Mind
+ * which unit a given verification query returns. EVERY one was created
  * AFTER this migration ran — the oldest 2026-07-19T17:47Z, nine hours later; the
  * newest the day before this note.
  *

--- a/migrations/043-backfill-conversation-participants/README.md
+++ b/migrations/043-backfill-conversation-participants/README.md
@@ -1,11 +1,20 @@
 # Migration 043: Backfill conversation participants + message authorParty (party model G1)
 
-## ⚠️ NOT RUN — maintainer decision required (run BEFORE the G2 read-path flip)
+## ✅ RUN IN PRODUCTION — 2026-07-19
 
-Running this is a deliberate maintainer action via the
+Applied to the `production` dataset on 2026-07-19 (maintainer-authorized; GitHub
+Actions run 29702487495: backup → dry-run → apply, `--no-dry-run --no-confirm`).
+
+The ordering requirement it carried — run after the G1 dual-write shipped and
+**before** G2 flips the read path onto `participants[]` — was met, and the G2a
+flip has since shipped (see the party-model note in `src/lib/messaging/sanity.ts`).
+That instruction is therefore historical: do **not** read it as work still owed.
+
+Do not re-run against `production`. It is idempotent, but a re-run is still an
+unnecessary production write. The run instructions below remain valid for
+**other datasets**, where running it is a deliberate maintainer action via the
 [`Run Sanity Migration`](../../.github/workflows/run-migration.yml) workflow
-after review. It should be run once the G1 dual-write has shipped and **before**
-G2 flips the read path onto `participants[]`.
+after review.
 
 ## Overview
 
@@ -90,7 +99,11 @@ npx sanity documents query 'count(*[_type == "message" && !(_id in path("drafts.
 
 ## Rollback
 
-The backfill is additive and never read in G1 (the read path still derives from
-the legacy fields), so there is normally nothing to roll back — the fields sit
-inert until G2. If required, restore from the backup artifact produced by the
+The backfill is additive, so nothing is destroyed by it. But the "inert until
+G2" reasoning that once made rollback trivially safe **no longer holds**: the
+G2a flip has shipped, so `participants[]` is now the PREFERRED read for
+participant/authz resolution (`canAccessConversation`, `resolveParticipantIds`).
+Removing the backfilled fields today falls back onto the legacy derivation
+rather than being a no-op. Treat rollback as a change to a live read path, not
+as housekeeping. If required, restore from the backup artifact produced by the
 workflow.

--- a/migrations/043-backfill-conversation-participants/README.md
+++ b/migrations/043-backfill-conversation-participants/README.md
@@ -92,10 +92,19 @@ After running, confirm no non-draft conversation lacks participants and no
 non-draft message with an author lacks an `authorParty`:
 
 ```bash
-# Both should return 0 once the migration has applied.
-npx sanity documents query 'count(*[_type == "conversation" && !(_id in path("drafts.**")) && count(participants) == 0])'
-npx sanity documents query 'count(*[_type == "message" && !(_id in path("drafts.**")) && defined(author._ref) && !defined(authorParty)])'
+# Both fields should be 0 once the migration has applied.
+# Verified against production on 2026-08-05: both 0, out of 8 non-draft
+# conversations and 15 non-draft messages.
+npx sanity documents query '{
+  "conversationsMissingParticipants": count(*[_type == "conversation" && !(_id in path("drafts.**")) && count(participants) == 0]),
+  "messagesMissingAuthorParty":       count(*[_type == "message" && !(_id in path("drafts.**")) && defined(author._ref) && !defined(authorParty)])
+}'
 ```
+
+> Wrapped in `{ … }` deliberately. A **bare** `count(…)` that evaluates to 0 makes
+> the Sanity CLI print `Error: Failed to run query: Query returned no results` and
+> exit 1 — so the expected success case here would look like a broken query.
+> Wrapping prints `{"conversationsMissingParticipants": 0, …}` instead.
 
 ## Rollback
 

--- a/migrations/043-backfill-conversation-participants/index.ts
+++ b/migrations/043-backfill-conversation-participants/index.ts
@@ -2,7 +2,15 @@ import { defineMigration, at, patch, set } from 'sanity/migrate'
 import type { SanityDocument } from '@sanity/types'
 
 /**
- * ⚠️ MIGRATION NOT RUN — MAINTAINER DECISION REQUIRED. ⚠️
+ * ✅ RUN IN PRODUCTION — 2026-07-19 (GitHub Actions run 29702487495).
+ *
+ * The G2a read-path flip this migration was a prerequisite of has ALSO shipped
+ * (see the party-model note in `src/lib/messaging/sanity.ts`), so the ordering
+ * requirement below is satisfied and historical.
+ *
+ * Do NOT re-run against `production` as a matter of course. It is idempotent
+ * (docs already carrying the representation are skipped), but a re-run is still
+ * an unnecessary production write. See README.md.
  *
  * Backfill the PARTY DATA MODEL (messaging G1) onto existing documents:
  *
@@ -19,8 +27,8 @@ import type { SanityDocument } from '@sanity/types'
  * This migration reconstructs the party representation for them from the SAME
  * legacy fields the read resolver derives from, so that once G2 flips the read
  * path to prefer `participants[]`, every historical thread already carries the
- * bit-identical representation. It must be run by the maintainer BEFORE the G2
- * read-path flip.
+ * bit-identical representation. It had to run BEFORE the G2 read-path flip; it
+ * did (2026-07-19), and the flip has since shipped.
  *
  * The derivation MIRRORS `deriveParties` / `partiesToStored` in
  * src/lib/messaging/sanity.ts VERBATIM (migrations do not resolve the `@/` alias
@@ -36,10 +44,12 @@ import type { SanityDocument } from '@sanity/types'
  * between runs is left untouched). Human-pointing refs are written WEAK (per
  * 041) so a later GDPR erase never orphan-blocks.
  *
- * NOT RUN: run intentionally, after review, via the "Run Sanity Migration"
- * workflow (.github/workflows/run-migration.yml) with migration id
+ * HOW IT WAS RUN, and how to run it against ANOTHER dataset: intentionally,
+ * after review, via the "Run Sanity Migration" workflow
+ * (.github/workflows/run-migration.yml) with migration id
  * `043-backfill-conversation-participants`. The workflow exports a dataset
- * backup and performs a dry run first.
+ * backup and performs a dry run first. `production` has already had this
+ * applied (see above).
  */
 
 /** The universal organizer group key. Mirrors ORGANIZERS_GROUP in types.ts. */
@@ -126,8 +136,9 @@ export default defineMigration({
     'legacy fields for documents predating the G1 dual-write, so the G2 read-path ' +
     'flip finds every historical thread already carrying the party representation. ' +
     'Additive, idempotent (skips docs already carrying the representation, skips ' +
-    'drafts); mirrors deriveParties/partiesToStored verbatim. NOT RUN by default — ' +
-    'run via the Run Sanity Migration workflow after maintainer review, before G2.',
+    'drafts); mirrors deriveParties/partiesToStored verbatim. APPLIED to ' +
+    'production on 2026-07-19, before the G2 flip — run against another dataset ' +
+    'via the Run Sanity Migration workflow after maintainer review.',
   // The message pass drives off the streamed iterator (author is on the doc);
   // the conversation pass needs the proposal->speakers JOIN, so it uses an
   // explicit fetch. Both types are declared so the workflow streams messages.

--- a/migrations/043-backfill-conversation-participants/index.ts
+++ b/migrations/043-backfill-conversation-participants/index.ts
@@ -8,6 +8,10 @@ import type { SanityDocument } from '@sanity/types'
  * (see the party-model note in `src/lib/messaging/sanity.ts`), so the ordering
  * requirement below is satisfied and historical.
  *
+ * Verified by EFFECT against production on 2026-08-05, using this directory's
+ * own README queries: 0 of 8 non-draft conversations lack `participants[]`, and
+ * 0 of 15 non-draft messages with an author lack `authorParty`.
+ *
  * Do NOT re-run against `production` as a matter of course. It is idempotent
  * (docs already carrying the representation are skipped), but a re-run is still
  * an unnecessary production write. See README.md.

--- a/migrations/044-organization-tier-backfill/index.ts
+++ b/migrations/044-organization-tier-backfill/index.ts
@@ -13,8 +13,11 @@ import type { SanityDocument } from '@sanity/types'
  * LOAD-BEARING FOR AUTHORIZATION. `src/lib/authz/organizer.ts` denies when a
  * request's organization is unresolvable, and justifies that fail-closed posture
  * on this backfill having run ("every live conference has an `organization`").
- * That precondition is satisfied. If you are considering reverting this data,
- * read that deny rule first.
+ * That precondition is satisfied, and was re-verified against production on
+ * 2026-08-05: ZERO non-draft `conference`, `speaker`, `topic`, `sponsor`,
+ * `staff` or `message` documents lack the organization key, and the single
+ * bootstrap org `organization-cloud-native-days` exists. If you are considering
+ * reverting this data, read that deny rule first — it fails CLOSED on it.
  *
  * Do NOT re-run against `production` as a matter of course. It is idempotent
  * (docs already carrying the key are skipped, the org is created via

--- a/migrations/044-organization-tier-backfill/index.ts
+++ b/migrations/044-organization-tier-backfill/index.ts
@@ -8,7 +8,17 @@ import {
 import type { SanityDocument } from '@sanity/types'
 
 /**
- * ⚠️ MIGRATION NOT RUN — MAINTAINER DECISION REQUIRED. ⚠️
+ * ✅ RUN IN PRODUCTION — 2026-07-26 (GitHub Actions run 30198714455).
+ *
+ * LOAD-BEARING FOR AUTHORIZATION. `src/lib/authz/organizer.ts` denies when a
+ * request's organization is unresolvable, and justifies that fail-closed posture
+ * on this backfill having run ("every live conference has an `organization`").
+ * That precondition is satisfied. If you are considering reverting this data,
+ * read that deny rule first.
+ *
+ * Do NOT re-run against `production` as a matter of course. It is idempotent
+ * (docs already carrying the key are skipped, the org is created via
+ * `createIfNotExists`), but a re-run is still an unnecessary production write.
  *
  * Bootstrap the MULTI-TENANT organization tier (CaaS T1-1, #613): create the
  * single `organization` (tenant) document and stamp its reference onto every
@@ -43,10 +53,12 @@ import type { SanityDocument } from '@sanity/types'
  * receives the SAME organization ref. Multi-tenant partitioning (distinct orgs)
  * is a later concern; this migration only establishes the key exists everywhere.
  *
- * NOT RUN: run intentionally, after review, via the "Run Sanity Migration"
- * workflow (.github/workflows/run-migration.yml) with migration id
- * `044-organization-tier-backfill`, dataset `production`. The workflow exports a
- * dataset backup and performs a dry run first.
+ * HOW IT WAS RUN, and how to run it against ANOTHER dataset: intentionally,
+ * after review, via the "Run Sanity Migration" workflow
+ * (.github/workflows/run-migration.yml) with migration id
+ * `044-organization-tier-backfill`. The workflow exports a dataset backup and
+ * performs a dry run first. `production` has already had this applied (see
+ * above).
  */
 
 /** Deterministic id for the single bootstrap organization. */
@@ -108,8 +120,9 @@ export default defineMigration({
     'reference onto every conference, speaker (as organizations[]), topic, ' +
     'staff, sponsor, sponsorEmailTemplate, message, travelExpense, ' +
     'sponsorActivity and conversationPreference lacking one. Additive and ' +
-    'idempotent (skips docs already carrying the key, skips drafts). NOT RUN by ' +
-    'default — run via the Run Sanity Migration workflow after maintainer review.',
+    'idempotent (skips docs already carrying the key, skips drafts). APPLIED to ' +
+    'production on 2026-07-26 — run against another dataset via the Run Sanity ' +
+    'Migration workflow after maintainer review.',
   documentTypes: [
     'conference',
     'speaker',

--- a/migrations/045-conference-visibility-backfill/index.ts
+++ b/migrations/045-conference-visibility-backfill/index.ts
@@ -4,6 +4,13 @@ import type { SanityDocument } from '@sanity/types'
 /**
  * ⚠️ MIGRATION NOT RUN — MAINTAINER DECISION REQUIRED. ⚠️
  *
+ * VERIFIED NOT RUN, two ways, on 2026-08-05: it appears in NONE of the "Run
+ * Sanity Migration" workflow's dispatches, AND its effect is absent from the
+ * data — all 3 non-draft conference documents still lack `visibility`
+ * (`count(*[_type=="conference" && !(_id in path("drafts.**")) &&
+ * !defined(visibility)])` returns 3 of 3). This banner is accurate; unlike its
+ * neighbours 041/043/044/046/047, it has not gone stale.
+ *
  * Stamp `visibility: 'live'` onto every EXISTING conference that lacks the field
  * (M0 trial groundwork, conference visibility state).
  *

--- a/migrations/046-conference-identity-backfill/index.ts
+++ b/migrations/046-conference-identity-backfill/index.ts
@@ -12,6 +12,13 @@ import {
 /**
  * ✅ RUN IN PRODUCTION — 2026-08-04 (GitHub Actions run 30882197078).
  *
+ * Verified by EFFECT against production on 2026-08-05: all 3 conference
+ * documents carry `theme` = {primaryColor #1D4ED8, accentColor #06B6D4},
+ * `backgroundPattern` = 'cloud-native', a defined `logoBright` +
+ * `logomarkBright`, and a populated `sponsorshipCustomization` (CND Norway 2026
+ * retains its own distinct prospectus wording plus `prospectusUrl`, consistent
+ * with this migration merging UNDER stored values rather than overwriting).
+ *
  * Do NOT re-run against `production` as a matter of course. It is idempotent
  * (every write is conditional on the field being absent), but a re-run is still
  * an unnecessary production write. See README.md.

--- a/migrations/046-conference-identity-backfill/index.ts
+++ b/migrations/046-conference-identity-backfill/index.ts
@@ -10,7 +10,11 @@ import {
 } from './plan'
 
 /**
- * ⚠️ MIGRATION NOT RUN — MAINTAINER DECISION REQUIRED. ⚠️
+ * ✅ RUN IN PRODUCTION — 2026-08-04 (GitHub Actions run 30882197078).
+ *
+ * Do NOT re-run against `production` as a matter of course. It is idempotent
+ * (every write is conditional on the field being absent), but a re-run is still
+ * an unnecessary production write. See README.md.
  *
  * Make the three EXISTING Cloud Native Days editions' visual identity EXPLICIT
  * DATA on their own conference documents, before the platform's hardcoded
@@ -51,11 +55,13 @@ import {
  * more than one conference the migration ABORTS before yielding a single patch,
  * rather than patching whatever it happened to find.
  *
- * NOT RUN: run intentionally, after review, via the "Run Sanity Migration"
- * workflow (.github/workflows/run-migration.yml) with migration id
- * `046-conference-identity-backfill`, dataset `production`. The workflow exports
- * a dataset backup and performs a dry run first — read the dry-run log, which
- * prints every field it would set and every manual follow-up it detected.
+ * HOW IT WAS RUN, and how to run it against ANOTHER dataset: intentionally,
+ * after review, via the "Run Sanity Migration" workflow
+ * (.github/workflows/run-migration.yml) with migration id
+ * `046-conference-identity-backfill`. The workflow exports a dataset backup and
+ * performs a dry run first — read the dry-run log, which prints every field it
+ * would set and every manual follow-up it detected. `production` has already
+ * had this applied (see above).
  */
 
 const isDraft = (id: string): boolean => id.startsWith('drafts.')
@@ -78,8 +84,8 @@ export default defineMigration({
     'when the defaults are neutralised toward Konf. Additive and idempotent ' +
     '(never overwrites a stored value, skips drafts). Targets are matched by ' +
     'routing domain and the migration aborts if any target is missing or ' +
-    'ambiguous. NOT RUN by default — run via the Run Sanity Migration workflow ' +
-    'after maintainer review.',
+    'ambiguous. APPLIED to production on 2026-08-04 — run against another ' +
+    'dataset via the Run Sanity Migration workflow after maintainer review.',
   documentTypes: ['conference'],
 
   async *migrate(documents, context) {

--- a/migrations/047-tenant-defaults-backfill/index.ts
+++ b/migrations/047-tenant-defaults-backfill/index.ts
@@ -12,6 +12,13 @@ import {
 /**
  * ✅ RUN IN PRODUCTION — 2026-08-04 (GitHub Actions run 30885965431).
  *
+ * Verified by EFFECT against production on 2026-08-05: all 3 conference
+ * documents carry `analyticsPirschCode`, `venueTravelInfo`, `speakerDinnerInfo`
+ * and `localRecommendations`; `socialHashtag` = '#cndb2025' is present on Bergen
+ * 2025 and on NEITHER of the other two — exactly the Bergen-2025-only targeting
+ * described below, which is what makes this a verification rather than a
+ * coincidence.
+ *
  * Do NOT re-run against `production` as a matter of course. It is idempotent
  * (every write is conditional on the field being absent), but a re-run is still
  * an unnecessary production write. See README.md.

--- a/migrations/047-tenant-defaults-backfill/index.ts
+++ b/migrations/047-tenant-defaults-backfill/index.ts
@@ -10,7 +10,11 @@ import {
 } from './plan'
 
 /**
- * ⚠️ MIGRATION NOT RUN — MAINTAINER DECISION REQUIRED. ⚠️
+ * ✅ RUN IN PRODUCTION — 2026-08-04 (GitHub Actions run 30885965431).
+ *
+ * Do NOT re-run against `production` as a matter of course. It is idempotent
+ * (every write is conditional on the field being absent), but a re-run is still
+ * an unnecessary production write. See README.md.
  *
  * Companion to 046. Where 046 pinned the three Cloud Native Days editions'
  * VISUAL identity, this one pins the remaining values that were hardcoded in
@@ -45,13 +49,16 @@ import {
  * conference.
  *
  * ORDERING: independent of 046 (disjoint fields), so it may run before or
- * after it. BOTH must be applied before the neutralisation PR is deployed.
+ * after it. BOTH had to be applied before the neutralisation PR was deployed;
+ * both were, on 2026-08-04 (046 = run 30882197078, this one = run 30885965431).
  *
- * NOT RUN: run intentionally, after review, via the "Run Sanity Migration"
- * workflow (.github/workflows/run-migration.yml) with migration id
- * `047-tenant-defaults-backfill`, dataset `production`. The workflow exports a
- * dataset backup and performs a dry run first — read the dry-run log, which
- * prints every field it would set and every manual follow-up it detected.
+ * HOW IT WAS RUN, and how to run it against ANOTHER dataset: intentionally,
+ * after review, via the "Run Sanity Migration" workflow
+ * (.github/workflows/run-migration.yml) with migration id
+ * `047-tenant-defaults-backfill`. The workflow exports a dataset backup and
+ * performs a dry run first — read the dry-run log, which prints every field it
+ * would set and every manual follow-up it detected. `production` has already
+ * had this applied (see above).
  */
 
 const isDraft = (id: string): boolean => id.startsWith('drafts.')
@@ -68,8 +75,9 @@ export default defineMigration({
     'documents, so those sites are unchanged once the code defaults become ' +
     'neutral. Additive and idempotent (never overwrites a stored value, skips ' +
     'drafts); aborts if any target is missing or ambiguous. Companion to 046 — ' +
-    'both must be applied before the neutralisation PR is deployed. NOT RUN by ' +
-    'default — run via the Run Sanity Migration workflow after maintainer review.',
+    'both were applied to production on 2026-08-04, ahead of the neutralisation ' +
+    'deploy. Run against another dataset via the Run Sanity Migration workflow ' +
+    'after maintainer review.',
   documentTypes: ['conference'],
 
   async *migrate(documents, context) {


### PR DESCRIPTION
## The problem

Five migration modules carried a `⚠️ MIGRATION NOT RUN — MAINTAINER DECISION REQUIRED ⚠️` banner in `index.ts` while having actually been applied to production. The module header is the file a runner opens first, so the banner is the claim that gets believed. A maintainer acting on a false "not run" either re-runs a production migration or executes instructions premised on a state that has already changed.

## How run state was established — two independent methods

**1. Workflow-run evidence.** The `Run Sanity Migration` workflow dispatch history is **complete — 13 runs ever** — and the job name is `Migrate ${{ inputs.dataset }}: ${{ inputs.migration }}`, so each run names its migration. For each I opened the log and confirmed it reached the **apply** step (`--no-dry-run --no-confirm`) and emitted real mutations — not merely the preceding dry-run step, which is separate and would look identical in a step-name listing.

**2. Verify by effect.** Production **is** queryable from this repo — `pnpm sanity documents query '<groq>'` authenticates from the Sanity CLI's own login, with no token and no `.env`. Recorded here because I initially got this wrong: an unauthenticated HTTP query returning `count(*) == 0` reads as "no data" but actually means "not authorised", and I wrongly took it as proof of no access. **If you are checking a migration's state, use the CLI — do not repeat that dead end.**

Effect agreed with the logs in all six cases, so no verdict changed.

| Migration | Verdict | Workflow evidence | Effect evidence (queried 2026-08-05) |
|---|---|---|---|
| 041 | **RUN** 2026-07-19 | run [29679682997](https://github.com/CloudNativeBergen/website/actions/runs/29679682997) — 24 docs, 24 mutations, 1 transaction | **0** strong refs predating the run survive — but see the finding below |
| 043 | **RUN** 2026-07-19 | run [29702487495](https://github.com/CloudNativeBergen/website/actions/runs/29702487495) — `writing 3 participant(s)` | **0 of 8** conversations lack `participants[]`; **0 of 15** messages lack `authorParty` (this directory's own README queries) |
| 044 | **RUN** 2026-07-26 | run [30198714455](https://github.com/CloudNativeBergen/website/actions/runs/30198714455) — org derived from 4 conferences | **0** docs lack the org key across `conference`/`speaker`/`topic`/`sponsor`/`staff`/`message`; `organization-cloud-native-days` exists |
| 045 | **NOT RUN** | appears in **none** of the 13 dispatches | **3 of 3** conferences still lack `visibility` |
| 046 | **RUN** 2026-08-04 | run [30882197078](https://github.com/CloudNativeBergen/website/actions/runs/30882197078) — `✓ set theme` | all 3 carry `theme` = {#1D4ED8, #06B6D4}, `backgroundPattern` = `cloud-native`, `logoBright`/`logomarkBright`, populated `sponsorshipCustomization` |
| 047 | **RUN** 2026-08-04 | run [30885965431](https://github.com/CloudNativeBergen/website/actions/runs/30885965431) — `✓ set analyticsPirschCode` | all 3 carry the analytics + three `/info` fields; `socialHashtag` = `#cndb2025` on Bergen 2025 and **neither** other edition — the documented Bergen-2025-only targeting, which is what makes this verification rather than coincidence |

A cancelled run [30885941308](https://github.com/CloudNativeBergen/website/actions/runs/30885941308) was dispatched against a mistyped id (`047-tenant-neutral-backfill`) and never reached apply.

### 045 is now settled positively

Previously this rested on absence from the workflow history — which rules out the sanctioned path but not someone running `sanity migration run` from a laptop. Its effect is directly observable and is **absent**: all three conferences still lack `visibility`. So 045 genuinely has not run, by two independent methods. **Its banner is unchanged**; it now also records the evidence, so the next reader does not have to redo this.

## 🚨 The most important finding: 041's trap has reopened

041's own effect held — **no** strong ref predating the 2026-07-19 run survives. But production today holds **802 new strong speaker references, across 428 documents**, on the very fields it weakened — every one created *after* the run (oldest 2026-07-19T17:47Z, nine hours later; newest 2026-08-05):

| Field | Strong refs today | Created before the run |
| --- | ---: | ---: |
| `notification.recipient` | 408 | 0 |
| `notification.actor` | 373 | 0 |
| `message.author` | 13 | 0 |
| `conversation.createdBy` | 7 | 0 |
| `conversation.subjectSpeaker` | 1 | 0 |

The two units reconcile exactly, and the docs now label which is which: 408 + 13 + 7 = **428 documents** hold 408 + 373 + 13 + 7 + 1 = **802 references**. The 374-reference difference is documents holding two strong refs at once — **measured**, not derived:

| Overlap | Count |
|---|---:|
| notifications with strong `recipient` **and** `actor` | 373 |
| conversations with strong `createdBy` **and** `subjectSpeaker` | 1 |
| messages (document and reference counts both 13) | 0 |

373 + 1 = 374, and 802 − 428 = 374.

Two revisions of this PR got this wrong in the same way — first annotating the document-count query with the reference total, then claiming the 373 notifications were "the whole of the gap" when 802 − 428 = 374. Both were derived rather than measured, and both were caught in review. The overlap is now **query (c)** in the README, printed with its output, so the reconciliation is re-runnable rather than asserted. I also swept both files for any remaining sentence asserting a *relationship* between numbers rather than reporting a measurement — that pattern produced both defects.

**Cause.** Schema `weak: true` governs Studio writes and validation, **not** API writes. `createReference()` (`src/lib/sanity/helpers.ts:68`) returns `{ _type: 'reference', _ref }` with no `_weak`. In `src/lib/notification/sanity.ts` the *same object literal* sets `relatedProposal` weak with a comment explaining why (L89-92), while `recipient` (L72) and `actor` (L85) — the two speaker refs 041 exists to weaken — are left strong.

So 041's stated premise, *"marking the fields `weak` in the schema fixes it going FORWARD"*, is **false**, and the GDPR erasure trap it was written to clear is open again: a speaker who has received a notification since 2026-07-19 cannot currently be deleted.

Sample newest row, unedited: `recipient: { "_ref": "1b0a8a72-…", "_type": "reference" }` — no `_weak`.

**This PR does not fix it** — the fix belongs at the write path and is code, not docs. What this PR does is stop the docs from claiming the problem is solved: the header, the Overview and the Verification block all said so, and all three now state the measured position, including that a **non-zero verification result is expected today and is not a failed apply**. Worth filing as its own issue; happy to do that on request.

While verifying, I also tested 041's README claim that `conversation.assignedTo` "has never had strong refs" — it holds (1 stored ref, weak; `src/lib/messaging/sanity.ts:1518` writes `{ ...createReference(id), _weak: true }`, which is the correct pattern the notification path is missing).

## What changed

Docs and metadata strings only — **no migration logic touched**. Each affected module repeated its false claim in three or four places, so fixing only the header would have left the file self-contradicting:

- module header comment
- the how-to-run note further down
- the `description` string inside `defineMigration({…})`
- plus, in 043, an ordering sentence

Corrected headers state the date, the run id, and the effect check, and say plainly not to re-run against `production` while keeping the run instructions valid for other datasets.

### 043 — where both sides agreed and both were wrong

043's `index.ts` **and** its README both said NOT RUN; it had run on 2026-07-19. Two further statements had gone stale:

1. The README instructed running it *before the G2 read-path flip* — the flip has shipped (`src/lib/messaging/sanity.ts`). Now marked historical rather than work still owed.
2. The **Rollback** section called the backfilled fields *"inert until G2"*. They are not — `participants[]` is now the preferred read for `canAccessConversation` / `resolveParticipantIds`, so rolling back today changes a live authorization read path rather than being a no-op.

### 044 — the codebase already contradicted the banner

`src/lib/authz/organizer.ts:19-21` bases a fail-closed deny on this backfill having run. Verified true, and now re-verified by query. Its header records that the deny rule depends on this data.

## Scope check — no other migration diverges

Swept all 47 migration directories (no `029-*`; `036` exists as two dirs). Only 041–047 make any run-state claim; the other 41 describe how to run and their idempotency without asserting whether they have run. Near-misses cleared: 040/042 say "one-shot" (design intent, not execution state); `006` references 004/005 as prerequisites (a claim about other migrations). 044 and 045 have no README.

## Suggested mechanical fix — proposed, not built here

The recurring failure is that the README is updated when a migration is run and the `index.ts` banners are not (`92c457a6` / #827 updated only the READMEs for 046/047). Cheapest first:

1. **Single source of truth** — a per-directory `status.json` (`{ runs: [{ dataset, date, workflowRunId }] }`) with the README section generated from it and the header reduced to a pointer.
2. **A test asserting the two agree.** Cheap, but 043 proves it is insufficient alone: both sides agreed and both were wrong.
3. **Close the loop at the source** — have the workflow itself record the run id into the migration directory on a successful apply, so the record is written by the thing that did the work.

Only (1) and (3) attack the cause. This PR adds a fourth consideration: **agreement between two docs is not evidence, and neither is a successful apply** — 041 applied cleanly and is wrong today anyway. Only the data settled it, and now that verify-by-effect is known to be one CLI command away, it is cheap enough to be the default.

### A usability trap fixed along the way

The Sanity CLI treats a count of **0** as an error — `Error: Failed to run query: Query returned no results`, exit 1. So the verification queries in 041 and 043 would look broken at exactly the moment they report success, which is the state the docs promise after an apply. Each count is now wrapped in an object, which prints `{"field": 0}` instead; 043's returns two clean zeros.

## Checks

`tsc --noEmit` clean, `eslint migrations/` clean, `prettier --check migrations/` clean. All queries run were **read-only**; nothing was written to production. All four documented queries were executed verbatim — extracted programmatically from the committed files rather than retyped — and each returned exactly the number recorded next to it (`documents: 428`; `408/373/13/7/1`; `notificationBoth: 373, conversationBoth: 1`; 043's two zeros).


