### PR TITLE
fix(reads): make "unknown" representable so a failed read stops asserting

### DIFF
--- a/__tests__/api/badge/badge-endpoints.test.ts
+++ b/__tests__/api/badge/badge-endpoints.test.ts
@@ -305,5 +305,49 @@ describe('Badge endpoints - dual format', () => {
         }
       }
     })
+
+    /**
+     * #848. This endpoint answers EXTERNAL verifiers — employers, other
+     * credential platforms — that we do not control. `getBadgeById` used to
+     * return the same `{ error }` for "no such badge" and "the badge store is
+     * unreachable", and the route turned both into a definitive, cacheable
+     * 404: to a verifier, indistinguishable from a forged credential.
+     */
+    describe('a badge-store outage is not a verdict on the credential', () => {
+      it('answers 503, not 404, and never says the badge does not exist', async () => {
+        mockedGetBadgeById.mockResolvedValue({
+          error: new Error('ECONNREFUSED sanity.io'),
+          reason: 'unavailable',
+        })
+
+        const { GET } = await import('@/app/api/badge/[badgeId]/verify/route')
+        const response = await GET(request, routeParams())
+
+        expect(response.status).toBe(503)
+        const body = await response.json()
+        // Not a verification verdict of any kind.
+        expect(body.verified).toBeUndefined()
+        expect(JSON.stringify(body)).not.toContain('Badge not found')
+        // A non-answer must not be cached as though it were one, and the
+        // verifier must be told to come back.
+        expect(response.headers.get('Cache-Control')).toBe('no-store')
+        expect(response.headers.get('Retry-After')).toBe('30')
+      })
+
+      it('STILL answers 404 for a badge that genuinely does not exist', async () => {
+        // The other direction: if the outage response were reused here, the
+        // test above would prove nothing.
+        mockedGetBadgeById.mockResolvedValue({
+          error: new Error('Badge not found'),
+          reason: 'not-found',
+        })
+
+        const { GET } = await import('@/app/api/badge/[badgeId]/verify/route')
+        const response = await GET(request, routeParams())
+
+        expect(response.status).toBe(404)
+        expect((await response.json()).error).toBe('Badge not found')
+      })
+    })
   })
 })

--- a/__tests__/api/trpc/invitation-letter.test.ts
+++ b/__tests__/api/trpc/invitation-letter.test.ts
@@ -84,6 +84,7 @@ beforeEach(() => {
     conference: conference as never,
     domain: 'test.com',
     error: null,
+    status: 'resolved' as const,
   })
   vi.mocked(generateInvitationLetterPdf).mockResolvedValue(
     Buffer.from('%PDF-1.7 fake'),
@@ -349,6 +350,7 @@ describe('invitationLetter.issue — validation', () => {
       conference: { ...conference, organizer: '  ' } as never,
       domain: 'test.com',
       error: null,
+      status: 'resolved' as const,
     })
 
     await expect(

--- a/__tests__/api/trpc/proposal.test.ts
+++ b/__tests__/api/trpc/proposal.test.ts
@@ -174,6 +174,7 @@ describe('proposal router', () => {
       conference: mockConference as any,
       domain: 'localhost',
       error: null,
+      status: 'resolved' as const,
     })
   })
 

--- a/__tests__/api/trpc/schedule-list-filter.test.ts
+++ b/__tests__/api/trpc/schedule-list-filter.test.ts
@@ -51,6 +51,7 @@ beforeEach(() => {
     conference: conference as never,
     domain: 'test.com',
     error: null,
+    status: 'resolved' as const,
   })
   fetchMock.mockResolvedValue([])
 })

