### PR TITLE
fix(gdpr): write speaker references weak so erasure is not blocked (#851)

### DIFF
--- a/__tests__/lib/messaging/party-model.test.ts
+++ b/__tests__/lib/messaging/party-model.test.ts
@@ -45,6 +45,7 @@ import {
   resolveRecipients,
   canAccessConversation,
   ensureProposalConversation,
+  ensureSponsorConversation,
   createGeneralConversation,
   addMessage,
   syncProposalConversationParticipants,
@@ -402,7 +403,11 @@ describe('dual-write — ensureProposalConversation writes participants[] alongs
 
     const doc = tx.createIfNotExists.mock.calls[0][0] as Record<string, unknown>
     // Legacy write-source fields are UNCHANGED (still present).
-    expect(doc.createdBy).toEqual({ _type: 'reference', _ref: 'sp-1' })
+    expect(doc.createdBy).toEqual({
+      _type: 'reference',
+      _ref: 'sp-1',
+      _weak: true,
+    })
     expect(doc.proposal).toEqual({
       _type: 'reference',
       _ref: 'prop-1',
@@ -439,7 +444,11 @@ describe('dual-write — createGeneralConversation', () => {
     })
     const doc = writeMock.create.mock.calls[0][0] as Record<string, unknown>
     // Legacy fields unchanged: creator ref present, no subjectSpeaker.
-    expect(doc.createdBy).toEqual({ _type: 'reference', _ref: 'sp-9' })
+    expect(doc.createdBy).toEqual({
+      _type: 'reference',
+      _ref: 'sp-9',
+      _weak: true,
+    })
     expect('subjectSpeaker' in doc).toBe(false)
     expect(doc.participants).toEqual([
       storedSpeaker('sp-9'),
@@ -455,7 +464,11 @@ describe('dual-write — createGeneralConversation', () => {
       subjectSpeakerId: 'sp-7',
     })
     const doc = writeMock.create.mock.calls[0][0] as Record<string, unknown>
-    expect(doc.subjectSpeaker).toEqual({ _type: 'reference', _ref: 'sp-7' })
+    expect(doc.subjectSpeaker).toEqual({
+      _type: 'reference',
+      _ref: 'sp-7',
+      _weak: true,
+    })
     expect(doc.participants).toEqual([
       storedSpeaker('org-1'),
       storedSpeaker('sp-7'),
@@ -475,8 +488,12 @@ describe('dual-write — addMessage writes authorParty alongside the author ref'
     })
 
     const doc = tx.create.mock.calls[0][0] as Record<string, unknown>
-    // Legacy author ref unchanged.
-    expect(doc.author).toEqual({ _type: 'reference', _ref: 'sp-9' })
+    // Legacy author ref — WEAK, like the party form beside it (#851).
+    expect(doc.author).toEqual({
+      _type: 'reference',
+      _ref: 'sp-9',
+      _weak: true,
+    })
     // Dual-written party form of the author.
     expect(doc.authorParty).toEqual({
       partyType: 'speaker',
@@ -484,6 +501,84 @@ describe('dual-write — addMessage writes authorParty alongside the author ref'
     })
     // A single-object field carries NO _key (only array items do).
     expect('_key' in (doc.authorParty as object)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2b. GDPR erasure — every persisted speaker ref must be WEAK (#851)
+// ---------------------------------------------------------------------------
+
+/**
+ * The legacy speaker refs on `conversation` and `message` are exactly the fields
+ * migration 041 weakens in the dataset. They must be written weak too, or the
+ * migration only ever clears a backlog that the next write refills.
+ *
+ * These assert the DOCUMENT HANDED TO THE CLIENT, not a helper's return value.
+ */
+describe('GDPR erasure (#851) — conversation/message speaker refs are WEAK', () => {
+  const weak = (id: string) => ({ _type: 'reference', _ref: id, _weak: true })
+
+  it('ensureProposalConversation: createdBy is weak (conference stays strong)', async () => {
+    const tx = installTransaction()
+    await ensureProposalConversation({
+      conferenceId: 'conf-1',
+      proposalId: 'prop-1',
+      proposalTitle: 'My Talk',
+      createdById: 'sp-erase',
+      proposalSpeakerIds: ['sp-erase'],
+    })
+    const doc = tx.createIfNotExists.mock.calls[0][0] as Record<string, unknown>
+    expect(doc.createdBy).toEqual(weak('sp-erase'))
+    expect(doc.conference).toEqual({ _type: 'reference', _ref: 'conf-1' })
+  })
+
+  it('createGeneralConversation: createdBy AND subjectSpeaker are weak', async () => {
+    await createGeneralConversation({
+      conferenceId: 'conf-1',
+      createdById: 'org-erase',
+      subject: 'About your talk',
+      subjectSpeakerId: 'sp-erase',
+    })
+    const doc = writeMock.create.mock.calls[0][0] as Record<string, unknown>
+    expect(doc.createdBy).toEqual(weak('org-erase'))
+    expect(doc.subjectSpeaker).toEqual(weak('sp-erase'))
+  })
+
+  // This path had NO test at all before #851 — the sabotage run proved it: the
+  // sponsor thread's `createdBy` could be reverted to a strong ref with the full
+  // suite still green.
+  it('ensureSponsorConversation: an organizer-initiated thread writes createdBy weak', async () => {
+    const tx = installTransaction()
+    await ensureSponsorConversation({
+      conferenceId: 'conf-1',
+      sponsorForConferenceId: 'sfc-1',
+      sponsorName: 'Acme',
+      createdById: 'org-erase',
+    })
+    const doc = tx.createIfNotExists.mock.calls[0][0] as Record<string, unknown>
+    expect(doc.createdBy).toEqual(weak('org-erase'))
+  })
+
+  it('ensureSponsorConversation: a portal-initiated thread omits createdBy entirely', async () => {
+    const tx = installTransaction()
+    await ensureSponsorConversation({
+      conferenceId: 'conf-1',
+      sponsorForConferenceId: 'sfc-2',
+      sponsorName: 'Acme',
+    })
+    const doc = tx.createIfNotExists.mock.calls[0][0] as Record<string, unknown>
+    expect('createdBy' in doc).toBe(false)
+  })
+
+  it('addMessage: author is weak — a strong one makes every speaker who ever sent a message undeletable', async () => {
+    const tx = installTransaction()
+    await addMessage({
+      conversationId: 'conversation.gen-1',
+      authorId: 'sp-erase',
+      body: 'hello',
+    })
+    const doc = tx.create.mock.calls[0][0] as Record<string, unknown>
+    expect(doc.author).toEqual(weak('sp-erase'))
   })
 })
 

--- a/__tests__/lib/messaging/sanity.test.ts
+++ b/__tests__/lib/messaging/sanity.test.ts
@@ -238,7 +238,11 @@ describe('addMessage — single transaction (create + lastMessageAt bump)', () =
       _type: 'reference',
       _ref: 'conversation.gen-1',
     })
-    expect(doc.author).toEqual({ _type: 'reference', _ref: 'sp-9' })
+    expect(doc.author).toEqual({
+      _type: 'reference',
+      _ref: 'sp-9',
+      _weak: true,
+    })
     expect(doc.body).toBe('hello')
 
     // The returned message mirrors what was written (same createdAt used for the bump).
@@ -317,7 +321,11 @@ describe('createGeneralConversation', () => {
       subjectSpeakerId: 'sp-7',
     })
     const doc = writeMock.create.mock.calls[0][0] as Record<string, unknown>
-    expect(doc.subjectSpeaker).toEqual({ _type: 'reference', _ref: 'sp-7' })
+    expect(doc.subjectSpeaker).toEqual({
+      _type: 'reference',
+      _ref: 'sp-7',
+      _weak: true,
+    })
   })
 })
 

--- a/__tests__/lib/notification/sanity.test.ts
+++ b/__tests__/lib/notification/sanity.test.ts
@@ -129,7 +129,11 @@ describe('createNotifications — single-transaction fan-out', () => {
 
     const doc = tx.create.mock.calls[0][0] as Record<string, unknown>
     expect(doc._type).toBe('notification')
-    expect(doc.recipient).toEqual({ _type: 'reference', _ref: 'sp-1' })
+    expect(doc.recipient).toEqual({
+      _type: 'reference',
+      _ref: 'sp-1',
+      _weak: true,
+    })
     expect(doc.conference).toEqual({ _type: 'reference', _ref: 'conf-1' })
     expect(typeof doc.createdAt).toBe('string')
   })
@@ -164,7 +168,11 @@ describe('createNotifications — single-transaction fan-out', () => {
     ])
 
     const doc = tx.create.mock.calls[0][0] as Record<string, unknown>
-    expect(doc.actor).toEqual({ _type: 'reference', _ref: 'actor-1' })
+    expect(doc.actor).toEqual({
+      _type: 'reference',
+      _ref: 'actor-1',
+      _weak: true,
+    })
     expect(doc.relatedProposal).toEqual({
       _type: 'reference',
       _ref: 'prop-1',
@@ -193,6 +201,102 @@ describe('createNotifications — single-transaction fan-out', () => {
     // a caller can distinguish a silent failure from a success.
     await expect(createNotifications([input()])).resolves.toBe(0)
     expect(console.error).toHaveBeenCalled()
+  })
+})
+
+/**
+ * GDPR ERASURE (#851). Every `speaker` reference a notification write persists
+ * must be WEAK, or Sanity refuses to delete that speaker document.
+ *
+ * These assert the SHAPE OF THE DOCUMENT HANDED TO THE TRANSACTION — not a
+ * helper's return value — because that is the only thing that reaches the API.
+ * `weak: true` in `sanity/schemaTypes/notification.ts` constrains Studio writes
+ * and validation ONLY; an API write is strong unless the stored ref object
+ * itself carries `_weak: true`. Nothing asserted this before, which is how a
+ * fix that migration 041 had already applied in the dataset silently re-armed
+ * in code and put 408 undeletable speaker refs back into production.
+ *
+ * `conference` is deliberately NOT weak: conferences are not erasure subjects
+ * and referential integrity there is wanted.
+ */
+describe('notification writes: speaker refs must be WEAK (GDPR erasure, #851)', () => {
+  const weakRef = (id: string) => ({
+    _type: 'reference',
+    _ref: id,
+    _weak: true,
+  })
+
+  it('createNotifications: recipient and actor are weak in the created doc', async () => {
+    const tx = installTransaction()
+
+    await createNotifications([
+      input({ recipientId: 'speaker-erasable', actorId: 'actor-erasable' }),
+    ])
+
+    const doc = tx.create.mock.calls[0][0] as Record<string, unknown>
+    expect(doc.recipient).toEqual(weakRef('speaker-erasable'))
+    expect(doc.actor).toEqual(weakRef('actor-erasable'))
+    // The non-speaker ref stays STRONG on purpose.
+    expect(doc.conference).toEqual({ _type: 'reference', _ref: 'conf-1' })
+  })
+
+  it('upsertMessageNotifications: recipient is weak on the seeded document', async () => {
+    readMock.fetch.mockResolvedValue([])
+    const tx = installTransaction()
+
+    await upsertMessageNotifications([msgInput({ recipientId: 'sp-erase' })])
+
+    const base = tx.createIfNotExists.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >
+    expect(base.recipient).toEqual(weakRef('sp-erase'))
+  })
+
+  it('upsertMessageNotifications: actor is weak in the patch `set` — a strong value here would RE-STRENGTHEN an already-weakened document', async () => {
+    readMock.fetch.mockResolvedValue([])
+    const tx = installTransaction()
+
+    await upsertMessageNotifications([msgInput({ actorId: 'actor-erase' })])
+
+    const [, ops] = tx.patch.mock.calls[0] as [
+      string,
+      { set: Record<string, unknown> },
+    ]
+    expect(ops.set.actor).toEqual(weakRef('actor-erase'))
+  })
+
+  it('no notification write path emits a strong speaker ref (guards every create/patch made)', async () => {
+    readMock.fetch.mockResolvedValue([])
+    const tx = installTransaction()
+
+    await createNotifications([input({ actorId: 'a-1' })])
+    await upsertMessageNotifications([msgInput()])
+
+    // Every ref object written to a speaker-typed field, across every
+    // create / createIfNotExists / patch-set this module made.
+    const written: Array<Record<string, unknown>> = [
+      ...tx.create.mock.calls.map((c) => c[0]),
+      ...tx.createIfNotExists.mock.calls.map((c) => c[0]),
+      ...tx.patch.mock.calls.map(
+        (c) => (c[1] as { set?: Record<string, unknown> })?.set,
+      ),
+    ].filter(Boolean) as Array<Record<string, unknown>>
+
+    expect(written.length).toBeGreaterThan(0)
+
+    const SPEAKER_FIELDS = ['recipient', 'actor'] as const
+    const strong: string[] = []
+    for (const doc of written) {
+      for (const field of SPEAKER_FIELDS) {
+        const value = doc[field] as
+          { _ref?: string; _weak?: boolean } | undefined
+        if (value?._ref && value._weak !== true) {
+          strong.push(`${field} -> ${value._ref}`)
+        }
+      }
+    }
+    expect(strong).toEqual([])
   })
 })
 
@@ -242,7 +346,11 @@ describe('upsertMessageNotifications — per-conversation collapse (M5)', () => 
     expect(base._type).toBe('notification')
     expect(base.notificationType).toBe('message_received')
     expect(base.count).toBe(1)
-    expect(base.recipient).toEqual({ _type: 'reference', _ref: 'sp-1' })
+    expect(base.recipient).toEqual({
+      _type: 'reference',
+      _ref: 'sp-1',
+      _weak: true,
+    })
     expect(base.conference).toEqual({ _type: 'reference', _ref: 'conf-1' })
 
     expect(tx.patch).toHaveBeenCalledTimes(1)
@@ -256,7 +364,11 @@ describe('upsertMessageNotifications — per-conversation collapse (M5)', () => 
     expect(ops.set.title).toBe('New message from Alice — A question')
     expect(ops.set.message).toBe('hey there')
     expect(ops.set.link).toBe('/cfp/messages/conversation.gen-1')
-    expect(ops.set.actor).toEqual({ _type: 'reference', _ref: 'actor-1' })
+    expect(ops.set.actor).toEqual({
+      _type: 'reference',
+      _ref: 'actor-1',
+      _weak: true,
+    })
     expect(typeof ops.set.createdAt).toBe('string')
     expect(tx.commit).toHaveBeenCalledTimes(1)
   })

--- a/__tests__/lib/sanity/weak-references.test.ts
+++ b/__tests__/lib/sanity/weak-references.test.ts
@@ -1,0 +1,248 @@
+/**
+ * @vitest-environment node
+ *
+ * REPO-WIDE INVARIANT (#851): a schema field declared `weak: true` must be
+ * written weak by the API too.
+ *
+ * WHY THIS EXISTS. `weak: true` in a `sanity/schemaTypes/*.ts` field definition
+ * governs Sanity STUDIO writes and validation. It does NOT govern writes made
+ * through the client API: reference strength is a property of the STORED ref
+ * object (`_weak: true`), so `createReference(id)` — which emits only
+ * `{ _type, _ref }` — produces a STRONG reference no matter what the schema
+ * says. A strong reference blocks deletion of its target, so a strong ref to a
+ * `speaker` makes that speaker undeletable and defeats GDPR erasure.
+ *
+ * That gap is not hypothetical. Migration 041 weakened these exact fields in the
+ * dataset and passed its own verification, while the code kept writing strong
+ * refs — production had accumulated 408 strong `notification.recipient` and 373
+ * strong `notification.actor` refs by the time #851 was filed. Nothing in the
+ * suite asserted the shape of what gets written, so the schema and the writer
+ * were free to disagree indefinitely.
+ *
+ * WHAT THIS CHECKS. It parses the schema files for every `(documentType, field)`
+ * pair declared `weak: true`, then parses every non-test source file under
+ * `src/` and flags any object literal that both
+ *   (a) self-identifies via `_type: '<documentType>'`, and
+ *   (b) assigns one of that type's weak fields a reference value that is
+ *       demonstrably strong — a bare `createReference(...)` call, or a literal
+ *       `{ _type: 'reference', _ref: ... }` with no `_weak: true`.
+ *
+ * WHAT IT DOES NOT CHECK — read this before trusting a green run:
+ *  - `.patch(id).set({ field: ... })` carries no `_type`, so a patch that
+ *    re-strengthens an existing document is INVISIBLE here. Those paths are
+ *    covered behaviourally instead (see the notification suite, which asserts
+ *    the `set` payload of the message-collapse upsert).
+ *  - A ref built indirectly (a variable, a helper, a spread from elsewhere) is
+ *    not resolved and is left alone rather than guessed at.
+ * It is a floor, not a proof: it catches the literal shape that caused #851 and
+ * every future copy of it, and it cannot catch reference strength in general.
+ */
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import ts from 'typescript'
+
+const REPO_ROOT = join(__dirname, '..', '..', '..')
+const SCHEMA_DIR = join(REPO_ROOT, 'sanity', 'schemaTypes')
+const SRC_DIR = join(REPO_ROOT, 'src')
+
+function parse(file: string): ts.SourceFile {
+  return ts.createSourceFile(
+    file,
+    readFileSync(file, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  )
+}
+
+function walk(node: ts.Node, visit: (n: ts.Node) => void): void {
+  visit(node)
+  node.forEachChild((child) => walk(child, visit))
+}
+
+/** The string value of `prop: 'literal'`, or undefined for anything else. */
+function stringProp(
+  obj: ts.ObjectLiteralExpression,
+  name: string,
+): string | undefined {
+  for (const prop of obj.properties) {
+    if (!ts.isPropertyAssignment(prop)) continue
+    if (prop.name.getText() !== name) continue
+    const init = prop.initializer
+    if (ts.isStringLiteral(init) || ts.isNoSubstitutionTemplateLiteral(init)) {
+      return init.text
+    }
+  }
+  return undefined
+}
+
+function hasTrueProp(obj: ts.ObjectLiteralExpression, name: string): boolean {
+  return obj.properties.some(
+    (prop) =>
+      ts.isPropertyAssignment(prop) &&
+      prop.name.getText() === name &&
+      prop.initializer.kind === ts.SyntaxKind.TrueKeyword,
+  )
+}
+
+function tsFilesUnder(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue
+      out.push(...tsFilesUnder(full))
+    } else if (
+      /\.tsx?$/.test(entry.name) &&
+      !/\.(test|spec)\.tsx?$/.test(entry.name) &&
+      !/\.stories\.tsx?$/.test(entry.name)
+    ) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+/**
+ * `{ documentType -> Set<weak field name> }`, read from the schema sources.
+ *
+ * A `defineType({ name: 'x', type: 'document', fields: [...] })` contributes its
+ * top-level `defineField({ name: 'f', type: 'reference', weak: true })` names.
+ * Nested object types (e.g. `conversationParticipant`) are keyed under their own
+ * type name; they are only checked where a literal declares that `_type`.
+ */
+function collectWeakFields(): Map<string, Set<string>> {
+  const byType = new Map<string, Set<string>>()
+
+  for (const file of readdirSync(SCHEMA_DIR).filter((f) => /\.ts$/.test(f))) {
+    const source = parse(join(SCHEMA_DIR, file))
+
+    walk(source, (node) => {
+      // Find the type-level object literal: it has both `name` and `fields`.
+      if (!ts.isObjectLiteralExpression(node)) return
+      const typeName = stringProp(node, 'name')
+      if (!typeName) return
+      const fieldsProp = node.properties.find(
+        (p) => ts.isPropertyAssignment(p) && p.name.getText() === 'fields',
+      ) as ts.PropertyAssignment | undefined
+      if (!fieldsProp || !ts.isArrayLiteralExpression(fieldsProp.initializer)) {
+        return
+      }
+
+      const weak = byType.get(typeName) ?? new Set<string>()
+      for (const element of fieldsProp.initializer.elements) {
+        // `defineField({...})` or a bare `{...}`.
+        const literal = ts.isCallExpression(element)
+          ? element.arguments.find(ts.isObjectLiteralExpression)
+          : ts.isObjectLiteralExpression(element)
+            ? element
+            : undefined
+        if (!literal) continue
+        const fieldName = stringProp(literal, 'name')
+        if (fieldName && hasTrueProp(literal, 'weak')) weak.add(fieldName)
+      }
+      if (weak.size > 0) byType.set(typeName, weak)
+    })
+  }
+
+  return byType
+}
+
+/** A ref value we can prove is STRONG, or null when we cannot tell. */
+function strongRefReason(value: ts.Expression): string | null {
+  // `createReference(x)` / `createReferenceWithKey(x)` with nothing added.
+  if (ts.isCallExpression(value)) {
+    const callee = value.expression.getText()
+    if (callee === 'createReference' || callee === 'createReferenceWithKey') {
+      return `${callee}(...) with no _weak`
+    }
+    return null
+  }
+
+  if (ts.isObjectLiteralExpression(value)) {
+    if (hasTrueProp(value, '_weak')) return null
+
+    // A spread of `createReference(...)` without `_weak: true` beside it.
+    const spreadsRef = value.properties.some(
+      (p) =>
+        ts.isSpreadAssignment(p) &&
+        ts.isCallExpression(p.expression) &&
+        /^createReference(WithKey)?$/.test(p.expression.expression.getText()),
+    )
+    if (spreadsRef) return 'spread createReference(...) with no _weak: true'
+
+    // A hand-built `{ _type: 'reference', _ref: ... }`.
+    if (stringProp(value, 'reference') === undefined) {
+      const isRefLiteral =
+        stringProp(value, '_type') === 'reference' &&
+        value.properties.some(
+          (p) => ts.isPropertyAssignment(p) && p.name.getText() === '_ref',
+        )
+      if (isRefLiteral) return 'reference literal with no _weak: true'
+    }
+    return null
+  }
+
+  // Identifier, conditional, spread from elsewhere: not resolvable here.
+  return null
+}
+
+describe('schema `weak: true` must be honoured by API writes (#851)', () => {
+  const weakFieldsByType = collectWeakFields()
+
+  it('reads the weak-field declarations out of the schema (guards the guard)', () => {
+    // If this ever empties out, every other assertion below passes vacuously.
+    expect(weakFieldsByType.size).toBeGreaterThan(0)
+    expect(weakFieldsByType.get('notification')).toEqual(
+      new Set(['recipient', 'actor', 'relatedProposal']),
+    )
+    expect(weakFieldsByType.get('conversation')).toEqual(
+      new Set([
+        'proposal',
+        'createdBy',
+        'subjectSpeaker',
+        'assignedTo',
+        'archivedBy',
+      ]),
+    )
+    expect(weakFieldsByType.get('message')).toEqual(new Set(['author']))
+  })
+
+  it('no source file writes a strong reference into a weak-declared field', () => {
+    const violations: string[] = []
+
+    for (const file of tsFilesUnder(SRC_DIR)) {
+      const source = parse(file)
+
+      walk(source, (node) => {
+        if (!ts.isObjectLiteralExpression(node)) return
+        const docType = stringProp(node, '_type')
+        if (!docType) return
+        const weakFields = weakFieldsByType.get(docType)
+        if (!weakFields) return
+
+        for (const prop of node.properties) {
+          if (!ts.isPropertyAssignment(prop)) continue
+          const fieldName = prop.name.getText().replace(/^['"]|['"]$/g, '')
+          if (!weakFields.has(fieldName)) continue
+
+          const reason = strongRefReason(prop.initializer)
+          if (!reason) continue
+
+          const { line } = source.getLineAndCharacterOfPosition(
+            prop.getStart(source),
+          )
+          violations.push(
+            `${relative(REPO_ROOT, file)}:${line + 1} — ${docType}.${fieldName}: ${reason}`,
+          )
+        }
+      })
+    }
+
+    // Each entry is a field the schema declares weak but the code writes strong,
+    // which blocks deletion of the referenced document (GDPR erasure, #851).
+    // Fix by spreading the ref: `{ ...createReference(id), _weak: true }`.
+    expect(violations).toEqual([])
+  })
+})

--- a/__tests__/lib/sanity/weak-references.test.ts
+++ b/__tests__/lib/sanity/weak-references.test.ts
@@ -46,14 +46,18 @@ const REPO_ROOT = join(__dirname, '..', '..', '..')
 const SCHEMA_DIR = join(REPO_ROOT, 'sanity', 'schemaTypes')
 const SRC_DIR = join(REPO_ROOT, 'src')
 
-function parse(file: string): ts.SourceFile {
+function parseSource(file: string, text: string): ts.SourceFile {
   return ts.createSourceFile(
     file,
-    readFileSync(file, 'utf8'),
+    text,
     ts.ScriptTarget.Latest,
     true,
     ts.ScriptKind.TS,
   )
+}
+
+function parse(file: string): ts.SourceFile {
+  return parseSource(file, readFileSync(file, 'utf8'))
 }
 
 function walk(node: ts.Node, visit: (n: ts.Node) => void): void {
@@ -211,9 +215,23 @@ describe('schema `weak: true` must be honoured by API writes (#851)', () => {
 
   it('no source file writes a strong reference into a weak-declared field', () => {
     const violations: string[] = []
+    const allWeakFieldNames = new Set(
+      [...weakFieldsByType.values()].flatMap((s) => [...s]),
+    )
 
     for (const file of tsFilesUnder(SRC_DIR)) {
-      const source = parse(file)
+      const text = readFileSync(file, 'utf8')
+
+      // CHEAP PRE-FILTER, purely for speed — parsing every file under src/ with
+      // the TypeScript compiler times out on a cold CI runner. This cannot
+      // create a false negative: a violation is BY CONSTRUCTION an object
+      // literal containing a `_type:` property AND a property whose name is a
+      // weak-declared field, so both substrings must be present in the file's
+      // text for the AST walk below to have anything to report.
+      if (!text.includes('_type:')) continue
+      if (![...allWeakFieldNames].some((f) => text.includes(f))) continue
+
+      const source = parseSource(file, text)
 
       walk(source, (node) => {
         if (!ts.isObjectLiteralExpression(node)) return
@@ -244,5 +262,7 @@ describe('schema `weak: true` must be honoured by API writes (#851)', () => {
     // which blocks deletion of the referenced document (GDPR erasure, #851).
     // Fix by spreading the ref: `{ ...createReference(id), _weak: true }`.
     expect(violations).toEqual([])
-  })
+    // Parsing is slow on a cold CI runner; the 5s default is not enough even
+    // with the pre-filter above.
+  }, 30000)
 })

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -1222,7 +1222,10 @@ export async function ensureProposalConversation({
       conference: createReference(conferenceId),
       conversationType: 'proposal',
       proposal: { ...createReference(proposalId), _weak: true },
-      createdBy: createReference(createdById),
+      // WEAK (#851): schema `weak: true` does not apply to API writes, and a
+      // strong `createdBy` blocks GDPR erasure of the speaker who opened the
+      // thread. Migration 041 weakens these; this keeps new writes weak.
+      createdBy: { ...createReference(createdById), _weak: true },
       subject: (proposalTitle || 'Proposal').slice(0, 200),
       createdAt: now,
       lastMessageAt: now,
@@ -1281,7 +1284,10 @@ export async function ensureSponsorConversation({
       createdAt: now,
       lastMessageAt: now,
       participants,
-      ...(createdById ? { createdBy: createReference(createdById) } : {}),
+      // WEAK (#851): see `ensureProposalConversation`.
+      ...(createdById
+        ? { createdBy: { ...createReference(createdById), _weak: true } }
+        : {}),
     })
     .commit()
   return id
@@ -1366,9 +1372,15 @@ export async function createGeneralConversation({
     _type: 'conversation',
     conference: createReference(conferenceId),
     conversationType: 'general',
-    createdBy: createReference(createdById),
+    // WEAK (#851): both point at `speaker`; strong refs here block erasure.
+    createdBy: { ...createReference(createdById), _weak: true },
     ...(subjectSpeakerId
-      ? { subjectSpeaker: createReference(subjectSpeakerId) }
+      ? {
+          subjectSpeaker: {
+            ...createReference(subjectSpeakerId),
+            _weak: true,
+          },
+        }
       : {}),
     subject: subject.slice(0, 200),
     createdAt: now,
@@ -1445,7 +1457,9 @@ export async function addMessage({
         authorName: sponsorAuthor.authorName,
       }
     : {
-        author: createReference(authorId as string),
+        // WEAK (#851): a strong `author` makes every speaker who ever sent a
+        // message undeletable — the exact condition migration 041 clears.
+        author: { ...createReference(authorId as string), _weak: true },
         authorParty: partyToStored({
           partyType: 'speaker',
           speakerId: authorId as string,

--- a/src/lib/notification/sanity.ts
+++ b/src/lib/notification/sanity.ts
@@ -69,7 +69,10 @@ export async function createNotifications(
     for (const item of items) {
       const doc: { _type: string; [key: string]: unknown } = {
         _type: 'notification',
-        recipient: createReference(item.recipientId),
+        // WEAK (#851): a strong ref here blocks GDPR erasure of the speaker.
+        // `weak: true` in the schema governs Studio writes only — an API write
+        // is strong unless the stored ref object itself carries `_weak`.
+        recipient: { ...createReference(item.recipientId), _weak: true },
         conference: createReference(item.conferenceId),
         notificationType: item.notificationType,
         title: item.title,
@@ -82,7 +85,9 @@ export async function createNotifications(
         doc.link = item.link
       }
       if (item.actorId) {
-        doc.actor = createReference(item.actorId)
+        // WEAK (#851): see `recipient` above — speaker erasure must not be
+        // blocked by a notification the speaker happened to trigger.
+        doc.actor = { ...createReference(item.actorId), _weak: true }
       }
       if (item.relatedProposalId) {
         // Weak reference so a later proposal deletion doesn't orphan-block.
@@ -264,7 +269,9 @@ export async function upsertMessageNotifications(
             set.link = item.link
           }
           if (item.actorId) {
-            set.actor = createReference(item.actorId)
+            // WEAK (#851): a patch `set` REPLACES the stored ref object, so a
+            // strong value here re-strengthens an already-weakened document.
+            set.actor = { ...createReference(item.actorId), _weak: true }
           }
           if (item.relatedProposalId) {
             // Weak reference so a later proposal deletion doesn't orphan-block.
@@ -277,7 +284,8 @@ export async function upsertMessageNotifications(
           tx.createIfNotExists({
             _id: id,
             _type: 'notification',
-            recipient: createReference(item.recipientId),
+            // WEAK (#851): same erasure trap as `createNotifications`.
+            recipient: { ...createReference(item.recipientId), _weak: true },
             conference: createReference(item.conferenceId),
             notificationType: 'message_received',
             title,


### PR DESCRIPTION
Fixes #851.

## What was wrong

`createReference()` returns `{ _type: 'reference', _ref }` — no `_weak`. Schema
`weak: true` governs Studio writes and validation, **not** API writes: reference
strength lives on the stored ref object. So every server-side write emitted a
STRONG reference regardless of the schema, and a strong reference blocks deletion
of its target — which is why a speaker who had received a notification since
migration 041 ran cannot be erased today.

## Measured in production (read-only Sanity CLI, 2026-08-05)

**Units matter here, so each row gives the command and its unit.** `count(*[…])`
returns **documents**, not references. A document can hold two offending
references (a notification with both `recipient` and `actor`), so the reference
total is larger than the document total — the two must not be conflated.

| field | `count(*[…])` → **documents** |
|---|---|
| `notification.recipient` strong | 408 |
| `notification.actor` strong | 373 |
| `message.author` strong | 13 |
| `conversation.createdBy` strong | 7 |
| `conversation.subjectSpeaker` strong | 1 |
| **sum of the five (references)** | **802 references** |
| **distinct documents affected** | **428 documents** |

The 428 figure is a single `count()` over the union predicate, not a sum. Newest
strong `notification.recipient`: `_createdAt 2026-08-05T04:00:12Z` — 041 ran
2026-07-19, so these are new writes, not a leftover backlog.

Note for whoever verifies the fix: **the Sanity CLI reports a zero count as an
error** (`Failed to run query: Query returned no results`), so wrap counts as
`{"n": count(*[…])}` — otherwise the success case of this fix reads as a failed
query.

## Scope: nine sites, not two

#851 names two. An audit of all 62 `createReference` / `createReferenceWithKey`
call sites found **nine** where the schema declares `weak: true` and the write
emits strong. All nine point at `speaker`; all nine are fixed. They include the
other three fields migration 041 exists to weaken, which the issue's repro did
not reach:

| file:line | doc.field | note |
|---|---|---|
| `src/lib/notification/sanity.ts:72` | `notification.recipient` | named in #851 |
| `src/lib/notification/sanity.ts:85` | `notification.actor` | named in #851 |
| `src/lib/notification/sanity.ts:267` | `notification.actor` | **patch `set`** |
| `src/lib/notification/sanity.ts:280` | `notification.recipient` | message-collapse `createIfNotExists` |
| `src/lib/messaging/sanity.ts:1225` | `conversation.createdBy` | proposal thread |
| `src/lib/messaging/sanity.ts:1284` | `conversation.createdBy` | sponsor thread |
| `src/lib/messaging/sanity.ts:1369` | `conversation.createdBy` | general thread |
| `src/lib/messaging/sanity.ts:1371` | `conversation.subjectSpeaker` | general thread |
| `src/lib/messaging/sanity.ts:1448` | `message.author` | every message sent |

`:267` matters beyond the backlog: a patch `set` **replaces** the stored ref
object, so on any active conversation the next message would re-strengthen a
document 041 had just weakened.

All nine use the existing house pattern — the shape `assignedTo` already used:
`{ ...createReference(id), _weak: true }`.

`conference` refs on the same documents stay strong on purpose: a conference is
not an erasure subject and referential integrity there is wanted.

## Migration 041 is still required after this merges

This stops the bleeding; it does not clean up the existing 802 strong references
across 428 documents. **Re-running 041 BEFORE this code fix would re-arm rather
than fix** — it would report success and the counts would climb again from the
next notification/message. Run it after this is deployed, via the Run Sanity
Migration workflow, as a separately authorised production step.

## Tests

This shipped because nothing asserted the shape of what gets written. Three
existing tests actively asserted the *buggy* shape — `party-model.test.ts`
asserted `authorParty.speaker` weak and `author` strong on adjacent lines, the
same split-brain the issue describes in the source. Corrected.

Added:

- **Behavioural** — asserting the document handed to `tx.create` /
  `tx.createIfNotExists` / the patch `set` payload, not a mock's return value,
  for every notification and messaging write path.
- **A repo-wide invariant** (`__tests__/lib/sanity/weak-references.test.ts`):
  parses `sanity/schemaTypes/*.ts` for every `(documentType, field)` declared
  `weak: true`, then parses every non-test file under `src/` and fails on any
  object literal that self-identifies as that `_type` and assigns the field a
  provably-strong reference. It also asserts the extracted schema map is
  non-empty and matches expectation, so it cannot pass vacuously.

  Its limits are documented in the file: it cannot see `.patch().set()` (no
  `_type` in the payload) and does not resolve refs built indirectly. It is a
  floor, not a proof — the patch paths are covered behaviourally instead.

Building the sabotage matrix also exposed a **coverage hole**:
`ensureSponsorConversation` had no test at all, so its `createdBy` could be
reverted to a strong ref with the full suite still green. Two tests added for it.

## Recommendation: do NOT invert `createReference()` to default weak

1. **It would not fix the class.** ~70 reference literals are hand-built
   (`{ _type: 'reference', _ref }`) and never touch the helper — including
   `speaker.organizations`, `sponsorActivity.createdBy` and
   `dashboardConfig.speaker`. Inverting buys a partial fix at full blast radius.
2. **The blast radius is unreviewable.** 52 of 62 call sites are strong today and
   many are strong *correctly* (`conference`, `tier`, `sponsor`, `conversation`).
   Flipping them changes delete-time integrity semantics repo-wide in a diff with
   no changed lines at the call sites.

To do it later, these would need to be true first: every schema field's intended
strength declared explicitly (many speaker-pointing fields are strong by
omission, not decision); an explicit `createStrongReference()` applied at the
intentional sites; the invariant test extended to hand-built literals and patch
payloads so the flip is verified rather than assumed; and a migration for
existing documents.

## Larger erasure surface — out of scope, needs its own issue

~17 further fields point at `speaker` and are strong in **both** schema and code:
`talk.speakers`, `conference.organizers`, `conference.teams[].members`,
`imageGallery.speakers`/`untaggedSpeakers`, `review.reviewer`,
`coSpeakerInvitation.invitedBy`/`acceptedSpeaker`, `sponsorActivity.createdBy`,
`sponsorForConference.assignedTo`, `travelSupport.speaker`/`reviewedBy`,
`volunteer.reviewedBy`, `invitationLetter.issuedBy`, `speakerBadge.speaker`,
`dashboardConfig.speaker`, `conversationPreference.speaker`, `schedule.owner`.
Each also blocks erasure. Unlike the nine above these are not code contradicting
the schema — the schema says strong — so changing them is a schema/product
decision plus migrations, not a bug fix.

Two further audit findings, reported rather than guessed at:
`src/lib/schedule/sanity.ts:411` writes a *speaker* id into `schedule.owner`,
which the schema declares `to: [{ type: 'staff' }]`; and
`src/app/api/cron/contract-reminders/route.ts:146` writes
`createdBy: { _ref: 'system' }` — a strong reference to an id with no document.

## Risk

Low, and partly pre-proven: 698 `notification` **documents** already hold a weak
`recipient` (041 weakened them 2026-07-19) and the inbox has read them fine
since. Weak refs deref identically; the only behavioural difference is that
`actor->` / `author->` may resolve null once a target is erased — the intended
outcome, and what the schema already promised.