--- a/__tests__/api/trpc/schedule-promote.test.ts
+++ b/__tests__/api/trpc/schedule-promote.test.ts
@@ -91,6 +91,7 @@ beforeEach(() => {
     conference: conference as never,
     domain: 'test.com',
     error: null,
+    status: 'resolved' as const,
   })
   vi.mocked(getTalkStatuses).mockResolvedValue({
     'talk-a': ProposalStatus.confirmed,

--- a/__tests__/api/trpc/sponsor-activity.test.ts
+++ b/__tests__/api/trpc/sponsor-activity.test.ts
@@ -66,6 +66,7 @@ describe('Sponsor CRM Activities & Assignments', () => {
       conference: mockConference as any,
       domain: 'test.com',
       error: null,
+      status: 'resolved' as const,
     })
     vi.mocked(getOrganizersByConference).mockResolvedValue({
       speakers: [mockOrganizer] as any,

--- a/__tests__/api/trpc/sponsor-contract-signature-guards.test.ts
+++ b/__tests__/api/trpc/sponsor-contract-signature-guards.test.ts
@@ -88,6 +88,7 @@ beforeEach(() => {
     conference: mockConference as never,
     domain: 'test.com',
     error: null,
+    status: 'resolved' as const,
   })
   vi.mocked(getOrganizersByConference).mockResolvedValue({
     speakers: [mockOrganizer] as never,

--- a/__tests__/api/trpc/sponsor-health.test.ts
+++ b/__tests__/api/trpc/sponsor-health.test.ts
@@ -73,6 +73,7 @@ describe('sponsor.crm.healthViolations', () => {
       conference: mockConference as any,
       domain: 'test.com',
       error: null,
+      status: 'resolved' as const,
     })
   })
 

--- a/__tests__/api/trpc/sponsor-invoice-status.test.ts
+++ b/__tests__/api/trpc/sponsor-invoice-status.test.ts
@@ -63,6 +63,7 @@ describe('updateInvoiceStatus mutation', () => {
       } as any,
       domain: 'test.com',
       error: null,
+      status: 'resolved' as const,
     })
     caller = appRouter.createCaller({
       session: {

--- a/__tests__/api/trpc/sponsor-move-stage.test.ts
+++ b/__tests__/api/trpc/sponsor-move-stage.test.ts
@@ -75,6 +75,7 @@ describe('sponsor.crm.moveStage — tier guard', () => {
       conference: mockConference as any,
       domain: 'test.com',
       error: null,
+      status: 'resolved' as const,
     })
     vi.mocked(getOrganizersByConference).mockResolvedValue({
       speakers: [mockOrganizer] as any,

--- a/__tests__/api/trpc/sponsor-pipeline-guards.test.ts
+++ b/__tests__/api/trpc/sponsor-pipeline-guards.test.ts
@@ -86,6 +86,7 @@ describe('sponsor CRM pipeline tier invariant — all write paths', () => {
       conference: mockConference as any,
       domain: 'test.com',
       error: null,
+      status: 'resolved' as const,
     })
     vi.mocked(getOrganizersByConference).mockResolvedValue({
       speakers: [mockOrganizer] as any,

--- a/__tests__/api/trpc/sponsor-stage-notification.test.ts
+++ b/__tests__/api/trpc/sponsor-stage-notification.test.ts
@@ -83,6 +83,7 @@ beforeEach(() => {
     conference: mockConference as never,
     domain: 'test.com',
     error: null,
+    status: 'resolved' as const,
   })
   vi.mocked(getSponsorForConference).mockResolvedValue({
     sponsorForConference: makeSfc(),

--- a/__tests__/api/trpc/sponsor-tenancy.test.ts
+++ b/__tests__/api/trpc/sponsor-tenancy.test.ts
@@ -105,6 +105,7 @@ beforeEach(() => {
     conference: mockConference as any,
     domain: 'test.com',
     error: null,
+    status: 'resolved' as const,
   })
 })
 

--- a/__tests__/api/trpc/volunteer.test.ts
+++ b/__tests__/api/trpc/volunteer.test.ts
@@ -104,6 +104,7 @@ describe('volunteer router', () => {
       conference: mockConference as any,
       domain: 'localhost',
       error: null,
+      status: 'resolved' as const,
     })
     // Re-pin the default: per-test mockResolvedValue/mockRejectedValue
     // overrides survive clearAllMocks and would otherwise leak forward.

--- a/__tests__/app/outage-is-not-an-answer.test.tsx
+++ b/__tests__/app/outage-is-not-an-answer.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * @vitest-environment node
+ *
+ * #848. A failed read must never be rendered as a confident negative.
+ *
+ * These tests do NOT stub the conference loader — they make the Sanity client
+ * itself THROW, exactly as a total outage does, and then assert on the markup
+ * the real page produces. That is the whole point: `getConferenceForDomain`
+ * answers a thrown read with a TRUTHY `{} as Conference`, so every downstream
+ * `if (conference)` succeeded and reasoned about an empty conference. The
+ * regression these lock down is a *rendered sentence*, not a helper's return
+ * value.
+ *
+ * Each surface is asserted in BOTH directions — outage and genuine absence —
+ * because a test that only proves "the outage copy appears" would also pass if
+ * the outage copy appeared for a host that really has no conference.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactElement } from 'react'
+
+const sanityFetch = vi.fn()
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: { fetch: (...a: unknown[]) => sanityFetch(...a) },
+  clientRead: { fetch: (...a: unknown[]) => sanityFetch(...a) },
+  clientReadUncached: { fetch: (...a: unknown[]) => sanityFetch(...a) },
+}))
+vi.mock('next/cache', () => ({ cacheLife: vi.fn(), cacheTag: vi.fn() }))
+vi.mock('next/headers', () => ({
+  headers: vi.fn(
+    async () =>
+      new Headers({ host: 'live-tenant.example', 'x-url': 'https://x/cfp' }),
+  ),
+}))
+vi.mock('next/server', () => ({ connection: vi.fn(async () => {}) }))
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(() => {
+    throw new Error('unexpected redirect')
+  }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/cfp/proposal',
+}))
+vi.mock('@/lib/domain-verification/routing', () => ({
+  isHostRoutable: vi.fn(async () => true),
+}))
+vi.mock('@/lib/gallery/sanity', () => ({
+  getGalleryImages: vi.fn(async () => []),
+  getFeaturedGalleryImages: vi.fn(async () => []),
+}))
+vi.mock('@/lib/sponsor-crm/sanity', () => ({
+  getPublicSponsorsForConference: vi.fn(async () => []),
+}))
+
+// The tenant chrome is a large tree with its own data needs; a probe is enough
+// to prove the layout got as far as rendering the site.
+vi.mock('@/components/Layout', () => ({
+  Layout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="tenant-chrome">{children}</div>
+  ),
+}))
+
+// The form itself is a tRPC/react-query client tree; a probe is enough to
+// prove the page reached the submit branch rather than an error branch.
+vi.mock('@/components/cfp/ProposalForm', () => ({
+  ProposalForm: () => <div data-testid="proposal-form" />,
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getAuthSession: vi.fn(async () => ({
+    speaker: { _id: 'speaker-1', email: 'ada@example.com' },
+  })),
+}))
+vi.mock('@/lib/speaker/sanity', () => ({
+  getSpeaker: vi.fn(async () => ({
+    speaker: { _id: 'speaker-1', name: 'Ada', email: 'ada@example.com' },
+    err: null,
+  })),
+}))
+vi.mock('@/lib/proposal/data/sanity', () => ({
+  getProposals: vi.fn(async () => ({ proposals: [], proposalsError: null })),
+}))
+
+import MainLayout from '@/app/(main)/layout'
+import NewProposalPage from '@/app/(cfp)/cfp/proposal/page'
+
+/** A live tenant with an OPEN call for papers. */
+const LIVE_CONFERENCE = {
+  _id: 'conf-1',
+  title: 'Cloud Native Days',
+  domains: ['live-tenant.example'],
+  contactEmail: 'hello@live-tenant.example',
+  formats: ['lightning_10'],
+  topics: [{ _id: 'topic-1', title: 'Platform engineering' }],
+  cfpStartDate: '2026-01-01',
+  cfpEndDate: '2026-12-01',
+}
+
+async function renderLayout(): Promise<string> {
+  return renderToStaticMarkup(
+    (await MainLayout({ children: null })) as ReactElement,
+  )
+}
+
+async function renderProposalPage(): Promise<string> {
+  return renderToStaticMarkup(
+    (await NewProposalPage({
+      searchParams: Promise.resolve({}),
+    })) as ReactElement,
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-06-01T12:00:00Z'))
+})
+
+describe('a Sanity outage does not put a live tenant up for sale', () => {
+  it('renders "temporarily unavailable" — NOT the claim-this-domain landing', async () => {
+    sanityFetch.mockRejectedValue(new Error('ECONNREFUSED sanity.io'))
+
+    const html = await renderLayout()
+
+    expect(html).toContain('Temporarily unavailable')
+    // The three sentences that used to greet a paying customer's visitors
+    // during an outage.
+    expect(html).not.toContain('No conference here yet')
+    expect(html).not.toContain('No conference is configured for this domain')
+    expect(html).not.toContain('Claim it')
+  })
+
+  it('keeps a crawler from banking the outage page as the tenant content', async () => {
+    sanityFetch.mockRejectedValue(new Error('ECONNREFUSED sanity.io'))
+
+    expect(await renderLayout()).toContain('noindex')
+  })
+
+  it('STILL offers the domain when the read succeeded and matched nothing', async () => {
+    // The other direction. If this went green on an outage too, the test above
+    // would prove nothing: both worlds would render the same screen.
+    sanityFetch.mockResolvedValue(null)
+
+    const html = await renderLayout()
+
+    expect(html).toContain('No conference here yet')
+    expect(html).not.toContain('Temporarily unavailable')
+  })
+
+  it('renders the tenant site when the conference resolves', async () => {
+    sanityFetch.mockResolvedValue(LIVE_CONFERENCE)
+
+    const html = await renderLayout()
+
+    expect(html).toContain('tenant-chrome')
+    expect(html).not.toContain('Temporarily unavailable')
+    expect(html).not.toContain('No conference here yet')
+  })
+})
+
+describe('a failed conference read does not close an open CFP', () => {
+  it('tells a speaker the page is temporarily unavailable, not that the CFP is closed', async () => {
+    sanityFetch.mockRejectedValue(new Error('ECONNREFUSED sanity.io'))
+
+    const html = await renderProposalPage()
+
+    expect(html).toContain('Temporarily Unavailable')
+    // The old bug verbatim: the Server Error was set, then `if (conference)`
+    // (always true) re-entered and overwrote it, because `isCfpOpen({})` is
+    // false. A speaker was turned away from a call that was OPEN.
+    expect(html).not.toContain('The Call for Papers is currently closed')
+    expect(html).not.toContain('CFP Closed')
+  })
+
+  it('STILL reports a genuinely closed CFP as closed', async () => {
+    sanityFetch.mockResolvedValue({
+      ...LIVE_CONFERENCE,
+      cfpStartDate: '2025-01-01',
+      cfpEndDate: '2025-02-01',
+    })
+
+    const html = await renderProposalPage()
+
+    expect(html).toContain('CFP Closed')
+    expect(html).not.toContain('Temporarily Unavailable')
+  })
+
+  it('STILL renders the submission form when the CFP is open', async () => {
+    sanityFetch.mockResolvedValue(LIVE_CONFERENCE)
+
+    const html = await renderProposalPage()
+
+    expect(html).toContain('proposal-form')
+    expect(html).not.toContain('CFP Closed')
+    expect(html).not.toContain('Temporarily Unavailable')
+    expect(html).not.toContain('Submissions Not Open Yet')
+  })
+})

--- a/__tests__/app/outage-is-not-an-answer.test.tsx
+++ b/__tests__/app/outage-is-not-an-answer.test.tsx
@@ -83,6 +83,7 @@ vi.mock('@/lib/proposal/data/sanity', () => ({
 }))
 
 import MainLayout from '@/app/(main)/layout'
+import NotFound from '@/app/not-found'
 import NewProposalPage from '@/app/(cfp)/cfp/proposal/page'
 
 /** A live tenant with an OPEN call for papers. */
@@ -101,6 +102,10 @@ async function renderLayout(): Promise<string> {
   return renderToStaticMarkup(
     (await MainLayout({ children: null })) as ReactElement,
   )
+}
+
+async function renderNotFound(): Promise<string> {
+  return renderToStaticMarkup((await NotFound()) as ReactElement)
 }
 
 async function renderProposalPage(): Promise<string> {
@@ -154,6 +159,43 @@ describe('a Sanity outage does not put a live tenant up for sale', () => {
     const html = await renderLayout()
 
     expect(html).toContain('tenant-chrome')
+    expect(html).not.toContain('Temporarily unavailable')
+    expect(html).not.toContain('No conference here yet')
+  })
+})
+
+/**
+ * The root 404 needs its OWN coverage: it sits outside the (main) group, so
+ * the layout's unavailable-branch never runs for it. During an outage every
+ * typo'd or unmatched URL on a live tenant's domain is this page.
+ */
+describe('the root 404 does not put a live tenant up for sale either', () => {
+  it('renders "temporarily unavailable" for a failed read, not the claim pitch', async () => {
+    sanityFetch.mockRejectedValue(new Error('ECONNREFUSED sanity.io'))
+
+    const html = await renderNotFound()
+
+    expect(html).toContain('Temporarily unavailable')
+    expect(html).not.toContain('No conference here yet')
+    expect(html).not.toContain('Claim it')
+  })
+
+  it('STILL offers the domain when the read succeeded and matched nothing', async () => {
+    sanityFetch.mockResolvedValue(null)
+
+    const html = await renderNotFound()
+
+    expect(html).toContain('No conference here yet')
+    expect(html).not.toContain('Temporarily unavailable')
+  })
+
+  it('STILL renders the tenant 404 when the conference resolves', async () => {
+    sanityFetch.mockResolvedValue(LIVE_CONFERENCE)
+
+    const html = await renderNotFound()
+
+    expect(html).toContain('tenant-chrome')
+    expect(html).toContain('Page not found')
     expect(html).not.toContain('Temporarily unavailable')
     expect(html).not.toContain('No conference here yet')
   })

--- a/__tests__/app/tickets/tickets-page-states.test.tsx
+++ b/__tests__/app/tickets/tickets-page-states.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * @vitest-environment node
+ *
+ * #846. `/tickets` had ONE fallback — "Tickets for X are not yet available" —
+ * and it fired for four unrelated worlds. Three of them were false while
+ * registration was open, and the falsehood was cached for hours
+ * (`cacheLife('hours')`).
+ *
+ * Every case below runs the REAL page against a real `getPublicTicketTypes`,
+ * varying only what the ticket vendor and the conference document say. Each is
+ * asserted against the others: if the four worlds rendered the same screen the
+ * suite would be worthless, so each test also names the sentence it must NOT
+ * produce.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactElement } from 'react'
+
+const sanityFetch = vi.fn()
+const fetchPublicTicketTypes = vi.fn()
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: { fetch: (...a: unknown[]) => sanityFetch(...a) },
+  clientRead: { fetch: (...a: unknown[]) => sanityFetch(...a) },
+  clientReadUncached: { fetch: (...a: unknown[]) => sanityFetch(...a) },
+}))
+vi.mock('next/cache', () => ({ cacheLife: vi.fn(), cacheTag: vi.fn() }))
+vi.mock('next/headers', () => ({
+  headers: vi.fn(async () => new Headers({ host: 'live-tenant.example' })),
+}))
+vi.mock('@/lib/domain-verification/routing', () => ({
+  isHostRoutable: vi.fn(async () => true),
+}))
+vi.mock('@/lib/gallery/sanity', () => ({
+  getGalleryImages: vi.fn(async () => []),
+  getFeaturedGalleryImages: vi.fn(async () => []),
+}))
+vi.mock('@/lib/sponsor-crm/sanity', () => ({
+  getPublicSponsorsForConference: vi.fn(async () => []),
+}))
+// Only the vendor call is stubbed; `hasTicketingBinding` / `ticketingBinding`
+// stay real so the page's own gating is under test.
+vi.mock('@/lib/tickets/provider', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  resolveTicketingProvider: vi.fn(async () => ({
+    configured: true,
+    provider: { fetchPublicTicketTypes },
+    eventRef: { customerId: 42, eventId: 7 },
+  })),
+}))
+
+import TicketsPage from '@/app/(main)/tickets/page'
+
+const COMING_SOON = 'Tickets Coming Soon'
+const NOT_YET_AVAILABLE = 'are not yet available'
+
+function conference(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: 'conf-1',
+    title: 'Cloud Native Days',
+    domains: ['live-tenant.example'],
+    contactEmail: 'hello@live-tenant.example',
+    startDate: '2026-09-01',
+    endDate: '2026-09-02',
+    checkinCustomerId: 42,
+    checkinEventId: 7,
+    ...overrides,
+  }
+}
+
+function ticket(over: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    name: 'Conference',
+    type: 'standard',
+    description: null,
+    price: [{ price: '1000', vat: '25', description: null, key: null }],
+    available: null,
+    requiresInvitation: false,
+    visibleStartsAt: null,
+    visibleEndsAt: null,
+    position: 0,
+    ...over,
+  }
+}
+
+/** The page returns a nested async component; flush it to markup. */
+async function renderPage(): Promise<string> {
+  const outer = (await TicketsPage()) as ReactElement<{ domain: string }>
+  const inner = await (
+    outer.type as (p: { domain: string }) => Promise<ReactElement>
+  )(outer.props)
+  return renderToStaticMarkup(inner)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-06-01T12:00:00Z'))
+})
+
+describe('a free-to-attend event can show its tickets', () => {
+  it('renders the ticket grid, marked Free, instead of "coming soon"', async () => {
+    // The free plan's entire constituency: every type costs nothing, so the
+    // old `price > 0` filter emptied the list and the page announced that
+    // tickets were not yet available while registration was open.
+    sanityFetch.mockResolvedValue(
+      conference({
+        registrationEnabled: true,
+        registrationLink: 'https://register.example/free-event',
+      }),
+    )
+    fetchPublicTicketTypes.mockResolvedValue({
+      event: { id: 7, name: 'Event', currencies: ['NOK'] },
+      tickets: [
+        ticket({ id: 1, name: 'Conference', price: [] }),
+        ticket({
+          id: 2,
+          name: 'Workshop day',
+          position: 1,
+          price: [{ price: '0', vat: '0', description: null, key: null }],
+        }),
+      ],
+    })
+
+    const html = await renderPage()
+
+    expect(html).toContain('Conference')
+    expect(html).toContain('Workshop day')
+    expect(html).toContain('Free')
+    expect(html).toContain('This event is free to attend')
+    // Never the VAT footnote, which is meaningless over free tickets.
+    expect(html).not.toContain('excl. 25% VAT')
+    expect(html).not.toContain(COMING_SOON)
+    expect(html).not.toContain(NOT_YET_AVAILABLE)
+  })
+
+  it('does not publish a PAID event’s free types (crew, organizer)', async () => {
+    // The deliberate limit on the fix. A zero-priced type on a paid event is
+    // overwhelmingly internal; the public subset reaches the page through
+    // `extractComplimentaryTickets` instead.
+    sanityFetch.mockResolvedValue(conference())
+    fetchPublicTicketTypes.mockResolvedValue({
+      event: { id: 7, name: 'Event', currencies: ['NOK'] },
+      tickets: [
+        ticket({ id: 1, name: 'Conference' }),
+        ticket({ id: 2, name: 'Crew', position: 1, price: [] }),
+      ],
+    })
+
+    const html = await renderPage()
+
+    expect(html).toContain('Conference')
+    expect(html).not.toContain('Crew')
+    expect(html).toContain('excl. 25% VAT')
+  })
+})
+
+describe('an external-registration tenant is not told tickets are unavailable', () => {
+  it('sends the visitor to register instead', async () => {
+    // Registration is on with a link, but nothing is bound to a ticket vendor.
+    // The homepage offered registration while /tickets denied it existed.
+    sanityFetch.mockResolvedValue(
+      conference({
+        checkinCustomerId: undefined,
+        checkinEventId: undefined,
+        registrationEnabled: true,
+        registrationLink: 'https://register.example/tickets',
+      }),
+    )
+
+    const html = await renderPage()
+
+    expect(html).toContain('Registration Is Open')
+    expect(html).toContain('https://register.example/tickets')
+    expect(html).not.toContain(COMING_SOON)
+    expect(html).not.toContain(NOT_YET_AVAILABLE)
+    // No vendor is bound, so none may be called.
+    expect(fetchPublicTicketTypes).not.toHaveBeenCalled()
+  })
+})
+
+describe('a ticket-provider outage is reported as an outage', () => {
+  it('says ticket information could not be loaded, not that there are none', async () => {
+    sanityFetch.mockResolvedValue(
+      conference({
+        registrationEnabled: true,
+        registrationLink: 'https://register.example/tickets',
+      }),
+    )
+    fetchPublicTicketTypes.mockRejectedValue(new Error('checkin.no 503'))
+
+    const html = await renderPage()
+
+    expect(html).toContain('Ticket Information Unavailable')
+    expect(html).not.toContain(COMING_SOON)
+    expect(html).not.toContain(NOT_YET_AVAILABLE)
+    // Registration came from the conference document, which we DID read, so
+    // the CTA is still supportable.
+    expect(html).toContain('https://register.example/tickets')
+  })
+
+  it('is DISTINGUISHABLE from a vendor that genuinely lists nothing', async () => {
+    // The pair that proves the union earns its keep. Same conference, same
+    // page; only the vendor's answer differs.
+    sanityFetch.mockResolvedValue(conference())
+
+    fetchPublicTicketTypes.mockResolvedValue({
+      event: { id: 7, name: 'Event', currencies: ['NOK'] },
+      tickets: [],
+    })
+    const empty = await renderPage()
+
+    fetchPublicTicketTypes.mockRejectedValue(new Error('checkin.no 503'))
+    const failed = await renderPage()
+
+    expect(empty).toContain(COMING_SOON)
+    expect(empty).not.toContain('Ticket Information Unavailable')
+    expect(failed).toContain('Ticket Information Unavailable')
+    expect(failed).not.toContain(COMING_SOON)
+  })
+})
+
+describe('the honest "coming soon" survives', () => {
+  it('still fires when the read succeeded, there are no tickets, and registration is closed', async () => {
+    sanityFetch.mockResolvedValue(conference({ registrationEnabled: false }))
+    fetchPublicTicketTypes.mockResolvedValue({
+      event: { id: 7, name: 'Event', currencies: ['NOK'] },
+      tickets: [],
+    })
+
+    const html = await renderPage()
+
+    expect(html).toContain(COMING_SOON)
+    expect(html).toContain(NOT_YET_AVAILABLE)
+    expect(html).not.toContain('Registration Is Open')
+    expect(html).not.toContain('Ticket Information Unavailable')
+  })
+
+  it('still renders the priced grid for an ordinary paid event', async () => {
+    sanityFetch.mockResolvedValue(
+      conference({
+        registrationEnabled: true,
+        registrationLink: 'https://register.example/tickets',
+      }),
+    )
+    fetchPublicTicketTypes.mockResolvedValue({
+      event: { id: 7, name: 'Event', currencies: ['NOK'] },
+      tickets: [ticket()],
+    })
+
+    const html = await renderPage()
+
+    // nb-NO groups with a non-breaking space.
+    expect(html).toMatch(/NOK\s1\s000/)
+    expect(html).toContain('Buy ticket')
+    expect(html).not.toContain('Free')
+    expect(html).not.toContain(COMING_SOON)
+    expect(html).not.toContain('This event is free to attend')
+  })
+})

--- a/src/app/(cfp)/cfp/proposal/page.tsx
+++ b/src/app/(cfp)/cfp/proposal/page.tsx
@@ -17,6 +17,7 @@ import { redirect } from 'next/navigation'
 import { headers } from 'next/headers'
 import { getSpeaker } from '@/lib/speaker/sanity'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { isConferenceUnavailable } from '@/lib/conference/guard'
 
 export default async function NewProposalPage({
   searchParams,
@@ -54,19 +55,34 @@ export default async function NewProposalPage({
   let loadingError: FormError | null = null
   let currentUserSpeaker: Speaker | null = null
 
-  const { conference, error } = await getConferenceForCurrentDomain({
+  const resolution = await getConferenceForCurrentDomain({
     topics: true,
   })
+  const { conference, error } = resolution
 
   if (!conference || error) {
     console.error('Error loading conference:', error)
-    loadingError = {
-      type: 'Server Error',
-      message: 'Failed to load conference.',
-    }
+    loadingError = isConferenceUnavailable(resolution)
+      ? {
+          // We could not READ the conference, so we know nothing about its CFP.
+          // Saying "the Call for Papers is closed" here (which is what the
+          // block below used to do, because `isCfpOpen({})` is false) turns an
+          // outage into a speaker walking away from an OPEN call.
+          type: 'Temporarily Unavailable',
+          message:
+            'We could not load the conference just now. This is a problem on our side, not with your submission — please try again in a few minutes.',
+        }
+      : {
+          type: 'Server Error',
+          message: 'Failed to load conference.',
+        }
   }
 
-  if (conference) {
+  // `if (conference)` used to guard this block — and it is ALWAYS true, because
+  // a failed read yields a truthy `{} as Conference` (#848). The CFP verdict
+  // below therefore ran on an EMPTY conference and OVERWROTE the error above
+  // with "CFP Closed". Only reason about the CFP when we actually have one.
+  if (!loadingError) {
     const { isCfpOpen, canAcceptProposals } =
       await import('@/lib/conference/state')
     const contactEmail = conference.cfpEmail || conference.contactEmail

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,23 +1,34 @@
 import { Layout } from '@/components/Layout'
 import { PlatformLanding } from '@/components/PlatformLanding'
+import { PlatformUnavailable } from '@/components/PlatformUnavailable'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
-import { isUnknownHost } from '@/lib/conference/guard'
+import { isConferenceUnavailable, isUnknownHost } from '@/lib/conference/guard'
 
 export default async function MainLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const { conference, error } = await getConferenceForCurrentDomain()
+  const resolution = await getConferenceForCurrentDomain()
+
+  // ORDER MATTERS (#848). A FAILED read must be answered before the
+  // unknown-host branch, never folded into it: the two used to be
+  // indistinguishable here, so a total Sanity/network failure rendered every
+  // live tenant's homepage as `PlatformLanding` — "No conference here yet…
+  // Claim it" — inviting strangers to claim a paying customer's domain for as
+  // long as the outage lasted. We do not know what lives at this Host; say so.
+  if (isConferenceUnavailable(resolution)) {
+    return <PlatformUnavailable />
+  }
 
   // When the Host resolves to no conference, short-circuit the ENTIRE (main)
   // subtree: render one platform landing instead of the tenant chrome. Because
   // `children` is never placed in the tree, the child page's server component
   // never executes — so pages that dereference an empty conference (e.g. cfp's
   // `conference.formats.filter`) can't crash on an unknown host.
-  if (isUnknownHost({ conference, error })) {
+  if (isUnknownHost(resolution)) {
     return <PlatformLanding signupUrl={process.env.PLATFORM_SIGNUP_URL} />
   }
 
-  return <Layout conference={conference}>{children}</Layout>
+  return <Layout conference={resolution.conference}>{children}</Layout>
 }

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -113,10 +113,19 @@ async function CachedHomeContent({ domain }: { domain: string }) {
       const ticketData = await getPublicTicketTypes(
         ticketingBinding(conference),
       )
-      if (ticketData) {
+      if (ticketData.status === 'ok') {
         lowestTicketPrice = getLowestTicketPrice(ticketData.tickets)
-        ticketAvailability = getTicketAvailability(ticketData.tickets)
+        // Free types count toward AVAILABILITY even though they carry no
+        // price: a free-to-attend event with an open window is on sale, and
+        // omitting its only ticket types left it reading as `unknown`.
+        ticketAvailability = getTicketAvailability([
+          ...ticketData.tickets,
+          ...ticketData.freeTickets,
+        ])
       }
+      // `unavailable` stays null on purpose — the lifecycle model treats a null
+      // availability as "make no claim", which is the only honest answer when
+      // the vendor read failed.
     } catch (ticketError) {
       console.error('Failed to fetch ticket prices for homepage:', ticketError)
     }

--- a/src/app/(main)/tickets/page.tsx
+++ b/src/app/(main)/tickets/page.tsx
@@ -1,9 +1,14 @@
 import { getConferenceForDomain } from '@/lib/conference/sanity'
 import { isUnknownHost } from '@/lib/conference/guard'
 import { isRegistrationAvailable } from '@/lib/conference/state'
-import { getPublicTicketTypes } from '@/lib/tickets/public'
+import {
+  getPublicTicketTypes,
+  resolveDisplayTickets,
+  type PublicTicketTypesResult,
+} from '@/lib/tickets/public'
 import { hasTicketingBinding, ticketingBinding } from '@/lib/tickets/provider'
 import { TicketPricingGrid } from '@/components/TicketPricingGrid'
+import { TicketsStatusNotice } from '@/components/TicketsStatusNotice'
 import { Container } from '@/components/Container'
 import { Button } from '@/components/Button'
 import { BackgroundImage } from '@/components/BackgroundImage'
@@ -30,8 +35,6 @@ import {
   GlobeAltIcon,
   MusicalNoteIcon,
   CheckBadgeIcon,
-  CalendarDaysIcon,
-  ClockIcon,
   TicketIcon,
 } from '@heroicons/react/24/outline'
 import Link from 'next/link'
@@ -110,11 +113,18 @@ async function CachedTicketsContent({ domain }: { domain: string }) {
   // Gate on the FULL binding (customer + event id — what the resolver
   // requires) and pass only the minimal binding so the 'use cache' key stays
   // stable across unrelated conference-field changes.
-  const ticketData = hasTicketingBinding(conference)
+  const ticketData: PublicTicketTypesResult = hasTicketingBinding(conference)
     ? await getPublicTicketTypes(ticketingBinding(conference))
-    : null
+    : { status: 'not-configured' }
 
-  const hasTicketPricing = ticketData && ticketData.tickets.length > 0
+  // What we may actually SHOW. `free` is true when the event has no priced
+  // public type — a free-to-attend event, whose entire ticket list used to be
+  // filtered out on its way here (#846).
+  const display =
+    ticketData.status === 'ok'
+      ? resolveDisplayTickets(ticketData)
+      : { tickets: [], free: false }
+  const hasTicketPricing = display.tickets.length > 0
   const registrationAvailable = isRegistrationAvailable(conference)
 
   const customization = conference.ticketCustomization
@@ -183,9 +193,14 @@ async function CachedTicketsContent({ domain }: { domain: string }) {
             {/* Pricing grid */}
             <div className="rounded-2xl bg-white/95 p-6 shadow-xl ring-1 ring-brand-cloud-blue/10 backdrop-blur-sm sm:p-8 dark:bg-gray-800/95 dark:ring-gray-700">
               <TicketPricingGrid
-                tickets={ticketData.tickets}
+                tickets={display.tickets}
+                free={display.free}
                 registrationLink={conference.registrationLink}
-                complimentaryTickets={ticketData.complimentaryTickets}
+                complimentaryTickets={
+                  ticketData.status === 'ok'
+                    ? ticketData.complimentaryTickets
+                    : []
+                }
               />
             </div>
 
@@ -285,90 +300,29 @@ async function CachedTicketsContent({ domain }: { domain: string }) {
     )
   }
 
-  // Fallback: "Tickets Coming Soon" when no pricing data is available
+  // NOT a single fallback any more (#846). Which of these three is true is now
+  // knowable, because `getPublicTicketTypes` reports `unavailable` separately
+  // from an empty-but-successful read, and `registrationAvailable` is consulted
+  // here instead of only inside the pricing branch.
+  const fallbackVariant =
+    ticketData.status === 'unavailable'
+      ? 'unavailable'
+      : registrationAvailable
+        ? 'registration-open'
+        : 'coming-soon'
+
   return (
-    <div className="relative py-20 sm:pt-36 sm:pb-24">
-      <BackgroundImage className="-top-36 -bottom-14" />
-      <Container className="relative">
-        <div className="mx-auto max-w-3xl">
-          <div className="overflow-hidden rounded-2xl bg-white/95 shadow-xl ring-1 ring-brand-cloud-blue/10 backdrop-blur-sm dark:bg-gray-800/95 dark:ring-gray-700">
-            <div className="px-6 py-8 sm:px-10 sm:py-12">
-              <div className="text-center">
-                <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-brand-sky-mist dark:bg-blue-900/50">
-                  <CalendarDaysIcon className="h-8 w-8 text-brand-cloud-blue dark:text-blue-400" />
-                </div>
-
-                <h1 className="font-jetbrains mb-4 text-4xl font-bold tracking-tighter text-brand-cloud-blue sm:text-6xl dark:text-blue-400">
-                  Tickets Coming Soon
-                </h1>
-
-                <p className="font-inter mb-8 text-xl tracking-tight text-brand-slate-gray dark:text-gray-300">
-                  Tickets for {conference.title} are not yet available.
-                  We&apos;re working hard to bring you an amazing conference
-                  experience!
-                </p>
-
-                {conference.startDate && (
-                  <div className="mb-6 flex items-center justify-center text-brand-slate-gray dark:text-gray-300">
-                    <ClockIcon className="mr-2 h-5 w-5 text-brand-cloud-blue dark:text-blue-400" />
-                    <span className="font-inter text-base">
-                      Conference Dates:{' '}
-                      <time dateTime={conference.startDate}>
-                        {formatDatesSafe(
-                          conference.startDate,
-                          conference.endDate,
-                        )}
-                      </time>
-                    </span>
-                  </div>
-                )}
-
-                <div className="mb-8 rounded-xl bg-brand-sky-mist p-6 dark:bg-blue-900/50">
-                  <h3 className="font-space-grotesk mb-2 text-lg font-semibold text-brand-cloud-blue dark:text-blue-400">
-                    Get Notified
-                  </h3>
-                  <p className="font-inter text-sm text-brand-slate-gray dark:text-gray-300">
-                    Want to be the first to know when tickets become available?
-                    Follow us on social media or check back here regularly for
-                    updates.
-                  </p>
-                </div>
-
-                <div className="flex flex-col justify-center gap-4 sm:flex-row">
-                  <Button
-                    href="/"
-                    variant="primary"
-                    className="inline-flex items-center px-6 py-3"
-                  >
-                    Back to Home
-                  </Button>
-
-                  <Button
-                    href="/speaker"
-                    variant="outline"
-                    className="inline-flex items-center px-6 py-3"
-                  >
-                    View Speakers
-                  </Button>
-                </div>
-
-                <div className="mt-8 border-t border-brand-cloud-blue/20 pt-6 dark:border-gray-700">
-                  <p className="font-inter text-sm text-brand-slate-gray dark:text-gray-300">
-                    Have questions?{' '}
-                    <Link
-                      href={`mailto:${conference.contactEmail}`}
-                      className="text-brand-cloud-blue transition-colors hover:text-brand-fresh-green dark:text-blue-400 dark:hover:text-brand-fresh-green"
-                    >
-                      Contact us
-                    </Link>
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </Container>
-    </div>
+    <TicketsStatusNotice
+      variant={fallbackVariant}
+      conferenceTitle={conference.title}
+      startDate={conference.startDate}
+      endDate={conference.endDate}
+      contactEmail={conference.contactEmail}
+      registrationLink={
+        registrationAvailable ? conference.registrationLink : undefined
+      }
+      ctaText={ctaText}
+    />
   )
 }
 

--- a/src/app/api/badge/[badgeId]/verify/route.ts
+++ b/src/app/api/badge/[badgeId]/verify/route.ts
@@ -38,7 +38,32 @@ export async function GET(
       )
     }
 
-    const { badge, error } = await getBadgeById(badgeId)
+    const { badge, error, reason } = await getBadgeById(badgeId)
+
+    // A FAILED read is not a verdict (#848). This endpoint answers external
+    // verifiers — employers, other credential platforms — and a 404 is a
+    // definitive, cacheable "this credential does not exist", i.e. exactly
+    // what a forgery looks like. When the badge store is unreachable we do not
+    // know, so say 503 and invite a retry rather than impugn a real badge.
+    if (reason === 'unavailable') {
+      console.error('Badge lookup unavailable during verification:', error)
+      return NextResponse.json(
+        generateErrorResponse(
+          'Badge verification is temporarily unavailable; this is not a statement about the credential',
+          503,
+        ),
+        {
+          status: 503,
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET',
+            // Never cache a non-answer as though it were one.
+            'Cache-Control': 'no-store',
+            'Retry-After': '30',
+          },
+        },
+      )
+    }
 
     if (error || !badge) {
       return NextResponse.json({ error: 'Badge not found' }, { status: 404 })

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -3,23 +3,33 @@ import { Button } from '@/components/Button'
 import { Container } from '@/components/Container'
 import { Layout } from '@/components/Layout'
 import { PlatformLanding } from '@/components/PlatformLanding'
+import { PlatformUnavailable } from '@/components/PlatformUnavailable'
 import { headers } from 'next/headers'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
-import { isUnknownHost } from '@/lib/conference/guard'
+import { isConferenceUnavailable, isUnknownHost } from '@/lib/conference/guard'
 
 export default async function NotFound() {
   const headersList = await headers()
   const domain = headersList.get('host') || ''
-  const { conference, error } = await getConferenceForDomain(domain, {})
+  const resolution = await getConferenceForDomain(domain, {})
+
+  // ORDER MATTERS, and this file needs its OWN branch (#848). It sits OUTSIDE
+  // the (main) group, so the layout's unavailable-check never runs for it:
+  // during a Sanity outage every typo'd or unmatched URL on a live tenant's
+  // domain served the claim pitch. The 404 status keeps crawlers from banking
+  // it, but a human visitor read it.
+  if (isConferenceUnavailable(resolution)) {
+    return <PlatformUnavailable />
+  }
 
   // Unknown host: don't render the tenant chrome (Header/Footer) around empty
   // conference data — show the same platform landing every other page uses.
-  if (isUnknownHost({ conference, error })) {
+  if (isUnknownHost(resolution)) {
     return <PlatformLanding signupUrl={process.env.PLATFORM_SIGNUP_URL} />
   }
 
   return (
-    <Layout conference={conference} showFooter={false}>
+    <Layout conference={resolution.conference} showFooter={false}>
       <div className="relative flex h-full items-center py-20 sm:py-36">
         <BackgroundImage className="-top-36 bottom-0" />
         <Container className="relative flex w-full flex-col items-center">

--- a/src/components/PlatformLanding.tsx
+++ b/src/components/PlatformLanding.tsx
@@ -1,4 +1,4 @@
-import { PLATFORM_NAME } from '@/lib/branding/platform'
+import { PlatformLockup } from './PlatformLockup'
 
 export interface PlatformLandingProps {
   /**
@@ -14,6 +14,11 @@ export interface PlatformLandingProps {
  * conference. Rendered by the (main) layout in place of the tenant chrome, so
  * every public page shares ONE well-designed unknown-host screen instead of a
  * grab-bag of per-page "Conference not found" errors.
+ *
+ * ONLY for a read that SUCCEEDED and matched nothing. A failed read renders
+ * `PlatformUnavailable` instead — this screen makes a positive claim about the
+ * domain ("no conference is configured", "claim it") that an outage cannot
+ * support (#848).
  */
 export function PlatformLanding({ signupUrl }: PlatformLandingProps) {
   // Scheme hardening: the URL comes from env config, but a misconfigured
@@ -27,44 +32,7 @@ export function PlatformLanding({ signupUrl }: PlatformLandingProps) {
         className="pointer-events-none absolute inset-0 bg-linear-to-b from-brand-sky-mist/60 via-transparent to-transparent dark:from-blue-950/40"
       />
       <div className="relative flex w-full max-w-lg flex-col items-center text-center">
-        {/* This screen is the PLATFORM's own, not any tenant's, so it carries
-            the platform's lockup — reproduced from konf.app's, which is the
-            authority (RunKonf/landingpage `index.html`, `.brand-lockup`).
-
-            The lockup is a badge MARK plus the word as LIVE TEXT, not a single
-            piece of vector art: the mark is stroked ember on both grounds while
-            the word takes the ground's foreground, and the trailing dot is
-            ember in both. Geometry, stroke widths and the `#e8823c` ember are
-            copied verbatim from konf.app; the font stack mirrors its
-            `--display`. Redrawing the word as paths (what this used to do)
-            produced a lockup that was subtly not the brand's — no dot, wrong
-            letterforms. */}
-        <div className="flex items-center gap-3">
-          <svg
-            viewBox="0 0 100 100"
-            aria-hidden="true"
-            className="h-14 w-14 flex-none"
-            fill="none"
-            stroke="#e8823c"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <rect x="28" y="20" width="44" height="60" rx="9" strokeWidth="7" />
-            <line x1="44" y1="31" x2="56" y2="31" strokeWidth="6" />
-            <line x1="42" y1="44" x2="42" y2="70" strokeWidth="7" />
-            <path d="M58 44 L45 57 L58 70" strokeWidth="7" />
-          </svg>
-          <span
-            className="text-5xl leading-none font-semibold tracking-[0.01em] text-brand-slate-gray dark:text-[#e9f0f4]"
-            style={{
-              fontFamily:
-                "Futura, 'Avenir Next', 'Century Gothic', system-ui, sans-serif",
-            }}
-          >
-            {PLATFORM_NAME.toLowerCase()}
-            <span className="text-[#e8823c]">.</span>
-          </span>
-        </div>
+        <PlatformLockup />
 
         <h1 className="font-jetbrains mt-10 text-3xl font-bold tracking-tighter text-brand-slate-gray sm:text-4xl dark:text-white">
           No conference here yet

--- a/src/components/PlatformLockup.tsx
+++ b/src/components/PlatformLockup.tsx
@@ -1,0 +1,47 @@
+import { PLATFORM_NAME } from '@/lib/branding/platform'
+
+/**
+ * The PLATFORM's own lockup, not any tenant's — reproduced from konf.app's,
+ * which is the authority (RunKonf/landingpage `index.html`, `.brand-lockup`).
+ *
+ * The lockup is a badge MARK plus the word as LIVE TEXT, not a single piece of
+ * vector art: the mark is stroked ember on both grounds while the word takes
+ * the ground's foreground, and the trailing dot is ember in both. Geometry,
+ * stroke widths and the `#e8823c` ember are copied verbatim from konf.app; the
+ * font stack mirrors its `--display`. Redrawing the word as paths (what this
+ * used to do) produced a lockup that was subtly not the brand's — no dot, wrong
+ * letterforms.
+ *
+ * Shared by every platform-level screen (`PlatformLanding`,
+ * `PlatformUnavailable`) so the two cannot drift apart.
+ */
+export function PlatformLockup() {
+  return (
+    <div className="flex items-center gap-3">
+      <svg
+        viewBox="0 0 100 100"
+        aria-hidden="true"
+        className="h-14 w-14 flex-none"
+        fill="none"
+        stroke="#e8823c"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <rect x="28" y="20" width="44" height="60" rx="9" strokeWidth="7" />
+        <line x1="44" y1="31" x2="56" y2="31" strokeWidth="6" />
+        <line x1="42" y1="44" x2="42" y2="70" strokeWidth="7" />
+        <path d="M58 44 L45 57 L58 70" strokeWidth="7" />
+      </svg>
+      <span
+        className="text-5xl leading-none font-semibold tracking-[0.01em] text-brand-slate-gray dark:text-[#e9f0f4]"
+        style={{
+          fontFamily:
+            "Futura, 'Avenir Next', 'Century Gothic', system-ui, sans-serif",
+        }}
+      >
+        {PLATFORM_NAME.toLowerCase()}
+        <span className="text-[#e8823c]">.</span>
+      </span>
+    </div>
+  )
+}

--- a/src/components/PlatformUnavailable.stories.tsx
+++ b/src/components/PlatformUnavailable.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { PlatformUnavailable } from './PlatformUnavailable'
+
+const meta = {
+  title: 'Components/PlatformUnavailable',
+  component: PlatformUnavailable,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'What a visitor sees when the conference read FAILED (#848). Compare with Components/PlatformLanding, which is the SUCCESSFUL "this domain has no conference" answer: that screen invites the visitor to claim the domain, and rendering it during an outage offered a live customer\'s domain to strangers. This one asserts nothing about the Host.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof PlatformUnavailable>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = { args: {} }

--- a/src/components/PlatformUnavailable.tsx
+++ b/src/components/PlatformUnavailable.tsx
@@ -1,0 +1,43 @@
+import { PlatformLockup } from './PlatformLockup'
+
+/**
+ * Shown when the conference read FAILED — when we do not know whether this Host
+ * has a conference (#848).
+ *
+ * This screen exists because the alternative was a lie. A total Sanity/network
+ * failure used to be indistinguishable from "no conference matched", so every
+ * live tenant's site collapsed into `PlatformLanding` — "No conference here
+ * yet… Is this your domain? Claim it" — and during an outage we invited
+ * strangers to claim a paying customer's domain.
+ *
+ * Nothing here asserts anything about the Host: not that it is unclaimed, not
+ * that it is claimed. It states only what is true — that we could not load the
+ * site — and says to try again.
+ *
+ * NOINDEX is deliberate. A crawler that samples a tenant's homepage mid-outage
+ * must not bank this page as that domain's content.
+ */
+export function PlatformUnavailable() {
+  return (
+    <main className="relative flex min-h-screen w-full flex-col items-center justify-center overflow-hidden bg-brand-glacier-white px-6 py-16 dark:bg-gray-950">
+      <meta name="robots" content="noindex, nofollow" />
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 bg-linear-to-b from-brand-sky-mist/60 via-transparent to-transparent dark:from-blue-950/40"
+      />
+      <div className="relative flex w-full max-w-lg flex-col items-center text-center">
+        <PlatformLockup />
+
+        <h1 className="font-jetbrains mt-10 text-3xl font-bold tracking-tighter text-brand-slate-gray sm:text-4xl dark:text-white">
+          Temporarily unavailable
+        </h1>
+
+        <p className="font-inter mt-4 text-lg leading-relaxed text-brand-slate-gray/80 dark:text-gray-300">
+          We couldn&apos;t load this site just now. This is a problem on our
+          side, not with the address you used &mdash; please try again in a few
+          minutes.
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/src/components/TicketPricingGrid.stories.tsx
+++ b/src/components/TicketPricingGrid.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { TicketPricingGrid } from './TicketPricingGrid'
+import type { PublicTicketType } from '@/lib/tickets/public'
+
+function ticket(over: Partial<PublicTicketType> = {}): PublicTicketType {
+  return {
+    id: 1,
+    name: 'Conference',
+    type: 'standard',
+    description: null,
+    price: [{ price: '4000', vat: '25', description: null, key: null }],
+    available: null,
+    requiresInvitation: false,
+    visibleStartsAt: null,
+    visibleEndsAt: null,
+    position: 0,
+    ...over,
+  }
+}
+
+const meta = {
+  title: 'Components/TicketPricingGrid',
+  component: TicketPricingGrid,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The public pricing grid. The free-to-attend states exist because a free event\'s ticket types were filtered out of the page entirely (#846) — they now reach the grid and render as "Free" rather than as nothing or as "NOK 0".',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof TicketPricingGrid>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Paid: Story = {
+  args: {
+    tickets: [
+      ticket({ id: 1, name: 'Conference' }),
+      ticket({
+        id: 2,
+        name: 'Conference + Workshop',
+        position: 1,
+        price: [{ price: '6000', vat: '25', description: null, key: null }],
+      }),
+    ],
+    registrationLink: 'https://register.example/tickets',
+  },
+}
+
+/**
+ * A free-to-attend event. Every type costs nothing, so the VAT footnote is
+ * replaced and each price cell reads "Free".
+ */
+export const FreeToAttend: Story = {
+  args: {
+    free: true,
+    tickets: [
+      ticket({ id: 1, name: 'Conference', price: [] }),
+      ticket({
+        id: 2,
+        name: 'Workshop day',
+        position: 1,
+        price: [{ price: '0', vat: '0', description: null, key: null }],
+      }),
+    ],
+    registrationLink: 'https://register.example/free-event',
+  },
+}
+
+/** A free event with no registration link configured yet — no CTA to offer. */
+export const FreeToAttendWithoutRegistration: Story = {
+  args: {
+    free: true,
+    tickets: [ticket({ id: 1, name: 'Conference', price: [] })],
+  },
+}
+
+/** Tiered pricing, the matrix layout. */
+export const Tiered: Story = {
+  args: {
+    tickets: [
+      ticket({ id: 1, name: 'Early Bird: Conference', position: 0 }),
+      ticket({
+        id: 2,
+        name: 'Regular: Conference',
+        position: 1,
+        price: [{ price: '5000', vat: '25', description: null, key: null }],
+      }),
+      ticket({
+        id: 3,
+        name: 'Early Bird: Conference + Workshop',
+        position: 2,
+        price: [{ price: '6000', vat: '25', description: null, key: null }],
+      }),
+      ticket({
+        id: 4,
+        name: 'Regular: Conference + Workshop',
+        position: 3,
+        price: [{ price: '7000', vat: '25', description: null, key: null }],
+      }),
+    ],
+    registrationLink: 'https://register.example/tickets',
+  },
+}

--- a/src/components/TicketPricingGrid.tsx
+++ b/src/components/TicketPricingGrid.tsx
@@ -9,12 +9,42 @@ import {
 import { TicketIcon, CalendarDaysIcon } from '@heroicons/react/24/outline'
 import clsx from 'clsx'
 
+/**
+ * A ticket type with nothing to charge for it. A free-to-attend event's types
+ * reach this grid either with no price rows at all or with a single zero row;
+ * both used to render as nothing or as "NOK 0" (#846).
+ */
+function isFreeTicket(ticket: PublicTicketType): boolean {
+  return !ticket.price.some((p) => parseFloat(p.price) > 0)
+}
+
+function FreePrice({ muted = false }: { muted?: boolean }) {
+  return (
+    <div
+      className={clsx(
+        'font-space-grotesk text-xl font-bold',
+        muted
+          ? 'text-gray-400 dark:text-gray-500'
+          : 'text-brand-fresh-green dark:text-green-400',
+      )}
+    >
+      Free
+    </div>
+  )
+}
+
 interface TicketPricingGridProps {
   tickets: PublicTicketType[]
   registrationLink?: string
   currency?: string
   vatPercent?: string
   complimentaryTickets?: ComplimentaryTicketInfo[]
+  /**
+   * The event is free to attend — every type in `tickets` costs nothing. Swaps
+   * the VAT footnote, which is meaningless (and faintly alarming) under a grid
+   * of free tickets.
+   */
+  free?: boolean
 }
 
 export function TicketPricingGrid({
@@ -23,6 +53,7 @@ export function TicketPricingGrid({
   currency = 'NOK',
   vatPercent,
   complimentaryTickets = [],
+  free = false,
 }: TicketPricingGridProps) {
   const { categories, tiers, matrix } = buildPricingMatrix(tickets)
 
@@ -290,8 +321,14 @@ export function TicketPricingGrid({
 
       {/* VAT note */}
       <p className="font-inter text-center text-xs text-gray-500 dark:text-gray-400">
-        All prices in {currency} excl. {vatDisplay}% VAT
-        {hasInclVatPrimary && ' unless otherwise noted'}.
+        {free ? (
+          <>This event is free to attend.</>
+        ) : (
+          <>
+            All prices in {currency} excl. {vatDisplay}% VAT
+            {hasInclVatPrimary && ' unless otherwise noted'}.
+          </>
+        )}
         {registrationLink && (
           <>
             {' '}
@@ -321,6 +358,10 @@ function MobilePriceCell({
   currency: string
   status: 'expired' | 'active' | 'upcoming'
 }) {
+  if (isFreeTicket(ticket)) {
+    return <FreePrice muted={status === 'expired'} />
+  }
+
   const price = ticket.price[0]
   if (!price) return null
 
@@ -359,6 +400,24 @@ function PriceCell({
   showLabel?: boolean
   showInclVat?: boolean
 }) {
+  if (isFreeTicket(ticket)) {
+    return (
+      <div>
+        <FreePrice muted={status !== 'active'} />
+        {registrationLink && status === 'active' && (
+          <a
+            href={registrationLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-inter mt-2 inline-block rounded-lg bg-brand-fresh-green px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-green-700 dark:hover:bg-green-600"
+          >
+            Register
+          </a>
+        )}
+      </div>
+    )
+  }
+
   const price = ticket.price[0]
   if (!price) return null
 

--- a/src/components/TicketsStatusNotice.stories.tsx
+++ b/src/components/TicketsStatusNotice.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { TicketsStatusNotice } from './TicketsStatusNotice'
+
+const meta = {
+  title: 'Components/TicketsStatusNotice',
+  component: TicketsStatusNotice,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The three things /tickets can honestly say when it has no pricing grid to show (#846). These used to be ONE screen — "Tickets Coming Soon / Tickets for X are not yet available" — which was false for an external-registration tenant and false during a ticket-provider outage, and cached for hours either way.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    conferenceTitle: 'Cloud Native Days',
+    startDate: '2026-09-01',
+    endDate: '2026-09-02',
+    contactEmail: 'hello@example.com',
+  },
+} satisfies Meta<typeof TicketsStatusNotice>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** The ticket provider could not be reached. Claims nothing about tickets. */
+export const Unavailable: Story = {
+  args: {
+    variant: 'unavailable',
+    registrationLink: 'https://register.example/tickets',
+  },
+}
+
+/** No ticket types to price, but registration is open elsewhere. */
+export const RegistrationOpen: Story = {
+  args: {
+    variant: 'registration-open',
+    registrationLink: 'https://register.example/tickets',
+  },
+}
+
+/** The honest original: read succeeded, no tickets, registration not open. */
+export const ComingSoon: Story = {
+  args: { variant: 'coming-soon' },
+}
+
+/** An outage on a tenant that has not configured registration at all. */
+export const UnavailableWithoutRegistration: Story = {
+  args: { variant: 'unavailable' },
+}

--- a/src/components/TicketsStatusNotice.tsx
+++ b/src/components/TicketsStatusNotice.tsx
@@ -1,0 +1,198 @@
+import {
+  CalendarDaysIcon,
+  ClockIcon,
+  ExclamationTriangleIcon,
+  TicketIcon,
+} from '@heroicons/react/24/outline'
+import Link from 'next/link'
+import { Container } from '@/components/Container'
+import { Button } from '@/components/Button'
+import { BackgroundImage } from '@/components/BackgroundImage'
+import { formatDatesSafe } from '@/lib/time'
+import { PIRSCH_EVENTS } from '@/lib/analytics'
+
+/**
+ * What /tickets says when it has no pricing grid to show.
+ *
+ * There used to be ONE screen here — "Tickets Coming Soon / Tickets for X are
+ * not yet available" — and it fired for three unrelated reasons (#846): the
+ * event was free to attend (its zero-priced types were filtered away), the
+ * tenant registers attendees somewhere else entirely, or the ticket vendor read
+ * had FAILED and been cached for hours. Two of those made the page state a
+ * confident falsehood while registration was open.
+ *
+ * Each variant now says only what is actually known:
+ *
+ *  - `unavailable`        — we could not reach the ticket provider. Claims
+ *                           nothing about prices or availability. If
+ *                           registration is configured the CTA still shows:
+ *                           that fact came from the conference document, which
+ *                           we DID read.
+ *  - `registration-open`  — no ticket types to price (external registration),
+ *                           but registration is open. Send the visitor there.
+ *  - `coming-soon`        — the honest original: the read succeeded, there are
+ *                           no public ticket types, and registration is not
+ *                           open.
+ */
+export type TicketsStatusVariant =
+  'unavailable' | 'registration-open' | 'coming-soon'
+
+export interface TicketsStatusNoticeProps {
+  variant: TicketsStatusVariant
+  conferenceTitle?: string
+  startDate?: string
+  endDate?: string
+  contactEmail?: string
+  /** Rendered as the primary CTA on every variant that has one. */
+  registrationLink?: string
+  ctaText?: string
+}
+
+const COPY: Record<
+  TicketsStatusVariant,
+  { icon: typeof CalendarDaysIcon; heading: string; note?: string }
+> = {
+  unavailable: {
+    icon: ExclamationTriangleIcon,
+    heading: 'Ticket Information Unavailable',
+    note: 'This is a temporary problem on our side. Nothing here says tickets are unavailable — we simply could not load them.',
+  },
+  'registration-open': {
+    icon: TicketIcon,
+    heading: 'Registration Is Open',
+  },
+  'coming-soon': {
+    icon: CalendarDaysIcon,
+    heading: 'Tickets Coming Soon',
+    note: 'Want to be the first to know when tickets become available? Follow us on social media or check back here regularly for updates.',
+  },
+}
+
+export function TicketsStatusNotice({
+  variant,
+  conferenceTitle,
+  startDate,
+  endDate,
+  contactEmail,
+  registrationLink,
+  ctaText = 'Register Now',
+}: TicketsStatusNoticeProps) {
+  const { icon: Icon, heading, note } = COPY[variant]
+  const name = conferenceTitle || 'this conference'
+  const showRegistrationCta = Boolean(registrationLink)
+
+  return (
+    <div className="relative py-20 sm:pt-36 sm:pb-24">
+      <BackgroundImage className="-top-36 -bottom-14" />
+      <Container className="relative">
+        <div className="mx-auto max-w-3xl">
+          <div className="overflow-hidden rounded-2xl bg-white/95 shadow-xl ring-1 ring-brand-cloud-blue/10 backdrop-blur-sm dark:bg-gray-800/95 dark:ring-gray-700">
+            <div className="px-6 py-8 sm:px-10 sm:py-12">
+              <div className="text-center">
+                <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-brand-sky-mist dark:bg-blue-900/50">
+                  <Icon
+                    className="h-8 w-8 text-brand-cloud-blue dark:text-blue-400"
+                    aria-hidden="true"
+                  />
+                </div>
+
+                <h1 className="font-jetbrains mb-4 text-4xl font-bold tracking-tighter text-brand-cloud-blue sm:text-6xl dark:text-blue-400">
+                  {heading}
+                </h1>
+
+                <p className="font-inter mb-8 text-xl tracking-tight text-brand-slate-gray dark:text-gray-300">
+                  {variant === 'unavailable' && (
+                    <>
+                      We couldn&apos;t load ticket information for {name} right
+                      now. Please try again in a few minutes.
+                    </>
+                  )}
+                  {variant === 'registration-open' && (
+                    <>
+                      Registration for {name} is open. Sign up through our
+                      registration partner.
+                    </>
+                  )}
+                  {variant === 'coming-soon' && (
+                    <>
+                      Tickets for {name} are not yet available. We&apos;re
+                      working hard to bring you an amazing conference
+                      experience!
+                    </>
+                  )}
+                </p>
+
+                {startDate && (
+                  <div className="mb-6 flex items-center justify-center text-brand-slate-gray dark:text-gray-300">
+                    <ClockIcon className="mr-2 h-5 w-5 text-brand-cloud-blue dark:text-blue-400" />
+                    <span className="font-inter text-base">
+                      Conference Dates:{' '}
+                      <time dateTime={startDate}>
+                        {formatDatesSafe(startDate, endDate ?? startDate)}
+                      </time>
+                    </span>
+                  </div>
+                )}
+
+                {note && (
+                  <div className="mb-8 rounded-xl bg-brand-sky-mist p-6 dark:bg-blue-900/50">
+                    <p className="font-inter text-sm text-brand-slate-gray dark:text-gray-300">
+                      {note}
+                    </p>
+                  </div>
+                )}
+
+                <div className="flex flex-col justify-center gap-4 sm:flex-row">
+                  {showRegistrationCta && (
+                    <Button
+                      href={registrationLink!}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      variant="primary"
+                      className="inline-flex items-center px-6 py-3"
+                      data-pirsch-event={
+                        PIRSCH_EVENTS.outboundCheckinTicketsPage
+                      }
+                    >
+                      {ctaText}
+                    </Button>
+                  )}
+
+                  <Button
+                    href="/"
+                    variant={showRegistrationCta ? 'outline' : 'primary'}
+                    className="inline-flex items-center px-6 py-3"
+                  >
+                    Back to Home
+                  </Button>
+
+                  <Button
+                    href="/speaker"
+                    variant="outline"
+                    className="inline-flex items-center px-6 py-3"
+                  >
+                    View Speakers
+                  </Button>
+                </div>
+
+                {contactEmail && (
+                  <div className="mt-8 border-t border-brand-cloud-blue/20 pt-6 dark:border-gray-700">
+                    <p className="font-inter text-sm text-brand-slate-gray dark:text-gray-300">
+                      Have questions?{' '}
+                      <Link
+                        href={`mailto:${contactEmail}`}
+                        className="text-brand-cloud-blue transition-colors hover:text-brand-fresh-green dark:text-blue-400 dark:hover:text-brand-fresh-green"
+                      >
+                        Contact us
+                      </Link>
+                    </p>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </Container>
+    </div>
+  )
+}

--- a/src/lib/badge/sanity.lookup.test.ts
+++ b/src/lib/badge/sanity.lookup.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+/**
+ * #848. `getBadgeById` returned `{ error }` for BOTH "the read succeeded and
+ * no badge has this id" and "the read failed", so `/api/badge/[id]/verify`
+ * could only answer 404 — a definitive, cacheable "this credential does not
+ * exist" — to an external verifier during a Sanity outage.
+ *
+ * These tests pin the classification at the source. Without them the route's
+ * own tests would be asserting on a `reason` that the real loader might never
+ * produce.
+ */
+const badgeFetch = vi.fn()
+vi.mock('../sanity/client', () => ({
+  clientRead: { fetch: (...a: unknown[]) => badgeFetch(...a) },
+  clientWrite: { fetch: (...a: unknown[]) => badgeFetch(...a) },
+  clientReadUncached: { fetch: (...a: unknown[]) => badgeFetch(...a) },
+}))
+
+import { getBadgeById } from './sanity'
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('getBadgeById distinguishes absence from failure', () => {
+  it('reports not-found when the read succeeded and matched nothing', async () => {
+    badgeFetch.mockResolvedValue(null)
+
+    const result = await getBadgeById('no-such-badge')
+
+    expect(result.badge).toBeUndefined()
+    expect(result.reason).toBe('not-found')
+  })
+
+  it('reports unavailable when the read threw', async () => {
+    badgeFetch.mockRejectedValue(new Error('ECONNREFUSED sanity.io'))
+
+    const result = await getBadgeById('real-badge')
+
+    expect(result.badge).toBeUndefined()
+    expect(result.reason).toBe('unavailable')
+    // The two failures are no longer the same value — which is the whole fix.
+    expect(result.reason).not.toBe('not-found')
+  })
+
+  it('carries no reason at all when a badge is found', async () => {
+    badgeFetch.mockResolvedValue({ badgeId: 'real-badge' })
+
+    const result = await getBadgeById('real-badge')
+
+    expect(result.badge).toEqual({ badgeId: 'real-badge' })
+    expect(result.reason).toBeUndefined()
+    expect(result.error).toBeUndefined()
+  })
+})

--- a/src/lib/badge/sanity.ts
+++ b/src/lib/badge/sanity.ts
@@ -204,9 +204,24 @@ export async function patchBadgeArtifacts(
   }
 }
 
-export async function getBadgeById(
-  badgeId: string,
-): Promise<{ badge?: BadgeRecord; error?: Error }> {
+/**
+ * Why a badge lookup produced no badge.
+ *
+ *  - `not-found`   — the read SUCCEEDED and no badge carries this id.
+ *  - `unavailable` — the read FAILED. Whether the badge exists is UNKNOWN.
+ *
+ * These were the same `{ error }` (#848), which mattered most at
+ * `/api/badge/[badgeId]/verify`: that endpoint is consumed by employers and
+ * other platforms we do not control, and a Sanity blip answered them with a
+ * definitive 404 — indistinguishable, to them, from a forged credential.
+ */
+export type BadgeLookupReason = 'not-found' | 'unavailable'
+
+export async function getBadgeById(badgeId: string): Promise<{
+  badge?: BadgeRecord
+  error?: Error
+  reason?: BadgeLookupReason
+}> {
   try {
     const badge = await clientRead.fetch<BadgeRecord>(
       `*[_type == "speakerBadge" && badgeId == $badgeId][0]{${BADGE_FIELDS}}`,
@@ -214,13 +229,13 @@ export async function getBadgeById(
     )
 
     if (!badge) {
-      return { error: new Error('Badge not found') }
+      return { error: new Error('Badge not found'), reason: 'not-found' }
     }
 
     return { badge }
   } catch (error) {
     console.error('Failed to fetch badge:', error)
-    return { error: error as Error }
+    return { error: error as Error, reason: 'unavailable' }
   }
 }
 

--- a/src/lib/conference/guard.test.ts
+++ b/src/lib/conference/guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isUnknownHost } from './guard'
+import { isUnknownHost, isConferenceUnavailable } from './guard'
 import type { Conference } from './types'
 
 // A minimal resolved conference — only `_id` matters to the guard.
@@ -46,5 +46,59 @@ describe('isUnknownHost', () => {
   it('tolerates an omitted error field', () => {
     expect(isUnknownHost({ conference: resolved })).toBe(false)
     expect(isUnknownHost({ conference: {} as Conference })).toBe(true)
+  })
+
+  it('is FALSE for a failed read — an outage is not an unclaimed domain', () => {
+    // #848. The empty conference is byte-identical in both worlds; only the
+    // status separates them. Without this, `PlatformLanding` invites strangers
+    // to claim a live customer's domain for the length of an outage.
+    expect(
+      isUnknownHost({
+        conference: {} as Conference,
+        error: new Error('ECONNREFUSED'),
+        status: 'unavailable',
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('isConferenceUnavailable', () => {
+  it('is true only for a FAILED read', () => {
+    expect(
+      isConferenceUnavailable({
+        conference: {} as Conference,
+        error: new Error('ECONNREFUSED'),
+        status: 'unavailable',
+      }),
+    ).toBe(true)
+  })
+
+  it('is false for a host that demonstrably has no conference', () => {
+    expect(
+      isConferenceUnavailable({
+        conference: {} as Conference,
+        error: new Error('Conference not found for domain: nope.example'),
+        status: 'not-found',
+      }),
+    ).toBe(false)
+  })
+
+  it('is false for a resolved conference, even alongside a secondary error', () => {
+    expect(
+      isConferenceUnavailable({
+        conference: resolved,
+        error: new Error('gallery read failed'),
+        status: 'resolved',
+      }),
+    ).toBe(false)
+  })
+
+  it('never guesses: no status means no unavailability claim', () => {
+    // Callers that hold only a conference (e.g. TenantThemeStyle) must not be
+    // silently told "unavailable" — the whole point is to stop asserting
+    // things we have not established.
+    expect(isConferenceUnavailable({ conference: {} as Conference })).toBe(
+      false,
+    )
   })
 })

--- a/src/lib/conference/guard.ts
+++ b/src/lib/conference/guard.ts
@@ -1,12 +1,39 @@
 import type { Conference } from './types'
 
 /**
+ * How a Host resolved — the seam that makes "we don't know" REPRESENTABLE.
+ *
+ * `getConferenceForDomain` hands back a TRUTHY `{} as Conference` whether the
+ * read succeeded and matched nothing or the read blew up, so `conference` alone
+ * cannot tell the two apart and every consumer that reasoned about it picked
+ * the confident answer: "no conference is configured for this domain".
+ *
+ *  - `resolved`    — a conference document owns this Host.
+ *  - `not-found`   — the read SUCCEEDED and no conference claims this Host
+ *                    (or its domain claim no longer carries a DNS proof).
+ *                    A statement about the world.
+ *  - `unavailable` — the read FAILED. We do not know whether a conference
+ *                    exists here. NOTHING may be asserted about this Host:
+ *                    not "unclaimed", not "CFP closed", not "no tickets".
+ */
+export type ConferenceResolutionStatus =
+  'resolved' | 'not-found' | 'unavailable'
+
+/**
  * The shape returned by `getConferenceForDomain` /
  * `getConferenceForCurrentDomain` that callers must inspect before rendering.
  */
 export interface ConferenceResolution {
   conference: Conference
   error?: Error | null
+  /**
+   * Optional so a caller holding only a conference (e.g. `TenantThemeStyle`,
+   * which receives one as a prop) can still ask `isUnknownHost`. When it is
+   * absent the guards fall back to the pre-status behaviour — which is why
+   * `isConferenceUnavailable` answers `false` rather than guessing: only a
+   * resolution that POSITIVELY reports `unavailable` is unavailable.
+   */
+  status?: ConferenceResolutionStatus
 }
 
 /**
@@ -16,12 +43,34 @@ export interface ConferenceResolution {
  * `error`) when a Host resolves to no conference, so a bare `!conference`
  * NEVER fires and dereferencing fields like `conference.formats` throws.
  * Every public (main) page and the (main) layout must gate on this instead.
+ *
+ * A FAILED read is NOT an unknown host (#848). It used to be treated as one,
+ * so a Sanity outage turned every live tenant's site into an unsold domain
+ * offering itself up to be claimed. Check `isConferenceUnavailable` FIRST.
  */
-export function isUnknownHost({ conference }: ConferenceResolution): boolean {
+export function isUnknownHost({
+  conference,
+  status,
+}: ConferenceResolution): boolean {
   // ONLY the absence of a resolved conference counts as unknown-host. An
   // `error` alongside a VALID conference (partial/secondary read failure) must
   // NOT flip the whole site to the platform landing — pages keep their own
   // error handling for that case (e.g. the terms page's conferenceError
   // branch, which a Boolean(error) test here would render unreachable).
+  if (status) return status === 'not-found'
   return !conference?._id
+}
+
+/**
+ * Did the conference read FAIL?
+ *
+ * True only when we could not find out whether this Host has a conference —
+ * never for a Host that demonstrably has none. Callers must render an
+ * "unavailable, try again" state: no claim about the tenant, the CFP or
+ * ticket availability is supportable here.
+ */
+export function isConferenceUnavailable({
+  status,
+}: ConferenceResolution): boolean {
+  return status === 'unavailable'
 }

--- a/src/lib/conference/sanity.ts
+++ b/src/lib/conference/sanity.ts
@@ -2,6 +2,7 @@ import { clientWrite, clientReadUncached } from '../sanity/client'
 import { Conference } from './types'
 import { normalizeDomain } from './domains'
 import { normalizeConference } from './normalize'
+import type { ConferenceResolutionStatus } from './guard'
 import { isConferenceOver } from './state'
 import { headers } from 'next/headers'
 import { cacheLife, cacheTag } from 'next/cache'
@@ -67,6 +68,7 @@ export async function getConferenceForCurrentDomain({
   conference: Conference
   domain: string
   error: Error | null
+  status: ConferenceResolutionStatus
 }> {
   const headersList = await headers()
   const domain = headersList.get('host') || ''
@@ -85,7 +87,9 @@ export async function getConferenceForCurrentDomain({
   } catch (err) {
     const error = err as Error
     const conference = normalizeConference({} as Conference)
-    return { conference, domain, error }
+    // We never got far enough to learn anything about this Host. `unavailable`,
+    // NOT `not-found` — see ./guard.ts.
+    return { conference, domain, error, status: 'unavailable' }
   }
 }
 
@@ -127,9 +131,17 @@ export async function getConferenceForDomain(
      */
     uncached?: boolean
   } = {},
-): Promise<{ conference: Conference; domain: string; error: Error | null }> {
+): Promise<{
+  conference: Conference
+  domain: string
+  error: Error | null
+  status: ConferenceResolutionStatus
+}> {
   let conference = {} as Conference
   let error = null
+  // Pessimistic default: nothing has been read yet, so nothing is known. Every
+  // exit below overwrites this deliberately.
+  let status: ConferenceResolutionStatus = 'unavailable'
 
   // Normalize the incoming Host to the SAME canonical form the stored `domains[]`
   // entries carry (they are trim+lowercased by `normalizeDomain` on write, and
@@ -312,6 +324,7 @@ export async function getConferenceForDomain(
 
     if (conferenceData) {
       conference = conferenceData
+      status = 'resolved'
 
       if (sponsors && conference._id) {
         conference.sponsors = await getPublicSponsorsForConference(
@@ -366,7 +379,10 @@ export async function getConferenceForDomain(
         }
       }
     } else {
-      // Conference not found
+      // Conference not found. The read SUCCEEDED — this is a statement about
+      // the world, and the only case in which callers may tell a visitor that
+      // no conference is configured for this domain.
+      status = 'not-found'
       error = new Error('Conference not found for domain: ' + host)
       conference = {} as Conference
 
@@ -381,6 +397,12 @@ export async function getConferenceForDomain(
     }
   } catch (err) {
     error = err as Error
+    // A SECONDARY read (sponsors, gallery) can throw after the conference
+    // itself resolved. That is a partial failure: we do know which conference
+    // owns this Host, so the resolution stays `resolved` and the page keeps its
+    // own error handling. Only a failure that leaves us WITHOUT a conference —
+    // the conference read itself, or the routing gate — is `unavailable`.
+    status = conference?._id ? 'resolved' : 'unavailable'
     // Set default empty arrays for gallery if error occurs
     if (gallery && conference) {
       conference.featuredGalleryImages = []
@@ -394,7 +416,7 @@ export async function getConferenceForDomain(
   // tenant has no `topics` (see @/lib/onboarding/create.ts), any conference can
   // lose its `formats` the moment an organizer empties the list, and the public
   // CFP page dereferences both. See ./normalize.ts.
-  return { conference: normalizeConference(conference), domain, error }
+  return { conference: normalizeConference(conference), domain, error, status }
 }
 
 /**

--- a/src/lib/conference/unknown-host.test.ts
+++ b/src/lib/conference/unknown-host.test.ts
@@ -44,7 +44,7 @@ vi.mock('@/lib/sponsor-crm/sanity', () => ({
 }))
 
 import { getConferenceForDomain } from './sanity'
-import { isUnknownHost } from './guard'
+import { isUnknownHost, isConferenceUnavailable } from './guard'
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -103,5 +103,70 @@ describe('getConferenceForDomain — unknown host gets NO gallery (#616)', () =>
       },
       { useCache: true },
     )
+  })
+})
+
+/**
+ * #848. The loader is where "we don't know" becomes representable. Every
+ * downstream honesty fix rests on it classifying correctly here.
+ */
+describe('getConferenceForDomain — a failed read is not a missing conference', () => {
+  it('classifies a thrown read as `unavailable`, never `not-found`', async () => {
+    conferenceFetchMock.mockRejectedValue(new Error('ECONNREFUSED sanity.io'))
+
+    const result = await getConferenceForDomain('live-tenant.example')
+
+    expect(result.status).toBe('unavailable')
+    expect(isConferenceUnavailable(result)).toBe(true)
+    // The empty conference is IDENTICAL to the unknown-host one; only the
+    // status tells them apart, which is exactly what the layout branches on.
+    expect(result.conference._id).toBeUndefined()
+    expect(isUnknownHost(result)).toBe(false)
+  })
+
+  it('classifies a successful miss as `not-found`', async () => {
+    conferenceFetchMock.mockResolvedValue(null)
+
+    const result = await getConferenceForDomain('nobody.example.com')
+
+    expect(result.status).toBe('not-found')
+    expect(isUnknownHost(result)).toBe(true)
+    expect(isConferenceUnavailable(result)).toBe(false)
+  })
+
+  it('classifies a match as `resolved`', async () => {
+    conferenceFetchMock.mockResolvedValue({
+      _id: 'conf-1',
+      title: 'Cloud Native Days',
+      domains: ['cnd.example'],
+    })
+
+    const result = await getConferenceForDomain('cnd.example')
+
+    expect(result.status).toBe('resolved')
+    expect(isUnknownHost(result)).toBe(false)
+    expect(isConferenceUnavailable(result)).toBe(false)
+  })
+
+  it('keeps a PARTIAL failure `resolved` — a secondary read is not the site', async () => {
+    // The conference itself read fine; the gallery blew up afterwards. The
+    // site must render, with the page's own error handling intact, not
+    // collapse to an outage screen.
+    conferenceFetchMock.mockResolvedValue({
+      _id: 'conf-1',
+      title: 'Cloud Native Days',
+      domains: ['cnd.example'],
+    })
+    getFeaturedGalleryImagesMock.mockRejectedValueOnce(
+      new Error('gallery read failed'),
+    )
+
+    const result = await getConferenceForDomain('cnd.example', {
+      gallery: { featuredOnly: true },
+    })
+
+    expect(result.error).toBeInstanceOf(Error)
+    expect(result.status).toBe('resolved')
+    expect(isConferenceUnavailable(result)).toBe(false)
   })
 })

--- a/src/lib/tickets/provider/index.ts
+++ b/src/lib/tickets/provider/index.ts
@@ -2,10 +2,17 @@ import { CheckinProvider } from './checkin'
 import { TitoProvider } from './tito'
 import { resolveTenantSecrets, perOrgSecretsStore } from '@/lib/secrets/store'
 import { isPlatformOrganization } from '@/lib/features/platform'
+// Every name re-exported below must be BOUND BEFORE the export block. TypeScript
+// hoists imports so a later `import type` compiles fine, but Storybook's Babel
+// docgen pass strips type-only imports and then fails the file with "Export
+// 'CheckinEventRef' is not defined" — which takes down `build-storybook` for any
+// story whose component graph reaches this barrel.
 import type {
   EventRef,
   TicketingProvider,
   TicketingProviderCredentials,
+  CheckinEventRef,
+  TitoEventRef,
 } from './types'
 
 export type {
@@ -25,7 +32,6 @@ export type {
   CheckinOrderCreatedData,
   CheckinWebhookUser,
 } from './types'
-import type { CheckinEventRef, TitoEventRef } from './types'
 
 /** Provider discriminator. Checkin.no is the default; Tito (this PR) is the
  * second provider — the proof the adapter generalizes. */

--- a/src/lib/tickets/public.test.ts
+++ b/src/lib/tickets/public.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, assert } from 'vitest'
 
 // B7: getPublicTicketTypes must route through the request-boundary resolver so a
 // tenant's per-org Checkin key is honored, and must preserve the prior soft-fail
@@ -14,7 +14,11 @@ vi.mock('./provider', () => ({
     resolveTicketingProviderMock(...a),
 }))
 
-import { getPublicTicketTypes, getTicketAvailability } from './public'
+import {
+  getPublicTicketTypes,
+  getTicketAvailability,
+  resolveDisplayTickets,
+} from './public'
 import type { PublicTicketType } from './provider/types'
 
 const CONF = {
@@ -58,19 +62,23 @@ describe('getPublicTicketTypes — resolver routing (B7)', () => {
       customerId: 42,
       eventId: 7,
     })
-    expect(result?.tickets).toHaveLength(1)
+    expect(result.status).toBe('ok')
+    assert(result.status === 'ok')
+    expect(result.tickets).toHaveLength(1)
   })
 
-  it('soft-fails to null when the conference is unconfigured', async () => {
+  it('reports not-configured (never throws) when the conference is unconfigured', async () => {
     resolveTicketingProviderMock.mockResolvedValue({
       configured: false,
       provider: null,
       eventRef: null,
     })
-    expect(await getPublicTicketTypes({})).toBeNull()
+    expect(await getPublicTicketTypes({})).toEqual({
+      status: 'not-configured',
+    })
   })
 
-  it('soft-fails to null (never throws) when the provider fetch errors', async () => {
+  it('reports unavailable (never throws) when the provider fetch errors', async () => {
     resolveTicketingProviderMock.mockResolvedValue({
       configured: true,
       provider: {
@@ -80,7 +88,114 @@ describe('getPublicTicketTypes — resolver routing (B7)', () => {
       },
       eventRef: { customerId: 42, eventId: 7 },
     })
-    expect(await getPublicTicketTypes(CONF)).toBeNull()
+    const result = await getPublicTicketTypes(CONF)
+    expect(result.status).toBe('unavailable')
+  })
+})
+
+/**
+ * #846. A failed vendor read and an event that genuinely publishes no tickets
+ * both used to be `null`, and an all-free event was filtered down to `[]` —
+ * three different worlds, one confident "tickets are not yet available".
+ */
+describe('getPublicTicketTypes — empty is not unknown, and free is not empty', () => {
+  function withTickets(tickets: Record<string, unknown>[]) {
+    resolveTicketingProviderMock.mockResolvedValue({
+      configured: true,
+      provider: {
+        fetchPublicTicketTypes: vi
+          .fn()
+          .mockResolvedValue({ event: { id: 7, name: 'Event' }, tickets }),
+      },
+      eventRef: { customerId: 42, eventId: 7 },
+    })
+  }
+
+  it('an all-free event keeps its ticket types instead of vanishing', async () => {
+    withTickets([
+      pubTicket({ id: 1, name: 'Free entry', price: [] }),
+      pubTicket({
+        id: 2,
+        name: 'Free entry (day 2)',
+        price: [{ price: '0', vat: '0' }],
+      }),
+    ])
+
+    const result = await getPublicTicketTypes(CONF)
+
+    assert(result.status === 'ok')
+    // No priced types — but the event HAS tickets, and now says so.
+    expect(result.tickets).toHaveLength(0)
+    expect(result.freeTickets.map((t) => t.name)).toEqual([
+      'Free entry',
+      'Free entry (day 2)',
+    ])
+  })
+
+  it('a genuinely empty event is distinguishable from a failed read', async () => {
+    withTickets([])
+    const empty = await getPublicTicketTypes(CONF)
+
+    resolveTicketingProviderMock.mockResolvedValue({
+      configured: true,
+      provider: {
+        fetchPublicTicketTypes: vi.fn().mockRejectedValue(new Error('boom')),
+      },
+      eventRef: { customerId: 42, eventId: 7 },
+    })
+    const failed = await getPublicTicketTypes(CONF)
+
+    // THE point of the union: these two must not be the same value.
+    expect(empty.status).toBe('ok')
+    expect(failed.status).toBe('unavailable')
+    expect(empty.status).not.toBe(failed.status)
+  })
+
+  it('invitation-only types are in neither public bucket', async () => {
+    withTickets([
+      pubTicket({ id: 1, name: 'Crew', price: [], requiresInvitation: true }),
+      pubTicket({ id: 2, name: 'Free entry', price: [] }),
+    ])
+
+    const result = await getPublicTicketTypes(CONF)
+
+    assert(result.status === 'ok')
+    expect(result.tickets).toHaveLength(0)
+    expect(result.freeTickets.map((t) => t.name)).toEqual(['Free entry'])
+  })
+})
+
+describe('resolveDisplayTickets', () => {
+  const paid = pubTicket({ id: 1, name: 'General' }) as PublicTicketType
+  const gratis = pubTicket({
+    id: 2,
+    name: 'Free entry',
+    price: [],
+  }) as unknown as PublicTicketType
+
+  it('shows the free types when the event has no priced type', () => {
+    const { tickets, free } = resolveDisplayTickets({
+      tickets: [],
+      freeTickets: [gratis],
+    })
+    expect(tickets).toEqual([gratis])
+    expect(free).toBe(true)
+  })
+
+  it('shows only the priced types when the event charges for entry', () => {
+    // The deliberate limit: a paid event's zero-priced types are crew/organizer
+    // far more often than they are public, so they do NOT join the paid grid.
+    const { tickets, free } = resolveDisplayTickets({
+      tickets: [paid],
+      freeTickets: [gratis],
+    })
+    expect(tickets).toEqual([paid])
+    expect(free).toBe(false)
+  })
+
+  it('shows nothing, and does not claim to be free, when there is nothing', () => {
+    const { tickets } = resolveDisplayTickets({ tickets: [], freeTickets: [] })
+    expect(tickets).toEqual([])
   })
 })
 

--- a/src/lib/tickets/public.ts
+++ b/src/lib/tickets/public.ts
@@ -116,14 +116,22 @@ export async function getPublicTicketTypes(
  *
  * FREE TYPES ARE SHOWN ONLY WHEN THE EVENT IS FREE TO ATTEND — i.e. when it has
  * no priced public type. Deliberate: on a paid event the zero-priced types in a
- * vendor's list are overwhelmingly internal (crew, organizer, comped), and the
- * subset that genuinely belongs on the public page already has a route there
- * via `extractComplimentaryTickets` (speaker/volunteer, description required).
- * Surfacing every free type next to the paid grid would publish the crew list.
+ * vendor's list are overwhelmingly internal (crew, organizer, comped), and
+ * surfacing all of them next to the paid grid would publish the crew list.
+ * `requiresInvitation` is NOT a safe discriminator to lean on instead — this
+ * data comes from the authenticated admin API, so a crew type an organizer
+ * forgot to flag would be published.
  *
- * KNOWN GAP: a paid event with a genuinely public free tier (a free student
- * ticket alongside paid ones) is not covered by this rule and still needs the
- * complimentary route or a priced-at-zero entry.
+ * KNOWN GAP, and it is a REAL one: a paid event's genuinely public free tier
+ * (a free student ticket alongside paid ones) is dropped. Do not read
+ * `extractComplimentaryTickets` as a fallback for it — that helper is gated on
+ * a NAME matching /speaker/i or /volunteer/i AND a non-empty description (see
+ * COMPLIMENTARY_TICKET_CONFIG below), so it rescues nothing named otherwise.
+ * The only route today is to price the tier at a symbolic non-zero amount.
+ *
+ * This rule is byte-identical to the behaviour that shipped before it: a paid
+ * event's free types were already filtered out. It mis-serves nobody it did not
+ * already, while fixing the all-free event outright.
  */
 export function resolveDisplayTickets(result: {
   tickets: PublicTicketType[]

--- a/src/lib/tickets/public.ts
+++ b/src/lib/tickets/public.ts
@@ -26,13 +26,43 @@ export interface ComplimentaryTicketInfo {
   link: string | null
 }
 
+/**
+ * The outcome of a public ticket read — a UNION, because "we have no tickets to
+ * show you" had three completely different causes that all collapsed into
+ * `null` (#846):
+ *
+ *  - `ok`              — the vendor answered. `tickets`/`freeTickets` may still
+ *                        be empty; that is now a claim we are entitled to make.
+ *  - `not-configured`  — this conference has no ticketing binding. Nothing was
+ *                        asked of any vendor.
+ *  - `unavailable`     — the vendor read FAILED. We do NOT know what tickets
+ *                        exist, what they cost, or whether any are on sale.
+ *                        Callers must not render an availability claim.
+ *
+ * The old `null` meant all three at once, so a checkin.no outage rendered as
+ * "Tickets for X are not yet available" — cached for hours.
+ */
+export type PublicTicketTypesResult =
+  | {
+      status: 'ok'
+      event: PublicEventInfo
+      /** Public (non-invitation) types with at least one price above zero. */
+      tickets: PublicTicketType[]
+      /**
+       * Public (non-invitation) types with NO price above zero — the ticket
+       * list of a free-to-attend event, which used to be filtered away
+       * entirely, leaving `tickets: []` and the page claiming that tickets
+       * were not yet available (#846).
+       */
+      freeTickets: PublicTicketType[]
+      complimentaryTickets: ComplimentaryTicketInfo[]
+    }
+  | { status: 'not-configured' }
+  | { status: 'unavailable'; error: Error }
+
 export async function getPublicTicketTypes(
   conference: ConferenceTicketingBinding,
-): Promise<{
-  event: PublicEventInfo
-  tickets: PublicTicketType[]
-  complimentaryTickets: ComplimentaryTicketInfo[]
-} | null> {
+): Promise<PublicTicketTypesResult> {
   'use cache'
   cacheLife('hours')
   cacheTag('content:tickets')
@@ -47,7 +77,7 @@ export async function getPublicTicketTypes(
     // this function's 'use cache' key minimal) so the fetch is skipped rather
     // than resolved-and-refused.
     const ticketing = await resolveTicketingProvider(conference)
-    if (!ticketing.configured) return null
+    if (!ticketing.configured) return { status: 'not-configured' }
     // Pass the provider-shaped eventRef (not a bare event id) so a Tito-bound
     // conference routes to its account/event slugs; Checkin ignores the extra
     // customerId and uses the event id.
@@ -55,20 +85,54 @@ export async function getPublicTicketTypes(
       ticketing.eventRef,
     )
 
-    // Filter to only public tickets: not invite-only, has at least one price > 0
+    // Public = not invite-only. The list is then SPLIT by price rather than
+    // filtered down to the priced ones: a free-to-attend event's entire ticket
+    // list is priced at zero, and dropping it made the event indistinguishable
+    // from one that has published no tickets at all (#846).
     const publicTickets = data.tickets
       .filter((t) => !t.requiresInvitation)
-      .filter((t) => t.price.some((p) => parseFloat(p.price) > 0))
       .sort((a, b) => a.position - b.position)
+    const isPriced = (t: PublicTicketType) =>
+      t.price.some((p) => parseFloat(p.price) > 0)
 
     // Extract complimentary tickets (invite-only or free) that have descriptions
     const complimentaryTickets = extractComplimentaryTickets(data.tickets)
 
-    return { event: data.event, tickets: publicTickets, complimentaryTickets }
+    return {
+      status: 'ok',
+      event: data.event,
+      tickets: publicTickets.filter(isPriced),
+      freeTickets: publicTickets.filter((t) => !isPriced(t)),
+      complimentaryTickets,
+    }
   } catch (error) {
     console.error('Failed to fetch public ticket types:', error)
-    return null
+    return { status: 'unavailable', error: error as Error }
   }
+}
+
+/**
+ * The ticket types to SHOW the public, and whether they are free.
+ *
+ * FREE TYPES ARE SHOWN ONLY WHEN THE EVENT IS FREE TO ATTEND — i.e. when it has
+ * no priced public type. Deliberate: on a paid event the zero-priced types in a
+ * vendor's list are overwhelmingly internal (crew, organizer, comped), and the
+ * subset that genuinely belongs on the public page already has a route there
+ * via `extractComplimentaryTickets` (speaker/volunteer, description required).
+ * Surfacing every free type next to the paid grid would publish the crew list.
+ *
+ * KNOWN GAP: a paid event with a genuinely public free tier (a free student
+ * ticket alongside paid ones) is not covered by this rule and still needs the
+ * complimentary route or a priced-at-zero entry.
+ */
+export function resolveDisplayTickets(result: {
+  tickets: PublicTicketType[]
+  freeTickets: PublicTicketType[]
+}): { tickets: PublicTicketType[]; free: boolean } {
+  if (result.tickets.length > 0) {
+    return { tickets: result.tickets, free: false }
+  }
+  return { tickets: result.freeTickets, free: true }
 }
 
 /**

--- a/src/server/routers/conference.homepagePreview.test.ts
+++ b/src/server/routers/conference.homepagePreview.test.ts
@@ -90,15 +90,19 @@ beforeEach(() => {
     conference: domainConference(),
     domain: 'cloudnativebergen.no',
     error: null,
+    status: 'resolved',
   })
   getConferenceForDomainMock.mockResolvedValue({
     conference: domainConference(),
     domain: 'cloudnativebergen.no',
     error: null,
+    status: 'resolved',
   })
   getPublicTicketTypesMock.mockResolvedValue({
+    status: 'ok',
     event: {},
     tickets: [{ amount: 3490 }],
+    freeTickets: [],
     complimentaryTickets: [],
   })
 })
@@ -156,6 +160,23 @@ describe('conference.homepagePreviewData', () => {
     expect(result.ticketsFromPrice).toBeNull()
     expect(result.ticketAvailability).toBeNull()
     errorSpy.mockRestore()
+  })
+
+  it('degrades to plain labels on the SOFT failure too (#846)', async () => {
+    // `getPublicTicketTypes` no longer rejects — it reports `unavailable`. The
+    // preview must make no availability claim from it, exactly as the public
+    // homepage does not.
+    getPublicTicketTypesMock.mockResolvedValue({
+      status: 'unavailable',
+      error: new Error('checkin.no is down'),
+    })
+
+    const result = await makeCaller({
+      isOrganizer: true,
+    }).homepagePreviewData()
+
+    expect(result.ticketsFromPrice).toBeNull()
+    expect(result.ticketAvailability).toBeNull()
   })
 
   it('skips the ticket call entirely without a full ticketing binding', async () => {

--- a/src/server/routers/conference.ts
+++ b/src/server/routers/conference.ts
@@ -1193,10 +1193,15 @@ export const conferenceRouter = router({
         const ticketData = await getPublicTicketTypes(
           ticketingBinding(conference),
         )
-        if (ticketData) {
+        if (ticketData.status === 'ok') {
           ticketsFromPrice =
             getLowestTicketPrice(ticketData.tickets)?.formatted ?? null
-          ticketAvailability = getTicketAvailability(ticketData.tickets)
+          // Mirrors the public homepage exactly (free types count toward
+          // availability) so the preview shows the same bytes.
+          ticketAvailability = getTicketAvailability([
+            ...ticketData.tickets,
+            ...ticketData.freeTickets,
+          ])
         }
       } catch (ticketError) {
         console.error(


### PR DESCRIPTION
Fixes #846 and #848 together — they are one bug.

## Root cause

A thrown read produced a **truthy** empty value, so every `if (x)` downstream succeeded and reasoned about emptiness. `getConferenceForDomain` returns `normalizeConference({} as Conference)`; `getPublicTicketTypes` returned `null`; `getBadgeById` returned `{ error }`. In each case "we could not find out" was byte-identical to "there is nothing", so the code picked the confident answer and served it with a 200.

This is not #825 (no error boundaries). A 500 is honest. These pages returned 200 and lied.

The fix is one shape applied four times: **make "unknown" representable in the return type, then branch on it.**

## What changed

### Conference resolution (#848)

`getConferenceForDomain` / `getConferenceForCurrentDomain` now report a `status`:

| status | meaning |
|---|---|
| `resolved` | a conference owns this Host |
| `not-found` | the read **succeeded** and nothing claims this Host |
| `unavailable` | the read **failed**; nothing may be asserted |

`isUnknownHost` is true only for `not-found`. New `isConferenceUnavailable` is true only for `unavailable`, and answers `false` when no status is present — it never guesses. A secondary read failing after the conference resolved (gallery, sponsors) stays `resolved`, preserving the partial-failure behaviour the guard's existing comment protects.

**1. A Sanity outage no longer puts a live tenant's domain up for sale.** `src/app/(main)/layout.tsx` short-circuited the whole `(main)` subtree into `PlatformLanding` — "No conference here yet… Is this your domain? **Claim it**" — for the length of any outage. It now renders a new `PlatformUnavailable`, which asserts nothing about the Host and carries `noindex` so a crawler cannot bank the outage page as the tenant's content.

**2. The root 404 no longer serves the claim pitch during an outage.** `src/app/not-found.tsx` sits **outside** the `(main)` group, so the layout's short-circuit never covered it, and it dropped the resolution `status` when calling `isUnknownHost` — so a failed read still rendered `PlatformLanding`. During an outage, **every typo'd or unmatched URL on a live tenant's domain** served "No conference here yet… Claim it". The 404 status keeps crawlers from banking it; a human visitor read it. Caught in adversarial review of this PR, not by me — my original honesty note claimed the layout short-circuit covered the outage path, which is true for `(main)` pages and was false here. `PlatformLanding` now renders from exactly two places, both checking `isConferenceUnavailable` first.

**3. A failed conference read no longer closes an open CFP.** `src/app/(cfp)/cfp/proposal/page.tsx` correctly set a Server Error, then `if (conference)` — always true — re-entered and **overwrote** it with "CFP Closed", because `isCfpOpen({})` is false. The block is now guarded on `!loadingError`, and an outage gets its own "Temporarily Unavailable" copy rather than turning a speaker away from a call that is open.

**4. Badge verification no longer reports an outage as a missing credential.** `getBadgeById` returned the same `{ error }` for "no such badge" and "store unreachable", so `/api/badge/[badgeId]/verify` answered a definitive, cacheable **404** — which, to the external platforms that consume this endpoint, is what a forged credential looks like. It now returns a `reason`, and the route answers **503** with `Cache-Control: no-store` and `Retry-After`, emitting no verification verdict at all.

### Public /tickets (#846)

`getPublicTicketTypes` returns a union instead of one `null` that meant three different things:

```ts
type PublicTicketTypesResult =
  | { status: 'ok'; event; tickets; freeTickets; complimentaryTickets }
  | { status: 'not-configured' }
  | { status: 'unavailable'; error }
```

and it **splits** public types into priced and free rather than filtering the free ones away.

The single "Tickets Coming Soon / Tickets for X are not yet available" fallback — which never consulted `registrationAvailable`, computed at `:118` and used only at `:193` — becomes three states in a new `TicketsStatusNotice`:

- **free-to-attend event** → reaches the pricing grid, rendered as "Free", with the VAT footnote replaced. This was the headline bug: the free plan's entire constituency could never show its tickets.
- **external-registration tenant** → "Registration Is Open" plus the register CTA, instead of denying tickets exist while the homepage offers them.
- **provider outage** → "Ticket Information Unavailable". Still shows the register CTA, because that fact came from the conference document, which was read successfully.
- **genuinely nothing** → the original copy, unchanged.

Free ticket availability now also feeds `getTicketAvailability` on the homepage and in the composer preview, so a free event with an open window reads as on sale rather than `unknown`.

## A decision worth flagging

**Free types are surfaced only when the event has no priced type.** On a paid event, a zero-priced type in a vendor's list is overwhelmingly internal (crew, organizer), and publishing all of them next to the paid grid would publish the crew list. `requiresInvitation` is **not** a safe discriminator to lean on instead: this data comes from the authenticated admin API, so a crew type an organizer forgot to flag would be published.

**Known gap, and it is a real one:** a paid event's genuinely public free tier — a free student ticket alongside paid ones, or a symbolic-price event's free tier — is **dropped**. An earlier draft of this PR said such types "already have a route" via `extractComplimentaryTickets`. **That was overstated and is now corrected in the code comment**: that helper is gated on a name matching `/speaker/i` or `/volunteer/i` **and** a non-empty description (`public.ts:415-450`), so it rescues nothing named otherwise. The only route today is to price the tier at a symbolic non-zero amount.

What makes this acceptable to ship: the rule is **byte-identical to production today** — a paid event's free types were already filtered out — so it mis-serves nobody it did not already, while fixing the all-free segment outright. A better discriminator is follow-up work, deliberately not attempted here.

## Verification

`pnpm test`: **511 files / 7486 tests → 514 files / 7524 tests**, all passing. `tsc --noEmit` clean. `prettier --check .` clean. `eslint .` — 0 errors, 201 warnings, all pre-existing tenancy warnings, none in changed files. `knip` clean.

Every guard was **sabotage-proven**: reverted, run, specific failures observed, restored. File and test counts held at 8 files / 76 tests on every run (8 / 79 after the `not-found` fix added three), so nothing silently stopped collecting.

| sabotage | failures |
|---|---|
| remove the layout's `isConferenceUnavailable` branch | 2 — the outage renders "Claim it" again |
| remove the root 404's `isConferenceUnavailable` branch | 1 — the outage renders "Claim it" again |
| classify a thrown read as `not-found` | 5 — layout, root 404, CFP page and the loader test |
| restore `if (conference)` on the CFP page | 1 — the outage reads as "CFP Closed" |
| stop splitting free tickets out | 3 — the free event vanishes from /tickets |
| pin the /tickets fallback to `coming-soon` | 3 — external registration and the outage both lie |
| remove the verify route's 503 branch | 1 — an outage answers 404 |
| classify a thrown badge read as `not-found` | 1 |

The tests that matter make the **Sanity client itself throw** and assert on the markup the real page produces (`__tests__/app/outage-is-not-an-answer.test.tsx`, `__tests__/app/tickets/tickets-page-states.test.tsx`) — not just the helper's return value. Each is asserted in **both** directions: an outage and a genuine absence must render different screens, or the test would prove nothing.

## What I did NOT fix

#848 lists six sites I was asked to check. I verified all of them by reading the code. Only badge-verify is in this PR; the rest are filed honestly rather than forced in:

- **Confirmed, same cause, not fixed here** — sponsor portal token (`src/lib/sponsor-crm/registration.ts:140-153` → `SponsorPortal.tsx:143`, "Invalid Link"); co-speaker invite (`src/lib/cospeaker/sanity.ts:64-67` → `invitation/respond/page.tsx:64-79`, "Invalid or Expired"); the speaker's own proposal list (`cfp/list/page.tsx:112` **drops `proposalsError` on the floor**, and the per-conference catch at `:169-183` zeroes the record → "You haven't submitted any proposals yet" at `:285`); `/privacy` and `/terms` (`src/lib/legal/resolve.ts:41-43` returns the same `null` as the legitimate no-org case, so `config.ts:122-126` guesses the controller name — worst case naming the **platform itself** as data controller, which that file's own doctrine at `:17-25` forbids for jurisdiction).
- **Confirmed but a DIFFERENT cause** — the workshops/staff/sponsor-messages empty states (`WorkshopList.tsx:189`, `staff/[role]/page.tsx:53`, `SponsorPortalMessages.tsx:97`, `StaffManager.tsx:234`, `WorkshopsClientPage.tsx:370`). The routers there distinguish the error correctly; the **client components discard it** by branching only on `isLoading`. That is a React-Query handling gap, not a return-type gap, so it does not belong in this seam.
- **Reported at the wrong line** — `verify/route.ts:145-148` is defensible as written: everything reaching that catch is deterministic on the badge JSON. The real collapse is one level down, at `src/lib/openbadges/crypto.ts:392-395`, whose `boolean` return has no vocabulary for "I could not evaluate this" — so a malformed `BADGE_ISSUER_ED25519_PUBLIC_KEY` (a botched key rotation) reports every genuine badge as unverified. Fixing it means changing that signature, which is its own change.

## Holes I am leaving

- **No visual verification.** Playwright is broken on this machine and `pnpm shoot` cannot run. Stories are added for every new state and are published by CI (https://698dd5d337def25e55183e8a-mcoqpkudkt.chromatic.com/) — `Components/PlatformUnavailable`, `Components/TicketsStatusNotice` (4 stories), `Components/TicketPricingGrid` (incl. `FreeToAttend`) — but **nobody has looked at the rendered pixels**. Chromatic's `UI Tests` check is blocked on the plan quota, so there is no visual diff either.
- A second commit (`fix(tickets): bind re-exported provider types before the export block`) moves an `import type` above the `export type` block in `src/lib/tickets/provider/index.ts`. TypeScript hoists imports so it always compiled, but Storybook's Babel docgen strips type-only imports and then failed the whole `build-storybook` — which the new TicketPricingGrid stories are the first to trigger. Type-only; no runtime behaviour.
- The other `isUnknownHost` call sites in `(main)` pages were not individually converted. The layout short-circuits before children execute, so the outage path is covered **there** — unlike `not-found.tsx`, which sits outside the group and needed its own branch. A `(main)` page whose *own* read fails while the layout's succeeded still renders its existing per-page error text, which is honest but plain.
- **Two admin surfaces still conflate the two failures**, unfixed and not claimed otherwise: `src/app/(admin)/admin/speakers/badge/page.tsx:29` renders "No Conference Found / No conference configuration found for the current domain" on an outage, and `src/app/api/admin/gallery/upload/route.ts:46` returns a 404 "Conference not found". Both are authenticated admin surfaces and neither offers a domain for claim, so they are a lesser instance of the same class — but they are instances.
- **Outage verdicts are still cached for hours.** `/tickets` wraps its content in `cacheLife('hours')` and `getPublicTicketTypes` carries its own. Same duration class as before; only the copy is now honest. Shortening the cache for the `unavailable` branch is a separate change.
- **One availability shift worth knowing about:** feeding `freeTickets` into `getTicketAvailability` means a paid event whose priced types have all expired, but which carries a windowless unflagged free type, now reads `on-sale` where it previously read `unknown`. Both render as "no sold-out claim", so nothing regresses into a false negative, but the value differs.
- `PlatformUnavailable` returns HTTP **200**. A layout cannot set a status code; the copy and `noindex` are the mitigation.

Refs #846, #848


