### PR TITLE
fix(secrets,email): resolve credentials per tenant, and fail closed by default

### DIFF
--- a/__tests__/api/cron/contract-reminders.test.ts
+++ b/__tests__/api/cron/contract-reminders.test.ts
@@ -30,6 +30,13 @@ vi.mock('@/lib/email/config', () => ({
       send: (...args: unknown[]) => mockResendSend(...args),
     },
   },
+  // #843: send paths resolve their client through `resolveEmailSender`, so the
+  // stub answers with the SAME spy the assertions below read.
+  resolveEmailSender: async () => ({
+    client: {
+      emails: { send: (...args: unknown[]) => mockResendSend(...args) },
+    },
+  }),
   retryWithBackoff: async (fn: () => Promise<unknown>) => fn(),
 }))
 

--- a/__tests__/api/trpc/volunteer.test.ts
+++ b/__tests__/api/trpc/volunteer.test.ts
@@ -64,6 +64,7 @@ import {
   TEST_ORG_ID,
 } from '../../helpers/trpc'
 import { createVolunteer, getVolunteerById } from '@/lib/volunteer/sanity'
+import { sendVolunteerApprovalEmail } from '@/lib/email/volunteer'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import {
   createNotifications,
@@ -281,6 +282,69 @@ describe('volunteer router', () => {
           message: 'Congrats',
         }),
       ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    })
+
+    /**
+     * THE CREDENTIAL KEY FOLLOWS THE DOCUMENT, NOT THE REQUEST (#843).
+     *
+     * When the volunteer's own conference has no `contactEmail`, this procedure
+     * rebuilds a conference object for the email, taking `_id`/`title` from the
+     * VOLUNTEER's conference and the address fields from the CURRENT domain's.
+     * `organization` is the field `resolveEmailSender` resolves the Resend
+     * account from, so it must come from the volunteer's conference like the
+     * identity fields — otherwise org A's volunteer mail goes out through org
+     * B's Resend account whenever B's organizer processes A's volunteer.
+     *
+     * REACHABLE, not theoretical: `sendEmail` is the one volunteer procedure
+     * with no `requireDocumentInCurrentConference` (its four siblings have it),
+     * and `getVolunteerById` is a global by-id fetch with no conference or org
+     * predicate. Production data makes it inexpressible today — every
+     * conference has a `contactEmail`, all under one org — which is exactly the
+     * "no live leak, fail-open shape anyway" standard #844 was justified on.
+     *
+     * WHY THIS CANNOT PASS FOR THE WRONG REASON: the two orgs are DISTINCT
+     * values, and the test asserts the positive (`ORG_A`) rather than merely
+     * "not B". A hardcoded `currentConf.organization` yields `TEST_ORG_ID` and
+     * fails on the value, not on an absence — so a stub that silently returned
+     * `undefined` would fail too rather than sneak through.
+     */
+    it("keys the sender on the VOLUNTEER's org, not the request domain's", async () => {
+      const ORG_A = 'organization-other-tenant'
+
+      vi.mocked(getVolunteerById).mockResolvedValue({
+        volunteer: {
+          _id: 'vol-1',
+          name: 'Test',
+          email: 'volunteer@other.example',
+          status: VolunteerStatus.APPROVED,
+          conference: {
+            _id: 'conf-other',
+            title: 'Another Tenant Conf',
+            // Belongs to ORG A…
+            organization: { _type: 'reference', _ref: ORG_A },
+            // …and carries NO contactEmail, which is what sends this down the
+            // rebuild branch under test.
+          },
+        } as any,
+        error: null,
+      })
+
+      // The request is on the fixture organizer's own domain — a DIFFERENT org.
+      const caller = createAdminCaller()
+      await caller.volunteer.admin.sendEmail({
+        volunteerId: 'vol-1',
+        subject: 'Welcome',
+        message: 'Congrats',
+      })
+
+      expect(sendVolunteerApprovalEmail).toHaveBeenCalledTimes(1)
+      const conferenceArg = vi.mocked(sendVolunteerApprovalEmail).mock
+        .calls[0][1] as { organization?: { _ref?: string } }
+
+      // The control: the two orgs really are different, so the assertion below
+      // is discriminating rather than trivially satisfied.
+      expect(ORG_A).not.toBe(TEST_ORG_ID)
+      expect(conferenceArg.organization?._ref).toBe(ORG_A)
     })
   })
 })

--- a/__tests__/lib/cospeaker/server.test.ts
+++ b/__tests__/lib/cospeaker/server.test.ts
@@ -33,6 +33,9 @@ vi.mock('@/lib/sanity/client', () => ({
 
 vi.mock('@/lib/email/config', () => ({
   resend: { emails: { send: mockSend } },
+  // #843: send paths resolve their client through `resolveEmailSender`, so the
+  // stub answers with the SAME spy the assertions below read.
+  resolveEmailSender: async () => ({ client: { emails: { send: mockSend } } }),
   retryWithBackoff: (fn: () => unknown) => fn(),
 }))
 

--- a/__tests__/lib/messaging/email.test.ts
+++ b/__tests__/lib/messaging/email.test.ts
@@ -15,6 +15,11 @@ const sendMock = vi.fn()
 
 vi.mock('@/lib/email/config', () => ({
   resend: { emails: { send: (...args: unknown[]) => sendMock(...args) } },
+  // #843: send paths resolve their client through `resolveEmailSender`, so the
+  // stub answers with the SAME spy the assertions below read.
+  resolveEmailSender: async () => ({
+    client: { emails: { send: (...args: unknown[]) => sendMock(...args) } },
+  }),
   // Pass-through: exercise sendOne's own success/failure handling directly.
   retryWithBackoff: async (fn: () => Promise<unknown>) => fn(),
 }))

--- a/__tests__/lib/proposal/email/notification.test.ts
+++ b/__tests__/lib/proposal/email/notification.test.ts
@@ -10,13 +10,17 @@ import { resend } from '@/lib/email/config'
 // the retry helper run for real so their integration is covered
 vi.mock('@/lib/email/config', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/email/config')>()
+  const resend = {
+    emails: {
+      send: vi.fn(),
+    },
+  }
   return {
     ...actual,
-    resend: {
-      emails: {
-        send: vi.fn(),
-      },
-    },
+    resend,
+    // #843: send paths resolve their client through `resolveEmailSender`, so the
+    // stub answers with the SAME spy the assertions below read.
+    resolveEmailSender: async () => ({ client: resend }),
   }
 })
 

--- a/docs/TENANT_SECRETS.md
+++ b/docs/TENANT_SECRETS.md
@@ -57,14 +57,35 @@ interface TenantSecretsStore {
 An implementation **must not throw** on a missing/partial secret — a miss is
 `null` so the resolver can fall through to the next store.
 
-### (a) `EnvSecretsStore` — the platform default
+### (a) `EnvSecretsStore` — the default tenant's credentials, and nobody else's
 
-Returns the **environment** credentials **regardless of `orgId`** — today's
-shared-account behavior verbatim. Returns `null` for a family with zero
-configured env vars, so the chain can terminate at `null` and the consumer's own
-soft-fail path runs (identical to unconfigured behavior today). `process.env` is
-read at call time (not import), so the module is import-safe and honours test env
-stubbing.
+Returns the **environment** credentials **only to the organization they belong
+to**, decided by `envCredentialsBelongToOrg`:
+
+| `PLATFORM_ORG_ID` | org                    | result                                                                     |
+| ----------------- | ---------------------- | -------------------------------------------------------------------------- |
+| unset             | any (incl. nullish)    | env credentials — single-tenant / self-hosted, the env _is_ the only org's |
+| set               | the platform org       | env credentials                                                            |
+| set               | any other org          | `null`                                                                     |
+| set               | nullish / unresolvable | `null` (fail closed)                                                       |
+
+It **fails closed**: a tenant with no secret of its own resolves to `null`, never
+to the platform's account. This is what makes `resolveTenantSecrets(orgId,
+family)` safe to call naively — the careless call and the correct call now have
+the same answer. (Before, the store ignored `orgId` entirely, so ticketing had to
+bypass the chain and Slack had to gate it; two of three consumers working around
+a default is the signal that the default is wrong.)
+
+Returns `null` for a family with zero configured env vars, so the chain can
+terminate at `null` and the consumer's own soft-fail path runs (identical to
+unconfigured behavior). `process.env` is read at call time (not import), so the
+module is import-safe and honours test env stubbing.
+
+`platformEnvCredentials(family)` is the **raw, org-blind** accessor beneath it,
+for a caller that has already made its own authorization decision. It has exactly
+one consumer — `resolveConferenceSlackToken`, on the far side of the
+`slack-mirror` gate, which may grant the platform token to an override org that
+`EnvSecretsStore` itself would refuse.
 
 ### (b) `JsonEnvSecretsStore` — the minimal per-org mechanism
 
@@ -112,15 +133,18 @@ manager slots in front of `envSecretsStore` (or replaces `perOrgSecretsStore`)
 behind the same interface. The chain is injectable (`resolveTenantSecrets(orgId,
 family, stores)`) for tests and alternate compositions.
 
+The env fallback is **conditional on the org**, so for a non-platform tenant the
+chain reads: its own secret, or `null`.
+
 ## Wired consumers
 
-| Family    | Boundary                                                                     | Status                                                                                                                                                                                                                                                          |
-| --------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ticketing | `resolveTicketingCredentials` (`src/lib/tickets/provider/index.ts`)          | **Wired (Checkin + Tito).** Per-org secret wins; the platform env is handed out **only to the platform org** (`PLATFORM_ORG_ID`). Any other org resolves to `null` ⇒ the conference reports unconfigured.                                                       |
-| email     | `resolveEmailSender(orgId)` (`src/lib/email/config.ts`)                      | **Wired (seam).** Lazily-constructed per-credentials client factory + cached default.                                                                                                                                                                           |
-| slack     | `resolveConferenceSlackToken(conference)` → `postSlackMessage({ botToken })` | **Wired + gated.** The ONLY token source — `postSlackMessage` has no env fallback. A per-org token always wins; the platform `SLACK_BOT_TOKEN` requires the `slack-mirror` entitlement (`src/lib/features/slack.ts`), which defaults to the platform org alone. |
-| push      | `resolveTenantSecrets(orgId, 'push')`                                        | **Seam only.** Env-only; VAPID config is process-global (see the TODO in `push/vapid.ts`).                                                                                                                                                                      |
-| badge     | `resolveTenantSecrets(orgId, 'badge')`                                       | **Seam only.** Env-only; signing keys thread through pure config (TODO in `badge/config.ts`).                                                                                                                                                                   |
+| Family    | Boundary                                                                     | Status                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ticketing | `resolveTicketingCredentials` (`src/lib/tickets/provider/index.ts`)          | **Wired (Checkin + Tito).** Per-org secret wins; the platform env is handed out **only to the platform org** (`PLATFORM_ORG_ID`). Any other org resolves to `null` ⇒ the conference reports unconfigured.                                                                                                                                                                                                                    |
+| email     | `resolveEmailSender(orgId)` (`src/lib/email/config.ts`)                      | **Wired, and used by every send path.** A per-org key gets the tenant's own Resend client; everyone else gets the cached platform client — the shared **T0 tier**, expressed in `config.ts` rather than by the secret store handing out the platform key. `src/lib/email/platform-client-usage.test.ts` allowlists the only direct `resend` consumer (the status-page deliverability probe) so no new send path can regress. |
+| slack     | `resolveConferenceSlackToken(conference)` → `postSlackMessage({ botToken })` | **Wired + gated.** The ONLY token source — `postSlackMessage` has no env fallback. A per-org token always wins; the platform `SLACK_BOT_TOKEN` requires the `slack-mirror` entitlement (`src/lib/features/slack.ts`), which defaults to the platform org alone.                                                                                                                                                              |
+| push      | `resolveTenantSecrets(orgId, 'push')`                                        | **Seam only.** Env-only; VAPID config is process-global (see the TODO in `push/vapid.ts`).                                                                                                                                                                                                                                                                                                                                   |
+| badge     | `resolveTenantSecrets(orgId, 'badge')`                                       | **Seam only.** Env-only; signing keys thread through pure config (TODO in `badge/config.ts`).                                                                                                                                                                                                                                                                                                                                |
 
 The one remaining direct `platformCheckinCredentials()` consumer is the inbound
 `/api/webhooks/checkin/ticket-sold` route, which verifies a signature **before**

--- a/src/app/api/cron/contract-reminders/route.ts
+++ b/src/app/api/cron/contract-reminders/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { clientWrite } from '@/lib/sanity/client'
 import { getCurrentDateTime } from '@/lib/time'
-import { resend, retryWithBackoff } from '@/lib/email/config'
+import { resolveEmailSender, retryWithBackoff } from '@/lib/email/config'
 import { platformFallbackContact } from '@/lib/email/from'
 import { unstable_noStore as noStore } from 'next/cache'
 
@@ -120,8 +120,13 @@ export async function GET(request: NextRequest) {
           continue
         }
 
+        // PER CONTRACT, not once for the run: this cron sweeps EVERY tenant's
+        // contracts in one loop, so the sender has to be resolved inside it or
+        // one org's reminder would go out on another's Resend account (#843).
+        const { client } = await resolveEmailSender(contract.organizationRef)
+
         await retryWithBackoff(async () => {
-          return resend.emails.send({
+          return client.emails.send({
             from: `${fromName} <${fromEmail}>`,
             to: [contract.signerEmail],
             subject: emailResult.subject,

--- a/src/lib/cospeaker/server.ts
+++ b/src/lib/cospeaker/server.ts
@@ -1,4 +1,4 @@
-import { resend, retryWithBackoff } from '@/lib/email/config'
+import { resolveEmailSender, retryWithBackoff } from '@/lib/email/config'
 import React from 'react'
 import crypto from 'crypto'
 import { clientWrite } from '@/lib/sanity/client'
@@ -37,6 +37,11 @@ export interface SendEmailParams<T = Record<string, unknown>> {
   component: React.ComponentType<T>
   props: T
   from: string
+  /**
+   * The owning organization, so the send uses the TENANT's Resend account when
+   * it has one (#843). Nullish ⇒ the shared platform account.
+   */
+  orgId?: string | null
 }
 
 export interface SendEmailResponse {
@@ -51,10 +56,13 @@ export async function sendEmail<T = Record<string, unknown>>({
   component: Component,
   props,
   from,
+  orgId,
 }: SendEmailParams<T>): Promise<SendEmailResponse> {
   try {
+    const { client } = await resolveEmailSender(orgId)
+
     const emailResult = await retryWithBackoff(async () => {
-      const result = await resend.emails.send({
+      const result = await client.emails.send({
         from: from,
         to: [to],
         subject,
@@ -335,6 +343,7 @@ export async function sendInvitationEmail(
       to: invitation.invitedEmail,
       subject: `You've been invited to co-present "${proposalTitle}"`,
       from: `${conference.organizer} <${conference.cfpEmail}>`,
+      orgId: conference.organization?._ref,
       component: CoSpeakerInvitationTemplate,
       props: {
         inviterName,
@@ -441,6 +450,7 @@ export async function sendResponseNotificationEmail(params: {
       to: inviterEmail,
       subject,
       from: `${conference.organizer} <${conference.cfpEmail}>`,
+      orgId: conference.organization?._ref,
       component: CoSpeakerResponseTemplate,
       props: {
         inviterName: inviterName || 'there',

--- a/src/lib/email/audience.ts
+++ b/src/lib/email/audience.ts
@@ -1,15 +1,68 @@
+import type { Resend } from 'resend'
 import { Conference } from '@/lib/conference/types'
 import { Speaker } from '@/lib/speaker/types'
 import { ProposalExisting } from '@/lib/proposal/types'
 import {
-  resend,
+  resolveEmailSender,
   retryWithBackoff,
   delay,
   isRateLimitError,
   EMAIL_CONFIG,
 } from './config'
 
+/**
+ * AUDIENCES ARE ACCOUNT-SCOPED, WHICH MAKES THEM DIFFERENT FROM A MESSAGE (#843).
+ *
+ * For a plain send, "which Resend client" is a per-message choice: resolve the
+ * tenant's sender, send, done. An AUDIENCE is not a message — it is a durable
+ * object living inside ONE Resend account, addressed by an opaque `audienceId`
+ * that account minted. The id is meaningless anywhere else: hand a
+ * platform-account audience id to a tenant's own client and the call fails, or
+ * worse, addresses a DIFFERENT audience that happens to exist there.
+ *
+ * So an audience id is not a value that travels alone — it is a HANDLE, and it
+ * only means anything alongside the client it came from. Every function here
+ * that takes an `audienceId` therefore takes the CLIENT with it, and the
+ * resolvers that mint an id return the client that minted it. Re-resolving from
+ * an org id at the point of use would be the bug this design exists to prevent:
+ * it could resolve to a different account than the one holding the id (a tenant
+ * provisioned with its own key between two calls), and nothing would report it.
+ *
+ * Contacts inherit this: `contacts.create`/`list`/`remove` are all addressed by
+ * `audienceId`, so they are on the same handle.
+ *
+ * NOTHING IS PERSISTED. Audience ids are never stored in Sanity — they are
+ * looked up by NAME through `audiences.list()` on every call. That is what makes
+ * moving a tenant onto its own Resend account self-healing rather than a
+ * migration: the first call on the new account simply finds no audience by that
+ * name and creates one there.
+ */
 export type AudienceType = 'speakers' | 'sponsors'
+
+/**
+ * An audience id together with the Resend account it belongs to. Returned by the
+ * resolvers so a caller that goes on to add contacts or create a broadcast uses
+ * the SAME account, without re-resolving.
+ */
+export interface ConferenceAudience {
+  audienceId: string
+  /** The account `audienceId` is valid on. */
+  client: Resend
+  error?: Error
+}
+
+/**
+ * The Resend account a conference's audiences and broadcasts live on: the
+ * tenant's own when it has credentials, the platform's otherwise (the shared
+ * T0 tier). ONE resolution point, so the audience, its contacts and any
+ * broadcast built on it cannot end up on different accounts.
+ */
+export async function conferenceAudienceClient(
+  conference: Conference,
+): Promise<Resend> {
+  const { client } = await resolveEmailSender(conference.organization?._ref)
+  return client
+}
 
 export interface Contact {
   email: string
@@ -21,16 +74,18 @@ export interface Contact {
 export async function getOrCreateConferenceAudienceByType(
   conference: Conference,
   audienceType: AudienceType,
-): Promise<{ audienceId: string; error?: Error }> {
+): Promise<ConferenceAudience> {
   const audienceName =
     audienceType === 'speakers'
       ? `${conference.title} Speakers`
       : `${conference.title} Sponsors`
 
+  const client = await conferenceAudienceClient(conference)
+
   try {
     const listStart = Date.now()
     const existingAudiences = await retryWithBackoff(() =>
-      resend.audiences.list(),
+      client.audiences.list(),
     )
     const listDuration = Date.now() - listStart
 
@@ -50,13 +105,13 @@ export async function getOrCreateConferenceAudienceByType(
     )
 
     if (existingAudience) {
-      return { audienceId: existingAudience.id }
+      return { audienceId: existingAudience.id, client }
     }
 
     await delay(EMAIL_CONFIG.RATE_LIMIT_DELAY)
     const createStart = Date.now()
     const audienceResponse = await retryWithBackoff(() =>
-      resend.audiences.create({
+      client.audiences.create({
         name: audienceName,
       }),
     )
@@ -74,7 +129,7 @@ export async function getOrCreateConferenceAudienceByType(
       )
     }
 
-    return { audienceId: audienceResponse.data!.id }
+    return { audienceId: audienceResponse.data!.id, client }
   } catch (error) {
     if (isRateLimitError(error)) {
       console.warn(
@@ -95,17 +150,18 @@ export async function getOrCreateConferenceAudienceByType(
         },
       )
     }
-    return { audienceId: '', error: error as Error }
+    return { audienceId: '', client, error: error as Error }
   }
 }
 
 export async function getOrCreateConferenceAudience(
   conference: Conference,
-): Promise<{ audienceId: string; error?: Error }> {
+): Promise<ConferenceAudience> {
   return getOrCreateConferenceAudienceByType(conference, 'speakers')
 }
 
 export async function addContactToAudience(
+  client: Resend,
   audienceId: string,
   contact: Contact,
 ): Promise<{ success: boolean; error?: Error }> {
@@ -120,7 +176,7 @@ export async function addContactToAudience(
 
     const contactResponse = await retryWithBackoff(
       async () =>
-        await resend.contacts.create({
+        await client.contacts.create({
           audienceId,
           email: contact.email,
           firstName: contact.firstName,
@@ -163,12 +219,13 @@ export async function addContactToAudience(
 }
 
 export async function removeContactFromAudience(
+  client: Resend,
   audienceId: string,
   email: string,
 ): Promise<{ success: boolean; error?: Error }> {
   try {
     const contactsResponse = await retryWithBackoff(
-      async () => await resend.contacts.list({ audienceId }),
+      async () => await client.contacts.list({ audienceId }),
     )
 
     if (contactsResponse.error) {
@@ -185,7 +242,7 @@ export async function removeContactFromAudience(
 
     const removeResponse = await retryWithBackoff(
       async () =>
-        await resend.contacts.remove({
+        await client.contacts.remove({
           audienceId,
           id: contact.id,
         }),
@@ -211,6 +268,7 @@ export async function removeContactFromAudience(
 }
 
 export async function addSpeakerToAudience(
+  client: Resend,
   audienceId: string,
   speaker: Speaker,
 ): Promise<{ success: boolean; error?: Error }> {
@@ -219,14 +277,15 @@ export async function addSpeakerToAudience(
     firstName: speaker.name.split(' ')[0] || '',
     lastName: speaker.name.split(' ').slice(1).join(' ') || '',
   }
-  return addContactToAudience(audienceId, contact)
+  return addContactToAudience(client, audienceId, contact)
 }
 
 export async function removeSpeakerFromAudience(
+  client: Resend,
   audienceId: string,
   speakerEmail: string,
 ): Promise<{ success: boolean; error?: Error }> {
-  return removeContactFromAudience(audienceId, speakerEmail)
+  return removeContactFromAudience(client, audienceId, speakerEmail)
 }
 
 export async function syncAudienceWithContacts(
@@ -244,8 +303,11 @@ export async function syncAudienceWithContacts(
   const syncStart = Date.now()
 
   try {
-    const { audienceId, error: audienceError } =
-      await getOrCreateConferenceAudienceByType(conference, audienceType)
+    const {
+      audienceId,
+      client,
+      error: audienceError,
+    } = await getOrCreateConferenceAudienceByType(conference, audienceType)
 
     if (audienceError || !audienceId) {
       console.error('[Audience] Failed to get/create audience:', {
@@ -257,7 +319,7 @@ export async function syncAudienceWithContacts(
 
     const listStart = Date.now()
     const contactsResponse = await retryWithBackoff(
-      async () => await resend.contacts.list({ audienceId }),
+      async () => await client.contacts.list({ audienceId }),
     )
     const listDuration = Date.now() - listStart
 
@@ -287,7 +349,11 @@ export async function syncAudienceWithContacts(
 
     let addedCount = 0
     for (const contact of contactsToAdd) {
-      const { success } = await addContactToAudience(audienceId, contact)
+      const { success } = await addContactToAudience(
+        client,
+        audienceId,
+        contact,
+      )
       if (success) {
         addedCount++
       }
@@ -297,6 +363,7 @@ export async function syncAudienceWithContacts(
     let removedCount = 0
     for (const existingContact of contactsToRemove) {
       const { success } = await removeContactFromAudience(
+        client,
         audienceId,
         existingContact.email,
       )

--- a/src/lib/email/badge.ts
+++ b/src/lib/email/badge.ts
@@ -8,7 +8,7 @@ import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
 // The SHARED client, not a private `new Resend(...)`: badge mail must go through
 // the same instrumented client as every other send, so it obeys the sender
 // policy and its failures are logged like the rest (platform#20).
-import { resend } from '@/lib/email/config'
+import { resolveEmailSender } from '@/lib/email/config'
 
 interface SendBadgeEmailParams {
   badge: BadgeRecord
@@ -61,8 +61,10 @@ export async function sendBadgeEmail({
     // when the conference has no contactEmail/domain — never a hardcoded brand).
     const fromEmail = resolveConferenceFrom(conference)
 
-    // Send email using Resend
-    const { data, error } = await resend.emails.send({
+    // Send email using the tenant's own Resend account when it has one.
+    const { client } = await resolveEmailSender(conference?.organization?._ref)
+
+    const { data, error } = await client.emails.send({
       from: fromEmail,
       to: speakerEmail,
       subject: `Your ${badge.badgeType} badge for ${conferenceName} ${conferenceYear}`,

--- a/src/lib/email/broadcast.ts
+++ b/src/lib/email/broadcast.ts
@@ -1,5 +1,5 @@
 import {
-  resend,
+  resolveEmailSender,
   retryWithBackoff,
   delay,
   EMAIL_CONFIG,
@@ -36,10 +36,16 @@ export async function sendBroadcastEmail({
   additionalContent = '',
 }: BroadcastEmailRequest): Promise<Response> {
   try {
-    const { audienceId, error: audienceError } =
-      audienceType === 'speakers'
-        ? await getOrCreateConferenceAudience(conference)
-        : await getOrCreateConferenceAudienceByType(conference, audienceType)
+    // The broadcast MUST be created on the account holding `audienceId` — see
+    // the account-scoping note in `@/lib/email/audience`. So the client comes
+    // back with the audience rather than being resolved a second time here.
+    const {
+      audienceId,
+      client,
+      error: audienceError,
+    } = audienceType === 'speakers'
+      ? await getOrCreateConferenceAudience(conference)
+      : await getOrCreateConferenceAudienceByType(conference, audienceType)
 
     if (!audienceId) {
       console.error('[Broadcast] Failed to get/create audience:', {
@@ -103,7 +109,7 @@ export async function sendBroadcastEmail({
     })
 
     const broadcastResponse = await retryWithBackoff(async () => {
-      return await resend.broadcasts.create({
+      return await client.broadcasts.create({
         name: subject,
         audienceId,
         from: resolvedFromEmail,
@@ -125,7 +131,7 @@ export async function sendBroadcastEmail({
     await delay(EMAIL_CONFIG.RATE_LIMIT_DELAY)
 
     const sendResponse = await retryWithBackoff(async () => {
-      return await resend.broadcasts.send(broadcastResponse.data!.id)
+      return await client.broadcasts.send(broadcastResponse.data!.id)
     })
 
     if (sendResponse.error) {
@@ -204,8 +210,10 @@ export async function sendIndividualEmail({
       unsubscribeUrl: undefined,
     })
 
+    const { client } = await resolveEmailSender(conference.organization?._ref)
+
     const emailResponse = await retryWithBackoff(async () => {
-      return await resend.emails.send({
+      return await client.emails.send({
         from: resolvedFromEmail,
         to: [primaryRecipient],
         ...(ccRecipients.length > 0 && { cc: ccRecipients }),

--- a/src/lib/email/config.test.ts
+++ b/src/lib/email/config.test.ts
@@ -48,3 +48,65 @@ describe('resolveEmailSender', () => {
     expect(other.client).toBe(resend)
   })
 })
+
+/**
+ * THE #843 / #844 INTERACTION — the one place the two fixes could have fought.
+ *
+ * #844 makes `EnvSecretsStore` refuse a non-platform org, so
+ * `resolveTenantSecrets(tenantOrg, 'email')` now returns `null` where it used to
+ * return the platform `RESEND_API_KEY`. Email is the ONE consumer that wants the
+ * platform account as a deliberate product tier — shared-services T0, where a
+ * tenant with no Resend account of its own sends through the platform's, with
+ * `sender-policy.ts` forcing a platform-verified `From:`.
+ *
+ * They do not actually conflict, and this pins WHY: `resolveEmailSender` has its
+ * OWN explicit fallback to the platform client, so a `null` from the chain lands
+ * on the same cached instance the env credentials used to produce. Before #844
+ * the tenant got `getResendClient({apiKey: RESEND_API_KEY})`, which short-circuits
+ * to the cached platform client; after #844 it gets `{ client: resend }` — the
+ * same object, by identity. The tier is expressed in `config.ts` rather than
+ * smuggled through a credential store that hands out the platform's key to
+ * everybody, which is the distinction #844 is about.
+ *
+ * These assertions are IDENTITY comparisons (`toBe`), not shape comparisons: a
+ * second Resend instance built from the same key would enforce the sender policy
+ * too, so `toEqual` could not tell the tier from a regression.
+ */
+describe('resolveEmailSender under the #844 platform-org gate', () => {
+  const PLATFORM = 'org-platform'
+  const TENANT = 'org-tenant'
+
+  it('keeps the shared T0 tier: a NON-platform tenant still sends on the platform client', async () => {
+    vi.stubEnv('PLATFORM_ORG_ID', PLATFORM)
+
+    // The control: the platform org's own resolution is unchanged…
+    expect((await resolveEmailSender(PLATFORM)).client).toBe(resend)
+    // …and so is a tenant's, even though the secrets chain now refuses it.
+    expect((await resolveEmailSender(TENANT)).client).toBe(resend)
+    // Including the unresolvable-org case, which the chain also refuses.
+    expect((await resolveEmailSender(null)).client).toBe(resend)
+    expect((await resolveEmailSender(undefined)).client).toBe(resend)
+  })
+
+  it('still routes a tenant with its OWN key to its OWN account (#843)', async () => {
+    vi.stubEnv('PLATFORM_ORG_ID', PLATFORM)
+    vi.stubEnv(
+      'TENANT_SECRETS_JSON',
+      JSON.stringify({
+        [TENANT]: {
+          email: { apiKey: 're_tenant_key', fallbackFrom: 'hei@tenant.no' },
+        },
+      }),
+    )
+
+    const tenant = await resolveEmailSender(TENANT)
+    // The whole point of #843: this is NOT the platform account.
+    expect(tenant.client).not.toBe(resend)
+    expect(tenant.from).toBe('hei@tenant.no')
+
+    // A per-org secret is the tenant's OWN credential, so the #844 gate does not
+    // stand in front of it — it never touches the env store at all.
+    const platform = await resolveEmailSender(PLATFORM)
+    expect(platform.client).toBe(resend)
+  })
+})

--- a/src/lib/email/gallery.ts
+++ b/src/lib/email/gallery.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render } from '@react-email/render'
 import { GallerySpeakerTaggedTemplate } from '@/components/email/GallerySpeakerTaggedTemplate'
-import { resend, retryWithBackoff } from './config'
+import { resolveEmailSender, retryWithBackoff } from './config'
 import { buildGalleryImageUrl } from '@/lib/gallery/url'
 import { logger } from '@/lib/logger'
 import type { Speaker } from '@/lib/speaker/types'
@@ -126,8 +126,10 @@ export async function sendGalleryTagEmail(
 
     const subject = `You've been tagged in a ${conference.title} photo`
 
+    const { client } = await resolveEmailSender(conference.organization?._ref)
+
     const result = await retryWithBackoff(async () => {
-      return await resend.emails.send({
+      return await client.emails.send({
         from: `${conference.title} <${conference.cfpEmail}>`,
         to: speaker.email,
         subject,

--- a/src/lib/email/invitation-letter.ts
+++ b/src/lib/email/invitation-letter.ts
@@ -1,4 +1,4 @@
-import { resend } from '@/lib/email/config'
+import { resolveEmailSender } from '@/lib/email/config'
 import { resolveConferenceFrom } from '@/lib/email/from'
 import { escapeHtml } from '@/lib/html/escape'
 import type { Conference } from '@/lib/conference/types'
@@ -38,7 +38,9 @@ export async function sendInvitationLetterEmail({
       localPart: 'contact',
     })
 
-    const response = await resend.emails.send({
+    const { client } = await resolveEmailSender(conference.organization?._ref)
+
+    const response = await client.emails.send({
       from,
       to,
       subject: `Letter of invitation — ${conference.title}`,

--- a/src/lib/email/platform-client-usage.test.ts
+++ b/src/lib/email/platform-client-usage.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+
+/**
+ * THE PLATFORM RESEND SINGLETON IS ALLOWLISTED (#843).
+ *
+ * `resend` (exported by `@/lib/email/config`) is ONE Resend account: the
+ * platform's. Every send that reaches for it directly sends a tenant's mail
+ * through the platform's account, which puts another organization's speakers,
+ * sponsors and attendees into the platform's logs, suppression lists and
+ * audience records. The per-org seam (`resolveEmailSender(orgId)`) existed for a
+ * long time with exactly ONE production caller while ten-plus other send paths
+ * imported the singleton — a seam nobody used is not a seam.
+ *
+ * Plumbing them all through `resolveEmailSender` fixes today. THIS test is what
+ * keeps it fixed: the next send path added to this codebase either resolves per
+ * org, or turns this red. That is deliberately a build failure and not a lint
+ * warning, because the failure mode it guards is silent by nature — a tenant's
+ * mail still sends, just from the wrong account, and nothing surfaces it.
+ *
+ * WHY A SOURCE SCAN and not a runtime spy: `resend` is a `const` binding to a
+ * cached instance, so there is no interception point at the module boundary. The
+ * import IS the observable event.
+ *
+ * ── WHY THIS TEST CANNOT PASS FOR THE WRONG REASON ──────────────────────────
+ * It asserts the allowlist EXACTLY, in both directions:
+ *  - a NEW importer fails the "no unexpected" assertion, and
+ *  - the scanner finding nothing at all (a broken glob, a regex that stopped
+ *    matching, a moved file) fails the "the known importer is still found"
+ *    assertion.
+ * A test that only checked "no unexpected importers" would go green if the
+ * scanner silently walked an empty tree, which is the exact false green this
+ * project has been bitten by. Both halves have to hold.
+ */
+
+/** The ONE file allowed to send on the platform account, and why. */
+const ALLOWED = new Map<string, string>([
+  [
+    'src/server/routers/status.ts',
+    'The admin status page probes DELIVERABILITY of the platform account ' +
+      'itself. Resolving per org would probe the tenant and report the wrong ' +
+      "account's health — the platform client is the subject of this call, " +
+      'not an incidental transport for it.',
+  ],
+])
+
+/** `src/lib/email/config.ts` DEFINES the singleton; it is not a consumer. */
+const DEFINITION = 'src/lib/email/config.ts'
+
+const ROOT = join(__dirname, '..', '..', '..')
+const SRC = join(ROOT, 'src')
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      out.push(...sourceFiles(full))
+    } else if (
+      /\.tsx?$/.test(entry) &&
+      !/\.(test|stories)\.tsx?$/.test(entry)
+    ) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+/** The module that owns the singleton, as an absolute path with no extension. */
+const CONFIG_MODULE = join(SRC, 'lib', 'email', 'config')
+
+/**
+ * Resolve an import specifier to an absolute, extension-less module path.
+ * Handles the `@/…` alias (→ `src/…`) and relative specifiers; returns `null`
+ * for a bare package name, which can never be this module.
+ */
+function resolveSpecifier(fromFile: string, specifier: string): string | null {
+  if (specifier.startsWith('@/')) return join(SRC, specifier.slice(2))
+  if (specifier.startsWith('.')) return resolve(dirname(fromFile), specifier)
+  return null
+}
+
+/**
+ * Whether `file` pulls the `resend` SINGLETON out of `@/lib/email/config`.
+ *
+ * Matches the static `import { … resend … } from '…'` form AND the dynamic
+ * `const { … resend … } = await import('…')` form, across line breaks — several
+ * real call sites use multi-line, multi-symbol imports, and a naive single-line
+ * grep for `import { resend }` reported 2 files when the true answer was more
+ * than ten. The destructure pattern keeps `resolveEmailSender` and a renamed
+ * `resend: x` binding from being confused with the plain symbol.
+ *
+ * THE SPECIFIER IS RESOLVED, NOT PATTERN-MATCHED. An earlier version of this
+ * test tested the raw specifier against `/email\/config/` and was PROVED WRONG
+ * by sabotage: half the offenders in `src/lib/email/` import from the RELATIVE
+ * `'./config'`, which that pattern silently missed, so re-pointing a send path
+ * at the singleton left the suite green. Resolving `@/…` and `./…` to a real
+ * path and comparing against the one module is the only form that cannot be
+ * dodged by how an author happened to spell the path.
+ */
+function importsPlatformSingleton(file: string, source: string): boolean {
+  const bindings =
+    /(?:import|const)\s*(\{[^}]*\})\s*(?:from|=\s*await\s+import\()\s*['"]([^'"]+)['"]/g
+  for (const match of source.matchAll(bindings)) {
+    if (!/(^|[{,\s])resend(\s*,|\s*\})/.test(match[1])) continue
+    if (resolveSpecifier(file, match[2]) === CONFIG_MODULE) return true
+  }
+  return false
+}
+
+describe('the platform Resend singleton is allowlisted (#843)', () => {
+  const importers = sourceFiles(SRC)
+    .filter((file) =>
+      importsPlatformSingleton(file, readFileSync(file, 'utf8')),
+    )
+    .map((file) => relative(ROOT, file).split('\\').join('/'))
+    .filter((file) => file !== DEFINITION)
+
+  it('scans a real tree and still finds the known allowlisted importer', () => {
+    // The control. If the walk, the filter or the regex ever stopped working,
+    // `importers` would be empty and the assertion below would pass vacuously.
+    expect(sourceFiles(SRC).length).toBeGreaterThan(100)
+    expect(importers).toContain('src/server/routers/status.ts')
+  })
+
+  it('detects the RELATIVE import form, not just the @/ alias', () => {
+    // The hole a sabotage actually found: `src/lib/email/*` import their own
+    // `'./config'`, so a scanner keyed on the string "email/config" misses every
+    // one of them. Pinned with a synthetic source rather than a real file, so it
+    // keeps testing the matcher after the last relative importer is gone.
+    const file = join(SRC, 'lib', 'email', 'somewhere.ts')
+    expect(
+      importsPlatformSingleton(file, "import { resend } from './config'"),
+    ).toBe(true)
+    expect(
+      importsPlatformSingleton(
+        file,
+        "import {\n  resend,\n  retryWithBackoff,\n} from '@/lib/email/config'",
+      ),
+    ).toBe(true)
+    expect(
+      importsPlatformSingleton(
+        join(SRC, 'server', 'routers', 'x.ts'),
+        "const { resend } = await import('@/lib/email/config')",
+      ),
+    ).toBe(true)
+    // …and does NOT fire on the per-org seam, or on an unrelated module.
+    expect(
+      importsPlatformSingleton(
+        file,
+        "import { resolveEmailSender } from './config'",
+      ),
+    ).toBe(false)
+    expect(
+      importsPlatformSingleton(file, "import { resend } from './other-config'"),
+    ).toBe(false)
+  })
+
+  it('has NO importer outside the allowlist', () => {
+    const unexpected = importers.filter((file) => !ALLOWED.has(file))
+    expect(
+      unexpected,
+      [
+        'These files send on the PLATFORM Resend account regardless of which',
+        "tenant's mail it is (#843). Resolve the sender per organization instead:",
+        '',
+        '    const { client } = await resolveEmailSender(conference.organization?._ref)',
+        '    await client.emails.send({ … })',
+        '',
+        'Every send path already has a conference, a ctx.orgId, or both. If a new',
+        'path genuinely must use the platform account, add it to ALLOWED in this',
+        'file WITH the reason — the allowlist is the record of that decision.',
+      ].join('\n'),
+    ).toEqual([])
+  })
+
+  it('documents a reason for every allowlist entry', () => {
+    for (const [file, reason] of ALLOWED) {
+      expect(
+        reason.length,
+        `${file} needs a real justification`,
+      ).toBeGreaterThan(40)
+    }
+  })
+})

--- a/src/lib/email/speaker.ts
+++ b/src/lib/email/speaker.ts
@@ -8,7 +8,7 @@ import { ProposalExisting } from '@/lib/proposal/types'
 import { Speaker } from '@/lib/speaker/types'
 import { addSpeakerToAudience, getOrCreateConferenceAudience } from './audience'
 import {
-  resend,
+  resolveEmailSender,
   retryWithBackoff,
   createEmailError,
   type EmailResult,
@@ -112,8 +112,11 @@ export async function sendMultiSpeakerEmail({
 
     if (addToAudience) {
       try {
-        const { audienceId, error: audienceError } =
-          await getOrCreateConferenceAudience(conference)
+        const {
+          audienceId,
+          client: audienceClient,
+          error: audienceError,
+        } = await getOrCreateConferenceAudience(conference)
         if (!audienceError && audienceId) {
           for (const speaker of targetSpeakers) {
             const speakerForAudience: Partial<Speaker> &
@@ -123,6 +126,7 @@ export async function sendMultiSpeakerEmail({
               email: speaker.email,
             }
             await addSpeakerToAudience(
+              audienceClient,
               audienceId,
               speakerForAudience as Speaker,
             )
@@ -183,8 +187,10 @@ export async function sendFormattedMultiSpeakerEmail({
       brandColor: emailBrandColor(conference.theme),
     })
 
+    const { client } = await resolveEmailSender(conference.organization?._ref)
+
     const emailResult = await retryWithBackoff(async () => {
-      const result = await resend.emails.send({
+      const result = await client.emails.send({
         from: `${conference.organizer} <${conference.cfpEmail}>`,
         to: speakers.map((s) => s.email),
         subject: subject,

--- a/src/lib/email/volunteer.ts
+++ b/src/lib/email/volunteer.ts
@@ -1,5 +1,5 @@
 import {
-  resend,
+  resolveEmailSender,
   retryWithBackoff,
   EmailResult,
   createEmailError,
@@ -11,6 +11,12 @@ import { VolunteerApprovalTemplate } from '@/components/email/VolunteerApprovalT
 import { emailBrandColor, type ConferenceTheme } from '@/lib/branding/theme'
 
 interface ConferenceForEmail {
+  /**
+   * The owning tenant. This local projection used to omit it, which is exactly
+   * why the volunteer mail went out on the PLATFORM's Resend account no matter
+   * whose conference it was (#843) — the org could not reach the send.
+   */
+  organization?: { _ref?: string } | null
   title: string
   contactEmail?: string
   cfpEmail?: string
@@ -65,8 +71,10 @@ export async function sendVolunteerApprovalEmail(
     const eventUrl = conferenceBaseUrl(conference)
     const socialLinks = conference.socialLinks?.map((link) => link.url) || []
 
+    const { client } = await resolveEmailSender(conference.organization?._ref)
+
     const result = await retryWithBackoff(async () => {
-      const response = await resend.emails.send({
+      const response = await client.emails.send({
         from: `${conference.organizer || conference.title} <${fromEmail}>`,
         to: volunteer.email!,
         subject,

--- a/src/lib/email/workshop.announcement.test.ts
+++ b/src/lib/email/workshop.announcement.test.ts
@@ -3,6 +3,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 const sendMock = vi.fn()
 vi.mock('./config', () => ({
   resend: { emails: { send: (...args: unknown[]) => sendMock(...args) } },
+  // #843: send paths resolve their client through `resolveEmailSender`, so the
+  // stub answers with the SAME spy the assertions below read.
+  resolveEmailSender: async () => ({
+    client: { emails: { send: (...args: unknown[]) => sendMock(...args) } },
+  }),
   // Pass-through retry so the render path runs once, deterministically.
   retryWithBackoff: (fn: () => Promise<unknown>) => fn(),
   createEmailError: (message: string, status = 500) => ({

--- a/src/lib/email/workshop.ts
+++ b/src/lib/email/workshop.ts
@@ -1,7 +1,7 @@
 import { escapeHtml } from '@/lib/html/escape'
 import { PLATFORM_NAME } from '@/lib/branding/platform'
 import {
-  resend,
+  resolveEmailSender,
   retryWithBackoff,
   createEmailError,
   type EmailResult,
@@ -20,6 +20,12 @@ export interface WorkshopConfirmationEmailRequest {
   userName: string
   status?: string
   conference?: Conference
+  /**
+   * The owning tenant, for call sites that have an org id but no conference
+   * document (the admin `manualSignup` path). Takes precedence over
+   * `conference.organization`; nullish ⇒ the shared platform account (#843).
+   */
+  orgId?: string | null
   workshopTitle: string
   workshopDate?: string
   workshopTime?: string
@@ -37,6 +43,7 @@ export async function sendBasicWorkshopConfirmation({
   userName,
   status = 'confirmed',
   conference,
+  orgId,
   workshopTitle,
   workshopDate,
   workshopTime,
@@ -114,8 +121,12 @@ export async function sendBasicWorkshopConfirmation({
       </html>
     `
 
+    const { client } = await resolveEmailSender(
+      orgId ?? conference?.organization?._ref,
+    )
+
     const emailResult = await retryWithBackoff(async () => {
-      const result = await resend.emails.send({
+      const result = await client.emails.send({
         from: fromEmail,
         to: [userEmail],
         subject,
@@ -223,8 +234,10 @@ export async function sendWorkshopSignupInstructions({
       </html>
     `
 
+    const { client } = await resolveEmailSender(conference?.organization?._ref)
+
     const emailResult = await retryWithBackoff(async () => {
-      const result = await resend.emails.send({
+      const result = await client.emails.send({
         from: fromEmail,
         to: [userEmail],
         subject,
@@ -331,8 +344,10 @@ export async function sendWorkshopAnnouncementEmail({
       </html>
     `
 
+    const { client } = await resolveEmailSender(conference?.organization?._ref)
+
     const emailResult = await retryWithBackoff(async () => {
-      const result = await resend.emails.send({
+      const result = await client.emails.send({
         from: fromEmail,
         to: [userEmail],
         subject,

--- a/src/lib/events/handlers/audienceUpdate.ts
+++ b/src/lib/events/handlers/audienceUpdate.ts
@@ -49,8 +49,11 @@ export async function handleAudienceUpdate(
     return
   }
 
-  const { audienceId, error: audienceError } =
-    await getOrCreateConferenceAudience(event.conference)
+  const {
+    audienceId,
+    client,
+    error: audienceError,
+  } = await getOrCreateConferenceAudience(event.conference)
 
   if (audienceError || !audienceId) {
     if (isRateLimitError(audienceError)) {
@@ -76,7 +79,7 @@ export async function handleAudienceUpdate(
       }
 
       if (isNowConfirmed) {
-        const result = await addSpeakerToAudience(audienceId, speaker)
+        const result = await addSpeakerToAudience(client, audienceId, speaker)
         if (result.success) {
           console.log(`Added speaker ${speaker.name} to audience`)
         } else {
@@ -93,6 +96,7 @@ export async function handleAudienceUpdate(
         }
       } else {
         const result = await removeSpeakerFromAudience(
+          client,
           audienceId,
           speaker.email,
         )

--- a/src/lib/events/handlers/emailNotification.ts
+++ b/src/lib/events/handlers/emailNotification.ts
@@ -61,6 +61,7 @@ export async function handleEmailNotification(
         },
         comment: event.metadata.comment || '',
         event: {
+          orgId: event.conference.organization?._ref,
           location: event.conference.city,
           date: formatDate(event.conference.startDate),
           name: event.conference.title,

--- a/src/lib/messaging/email.ts
+++ b/src/lib/messaging/email.ts
@@ -1,6 +1,6 @@
 import 'server-only'
 import React from 'react'
-import { resend, retryWithBackoff } from '@/lib/email/config'
+import { resolveEmailSender, retryWithBackoff } from '@/lib/email/config'
 import { MessageNotificationTemplate } from '@/components/email/MessageNotificationTemplate'
 import { emailBrandColor } from '@/lib/branding/theme'
 import type { Conference } from '@/lib/conference/types'
@@ -51,13 +51,15 @@ async function sendOne(
   },
 ): Promise<boolean> {
   try {
+    const { client } = await resolveEmailSender(conference.organization?._ref)
+
     await retryWithBackoff(async () => {
       // FIRST-CONTACT (S9c): a warmer subject when the organizers open a thread
       // with a speaker; every other email keeps the standard subject.
       const emailSubject = recipient.firstContact
         ? `The ${conference.title} organizers started a conversation with you — "${subject}"`
         : `New message about "${subject}"`
-      const result = await resend.emails.send({
+      const result = await client.emails.send({
         from: `${conference.organizer} <${conference.cfpEmail}>`,
         to: [recipient.email],
         subject: emailSubject,

--- a/src/lib/messaging/sponsorEmail.ts
+++ b/src/lib/messaging/sponsorEmail.ts
@@ -1,6 +1,6 @@
 import 'server-only'
 import React from 'react'
-import { resend, retryWithBackoff } from '@/lib/email/config'
+import { resolveEmailSender, retryWithBackoff } from '@/lib/email/config'
 import { SponsorMessageNotificationTemplate } from '@/components/email/SponsorMessageNotificationTemplate'
 import { emailBrandColor } from '@/lib/branding/theme'
 import type { Conference } from '@/lib/conference/types'
@@ -41,10 +41,12 @@ async function sendOne(
   },
 ): Promise<boolean> {
   try {
+    const { client } = await resolveEmailSender(conference.organization?._ref)
+
     await retryWithBackoff(async () => {
       const fromEmail = conference.sponsorEmail || conference.cfpEmail
       const fromName = conference.organizer || conference.title
-      const result = await resend.emails.send({
+      const result = await client.emails.send({
         from: `${fromName} <${fromEmail}>`,
         to: [recipient.email],
         subject: `New message about "${subject}"`,

--- a/src/lib/proposal/email/notification.ts
+++ b/src/lib/proposal/email/notification.ts
@@ -4,7 +4,7 @@ import {
   ProposalRejectTemplate,
   ProposalWaitlistTemplate,
 } from '@/components/email'
-import { resend, retryWithBackoff } from '@/lib/email/config'
+import { resolveEmailSender, retryWithBackoff } from '@/lib/email/config'
 import {
   NotificationParams,
   createTemplateProps,
@@ -70,8 +70,10 @@ export async function sendAcceptRejectNotification(params: NotificationParams) {
 
   // Retry transient provider failures (e.g. rate limits) with backoff,
   // consistent with the other email flows in the codebase
+  const { client } = await resolveEmailSender(params.event.orgId)
+
   return retryWithBackoff(async () => {
-    const { data, error } = await resend.emails.send({
+    const { data, error } = await client.emails.send({
       from: `${params.event.organizer} <${params.event.contactEmail}>`,
       to: [params.speaker.email],
       subject: subject,

--- a/src/lib/proposal/email/types.ts
+++ b/src/lib/proposal/email/types.ts
@@ -24,6 +24,12 @@ export interface ProposalAcceptTemplateProps extends BaseEmailTemplateProps {
 export type ProposalRejectTemplateProps = BaseEmailTemplateProps
 
 export interface NotificationEventData {
+  /**
+   * The owning organization, so the send resolves the TENANT's Resend account
+   * rather than the platform's (#843). Nullish ⇒ the platform account, which is
+   * the shared T0 tier and the behaviour every legacy caller already had.
+   */
+  orgId?: string | null
   location: string
   date: string
   name: string

--- a/src/lib/secrets/store.test.ts
+++ b/src/lib/secrets/store.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import {
   EnvSecretsStore,
   JsonEnvSecretsStore,
+  platformEnvCredentials,
   resolveTenantSecrets,
   type TenantSecretsStore,
 } from './store'
@@ -28,7 +29,10 @@ function fakeStore(
 }
 
 describe('EnvSecretsStore', () => {
-  it('returns env ticketing creds regardless of orgId', async () => {
+  it('returns env ticketing creds to every org when no platform org is configured', async () => {
+    // PLATFORM_ORG_ID is unset here (as in .env.test and every self-hosted
+    // deploy), which is the single-tenant case: the env is the only org's own.
+    vi.stubEnv('PLATFORM_ORG_ID', '')
     vi.stubEnv('CHECKIN_API_KEY', 'k')
     vi.stubEnv('CHECKIN_API_SECRET', 's')
     vi.stubEnv('CHECKIN_WEBHOOK_SECRET', 'w')
@@ -37,7 +41,6 @@ describe('EnvSecretsStore', () => {
     const a = await store.get('org-a', 'ticketing')
     const b = await store.get(null, 'ticketing')
     expect(a).toEqual({ apiKey: 'k', apiSecret: 's', webhookSecret: 'w' })
-    // Same platform creds no matter the org (today's shared-account behavior).
     expect(b).toEqual(a)
   })
 
@@ -91,6 +94,138 @@ describe('EnvSecretsStore', () => {
       ed25519Seed: 'seed',
       rsaOnly: true,
     })
+  })
+})
+
+/**
+ * #844 — the default chain must fail CLOSED.
+ *
+ * `EnvSecretsStore` used to be org-blind: it took an `orgId`, ignored it, and
+ * handed the platform's accounts to anybody, so a naive
+ * `resolveTenantSecrets(orgId, family)` silently returned another tenant's
+ * credentials. These tests pin the gate.
+ *
+ * HOW EACH ONE AVOIDS PASSING FOR THE WRONG REASON. A bare `toBeNull()` would
+ * also pass if the env var were simply unset (or a stub silently failed), which
+ * is exactly the false green that makes a security test worthless. So EVERY
+ * refusal below is asserted TOGETHER WITH the platform org's success under the
+ * IDENTICAL env, in the same test body. The only difference between the two
+ * assertions is the org id — so if the env were not configured, the paired
+ * platform assertion fails and the test cannot go green. `expect.not.toBeNull()`
+ * on the platform side is deliberate load-bearing scaffolding, not decoration.
+ */
+describe('EnvSecretsStore — cross-tenant isolation (#844)', () => {
+  const PLATFORM = 'org-platform'
+  const TENANT = 'org-tenant'
+
+  /** Every family, with an env value configured for each. */
+  function configureEveryFamily() {
+    vi.stubEnv('CHECKIN_API_KEY', 'checkin-key')
+    vi.stubEnv('CHECKIN_API_SECRET', 'checkin-secret')
+    vi.stubEnv('CHECKIN_WEBHOOK_SECRET', 'checkin-webhook')
+    vi.stubEnv('RESEND_API_KEY', 're_platform')
+    vi.stubEnv('SLACK_BOT_TOKEN', 'xoxb-platform')
+    vi.stubEnv('VAPID_PUBLIC_KEY', 'pub')
+    vi.stubEnv('VAPID_PRIVATE_KEY', 'priv')
+    vi.stubEnv('VAPID_SUBJECT', 'mailto:ops@platform.test')
+    vi.stubEnv('BADGE_ISSUER_RSA_PRIVATE_KEY', 'rsa-priv')
+    vi.stubEnv('BADGE_ISSUER_RSA_PUBLIC_KEY', 'rsa-pub')
+    vi.stubEnv('BADGE_ISSUER_ED25519_SEED', 'seed')
+  }
+
+  const FAMILIES: SecretFamily[] = [
+    'ticketing',
+    'email',
+    'slack',
+    'push',
+    'badge',
+  ]
+
+  it('refuses a NON-platform org every family the platform org receives', async () => {
+    vi.stubEnv('PLATFORM_ORG_ID', PLATFORM)
+    configureEveryFamily()
+    const store = new EnvSecretsStore()
+
+    for (const family of FAMILIES) {
+      // The control: with this exact env, the platform org DOES get creds. If
+      // this side ever went null the env would be unconfigured and the refusal
+      // below would prove nothing — so the pair is what makes the test real.
+      expect(await store.get(PLATFORM, family)).not.toBeNull()
+      // The guard under test.
+      expect(await store.get(TENANT, family)).toBeNull()
+    }
+  })
+
+  it('refuses an UNRESOLVABLE org (null/undefined/empty) once the contract is set', async () => {
+    vi.stubEnv('PLATFORM_ORG_ID', PLATFORM)
+    configureEveryFamily()
+    const store = new EnvSecretsStore()
+
+    expect(await store.get(PLATFORM, 'email')).not.toBeNull()
+    for (const orgId of [null, undefined, '']) {
+      expect(await store.get(orgId, 'email')).toBeNull()
+      expect(await store.get(orgId, 'slack')).toBeNull()
+    }
+  })
+
+  it('never matches on anything but the configured id — a look-alike gets nothing', async () => {
+    vi.stubEnv('PLATFORM_ORG_ID', PLATFORM)
+    configureEveryFamily()
+    const store = new EnvSecretsStore()
+
+    expect(await store.get(PLATFORM, 'slack')).not.toBeNull()
+    for (const impostor of [
+      `${PLATFORM}-2`,
+      ` ${PLATFORM}`,
+      PLATFORM.toUpperCase(),
+      'org-platform-clone',
+    ]) {
+      expect(await store.get(impostor, 'slack')).toBeNull()
+    }
+  })
+
+  it('keeps every org working when PLATFORM_ORG_ID is UNSET (single-tenant / self-hosted)', async () => {
+    vi.stubEnv('PLATFORM_ORG_ID', '')
+    configureEveryFamily()
+    const store = new EnvSecretsStore()
+
+    for (const family of FAMILIES) {
+      expect(await store.get(TENANT, family)).not.toBeNull()
+      expect(await store.get(null, family)).not.toBeNull()
+    }
+  })
+
+  it('DEFAULT chain: a tenant gets its OWN secret or nothing — never the platform env', async () => {
+    vi.stubEnv('PLATFORM_ORG_ID', PLATFORM)
+    vi.stubEnv('SLACK_BOT_TOKEN', 'xoxb-platform')
+    vi.stubEnv(
+      'TENANT_SECRETS_JSON',
+      JSON.stringify({ 'org-own': { slack: { botToken: 'xoxb-own' } } }),
+    )
+
+    // Control: the platform org still reaches its env token through the chain.
+    expect(await resolveTenantSecrets(PLATFORM, 'slack')).toEqual({
+      botToken: 'xoxb-platform',
+    })
+    // A tenant WITH its own secret gets that — provisioning is the grant.
+    expect(await resolveTenantSecrets('org-own', 'slack')).toEqual({
+      botToken: 'xoxb-own',
+    })
+    // A tenant WITHOUT one gets null, not 'xoxb-platform'. This is the exact
+    // call shape #844 says a future consumer would write naively.
+    expect(await resolveTenantSecrets(TENANT, 'slack')).toBeNull()
+  })
+
+  it('leaves the raw platform accessor org-blind on purpose (Slack reads it behind its own gate)', async () => {
+    vi.stubEnv('PLATFORM_ORG_ID', PLATFORM)
+    vi.stubEnv('SLACK_BOT_TOKEN', 'xoxb-platform')
+    // No orgId to pass: the caller, not this function, decides authorization.
+    expect(platformEnvCredentials('slack')).toEqual({
+      botToken: 'xoxb-platform',
+    })
+    // …and it is still honest about an unconfigured family.
+    vi.stubEnv('SLACK_BOT_TOKEN', '')
+    expect(platformEnvCredentials('slack')).toBeNull()
   })
 })
 

--- a/src/lib/secrets/store.ts
+++ b/src/lib/secrets/store.ts
@@ -1,4 +1,5 @@
 import 'server-only'
+import { resolvePlatformOrgId } from '@/lib/authz/platform'
 import type {
   BadgeSigningCredentials,
   EmailCredentials,
@@ -14,9 +15,15 @@ import type {
  *
  * WHAT THIS IS: the seam through which every integration's credentials are
  * resolved at the request boundary, keyed by organization, with the platform
- * environment as the default-tenant fallback. It lays the GROUNDWORK for
+ * environment as the DEFAULT TENANT's fallback. It lays the GROUNDWORK for
  * per-org secrets WITHOUT migrating today's setup — the global env stays the
  * platform-default tenant's credentials indefinitely.
+ *
+ * IT FAILS CLOSED (#844). "The default tenant" is a specific organization, not
+ * everybody: the env credentials reach the platform org (or, on a deploy with no
+ * `PLATFORM_ORG_ID`, the only org there is) and NOBODY else. A tenant with no
+ * secret of its own resolves to `null`, which every consumer already handles as
+ * "unconfigured". See {@link envCredentialsBelongToOrg}.
  *
  * WHAT THIS IS NOT: a management UI, and NOT a Sanity-backed store (secrets
  * never live in Sanity). #617's later wave adds the admin surface that writes
@@ -47,72 +54,150 @@ function anyConfigured(bag: object): boolean {
 }
 
 /**
- * (a) The platform-DEFAULT store: returns the environment credentials REGARDLESS
- * of `orgId`. This is today's behavior verbatim — every tenant shares the global
- * env account. Returns `null` for a family with ZERO configured env vars so the
- * resolver terminates at `null` and the consumer's own soft-fail path runs
- * (identical to unconfigured behavior today).
+ * Whether the DEPLOYMENT ENVIRONMENT's credentials are this organization's OWN.
+ *
+ * `RESEND_API_KEY`, `SLACK_BOT_TOKEN`, `CHECKIN_*` and friends are one set of
+ * accounts belonging to whoever owns the deployment. The one signal in the
+ * codebase for who that is, is the platform-org contract — the same three-case
+ * reading `isEmailDeliveryPlatformManaged` (`@/lib/settings/activation-server`)
+ * already uses:
+ *
+ *  - `PLATFORM_ORG_ID` UNSET → single-tenant / self-hosted. Nobody sits above
+ *    the organizer, so the env IS theirs. This is what keeps every deploy that
+ *    never opted into multi-tenancy — and every local checkout — byte-identical.
+ *  - SET, and this IS the platform org → the operator's own tenant. Theirs too.
+ *  - SET, and this is any OTHER tenant → the env belongs to the operator. The
+ *    tenant gets `null`.
+ *
+ * FAILS CLOSED on a nullish `orgId` whenever the contract is set: an
+ * unresolvable tenant must never resolve to someone else's account. (This is
+ * the one place the reading differs from `isEmailDeliveryPlatformManaged`, which
+ * answers a UI question — "is this row the organizer's to complete?" — and so
+ * fails the other way on purpose. Handing out a credential and rendering a
+ * checklist row have opposite safe directions.)
+ *
+ * Routed through `resolvePlatformOrgId()`, the ONE resolver for the contract
+ * (`@/lib/authz/platform`) — a pure env read, no Sanity access, no cache to go
+ * stale. It is imported directly rather than via `isPlatformOrganization`
+ * (`@/lib/features/platform`) only to keep this module's import graph free of
+ * `@/lib/organization/sanity`: `@/lib/email/config` imports this file and is in
+ * turn imported almost everywhere, so a Sanity edge here reaches the whole app.
+ * The comparison is the identical one.
+ */
+export function envCredentialsBelongToOrg(
+  orgId: string | null | undefined,
+): boolean {
+  const platformOrgId = resolvePlatformOrgId()
+  if (platformOrgId === null) return true
+  return Boolean(orgId) && orgId === platformOrgId
+}
+
+/**
+ * The DEPLOYMENT ENVIRONMENT's credentials for `family`, with NO org question
+ * asked. Returns `null` for a family with ZERO configured env vars so a resolver
+ * terminates at `null` and the consumer's own soft-fail path runs (identical to
+ * unconfigured behavior today).
+ *
+ * NOT a `TenantSecretsStore`, and deliberately takes no `orgId`: this is the raw
+ * platform credential, so every caller must have made its own authorization
+ * decision first. Grep for it — there is exactly one caller
+ * (`resolveConferenceSlackToken`, on the far side of the `slack-mirror` gate,
+ * which grants the platform token to override orgs that {@link EnvSecretsStore}
+ * itself would refuse). The org-KEYED way to ask for these is
+ * {@link EnvSecretsStore}, which is what the default chain uses.
+ *
+ * The ticketing mirror of this shape is `platformCheckinCredentials()` /
+ * `platformTitoCredentials()` in `@/lib/tickets/provider`.
  *
  * `process.env` is read at call time (not import) so this module stays
  * import-safe and honours test env stubbing.
  */
+export function platformEnvCredentials<F extends SecretFamily>(
+  family: F,
+): FamilyCredentials<F> | null {
+  const env = process.env
+  switch (family) {
+    case 'ticketing': {
+      // The env-backed ticketing family is CHECKIN-SHAPED. Tito's platform
+      // fallback is NOT here — it lives in `platformTitoCredentials()`
+      // (TITO_API_KEY / TITO_WEBHOOK_SECRET) and the Tito resolver branch
+      // skips this env store, because a single (orgId, 'ticketing') lookup
+      // can't know which vendor a conference selected. Per-org Tito secrets
+      // still flow through the provider-agnostic JSON store below.
+      const bag: TicketingCredentials = {
+        apiKey: env.CHECKIN_API_KEY,
+        apiSecret: env.CHECKIN_API_SECRET,
+        webhookSecret: env.CHECKIN_WEBHOOK_SECRET,
+      }
+      return (anyConfigured(bag) ? bag : null) as FamilyCredentials<F> | null
+    }
+    case 'email': {
+      const apiKey = env.RESEND_API_KEY
+      if (!apiKey) return null
+      const bag: EmailCredentials = { apiKey }
+      return bag as FamilyCredentials<F>
+    }
+    case 'slack': {
+      const botToken = env.SLACK_BOT_TOKEN
+      if (!botToken) return null
+      const bag: SlackCredentials = { botToken }
+      return bag as FamilyCredentials<F>
+    }
+    case 'push': {
+      const bag: PushCredentials = {
+        publicKey: env.VAPID_PUBLIC_KEY ?? '',
+        privateKey: env.VAPID_PRIVATE_KEY ?? '',
+        subject: env.VAPID_SUBJECT?.trim() ?? '',
+      }
+      return (anyConfigured(bag) ? bag : null) as FamilyCredentials<F> | null
+    }
+    case 'badge': {
+      const rsaPrivateKey = env.BADGE_ISSUER_RSA_PRIVATE_KEY
+      const rsaPublicKey = env.BADGE_ISSUER_RSA_PUBLIC_KEY
+      const ed25519Seed = env.BADGE_ISSUER_ED25519_SEED
+      if (!rsaPrivateKey && !rsaPublicKey && !ed25519Seed) return null
+      const bag: BadgeSigningCredentials = {
+        rsaPrivateKey: rsaPrivateKey ?? '',
+        rsaPublicKey: rsaPublicKey ?? '',
+        ed25519Seed: ed25519Seed ?? '',
+        rsaOnly: env.BADGE_ISSUER_RSA_ONLY === 'true',
+      }
+      return bag as FamilyCredentials<F>
+    }
+    default:
+      return null
+  }
+}
+
+/**
+ * (a) The platform-DEFAULT store: the deployment environment's credentials,
+ * handed out ONLY to the organization those credentials actually belong to
+ * ({@link envCredentialsBelongToOrg}). Any other tenant — and any unresolvable
+ * tenant once `PLATFORM_ORG_ID` is set — gets `null`, so the default chain
+ * terminates at `null` and the consumer takes the same soft-fail path it takes
+ * when nothing is configured at all.
+ *
+ * WHY IT IS GATED HERE rather than at each consumer (#844). This store used to
+ * be org-BLIND: it took an `orgId`, ignored it, and returned the platform's
+ * accounts to anybody. Nothing in the type system or the call shape distinguished
+ * a careless `resolveTenantSecrets(orgId, family)` from a correct one — the same
+ * fail-open class as a scoped query that silently runs global when its org is
+ * `null`. Two of the three consumers had already had to work around the default
+ * (ticketing bypassed the chain, Slack gated it), which is the signal that the
+ * default pointed the wrong way. Now the careless call gets `null`.
+ *
+ * NOT A REPLACEMENT for a consumer's own authorization. Answering "these
+ * credentials are yours" is not the same question as "you may use this
+ * integration": `resolveTicketingCredentials` and `resolveConferenceSlackToken`
+ * both still decide their own, and this store is the floor beneath them.
+ */
 export class EnvSecretsStore implements TenantSecretsStore {
   async get<F extends SecretFamily>(
-    _orgId: string | null | undefined,
+    orgId: string | null | undefined,
     family: F,
   ): Promise<FamilyCredentials<F> | null> {
-    const env = process.env
-    switch (family) {
-      case 'ticketing': {
-        // The env-backed ticketing family is CHECKIN-SHAPED. Tito's platform
-        // fallback is NOT here — it lives in `platformTitoCredentials()`
-        // (TITO_API_KEY / TITO_WEBHOOK_SECRET) and the Tito resolver branch
-        // skips this env store, because a single (orgId, 'ticketing') lookup
-        // can't know which vendor a conference selected. Per-org Tito secrets
-        // still flow through the provider-agnostic JSON store below.
-        const bag: TicketingCredentials = {
-          apiKey: env.CHECKIN_API_KEY,
-          apiSecret: env.CHECKIN_API_SECRET,
-          webhookSecret: env.CHECKIN_WEBHOOK_SECRET,
-        }
-        return (anyConfigured(bag) ? bag : null) as FamilyCredentials<F> | null
-      }
-      case 'email': {
-        const apiKey = env.RESEND_API_KEY
-        if (!apiKey) return null
-        const bag: EmailCredentials = { apiKey }
-        return bag as FamilyCredentials<F>
-      }
-      case 'slack': {
-        const botToken = env.SLACK_BOT_TOKEN
-        if (!botToken) return null
-        const bag: SlackCredentials = { botToken }
-        return bag as FamilyCredentials<F>
-      }
-      case 'push': {
-        const bag: PushCredentials = {
-          publicKey: env.VAPID_PUBLIC_KEY ?? '',
-          privateKey: env.VAPID_PRIVATE_KEY ?? '',
-          subject: env.VAPID_SUBJECT?.trim() ?? '',
-        }
-        return (anyConfigured(bag) ? bag : null) as FamilyCredentials<F> | null
-      }
-      case 'badge': {
-        const rsaPrivateKey = env.BADGE_ISSUER_RSA_PRIVATE_KEY
-        const rsaPublicKey = env.BADGE_ISSUER_RSA_PUBLIC_KEY
-        const ed25519Seed = env.BADGE_ISSUER_ED25519_SEED
-        if (!rsaPrivateKey && !rsaPublicKey && !ed25519Seed) return null
-        const bag: BadgeSigningCredentials = {
-          rsaPrivateKey: rsaPrivateKey ?? '',
-          rsaPublicKey: rsaPublicKey ?? '',
-          ed25519Seed: ed25519Seed ?? '',
-          rsaOnly: env.BADGE_ISSUER_RSA_ONLY === 'true',
-        }
-        return bag as FamilyCredentials<F>
-      }
-      default:
-        return null
-    }
+    if (!envCredentialsBelongToOrg(orgId)) return null
+    return platformEnvCredentials(family)
   }
 }
 
@@ -198,9 +283,13 @@ export const perOrgSecretsStore: TenantSecretsStore = new JsonEnvSecretsStore()
 
 /**
  * The production resolution chain: a per-org hit wins, otherwise the platform
- * env default, otherwise `null`. A real secret-manager store slots in front of
- * `envSecretsStore` here (or replaces `perOrgSecretsStore`) behind the exact
- * same interface — no consumer changes.
+ * env default IF the env belongs to that org, otherwise `null`. A real
+ * secret-manager store slots in front of `envSecretsStore` here (or replaces
+ * `perOrgSecretsStore`) behind the exact same interface — no consumer changes.
+ *
+ * SAFE TO USE NAIVELY (#844): `resolveTenantSecrets(orgId, family)` on this chain
+ * hands a non-platform tenant its OWN credentials or nothing. It cannot hand it
+ * the platform's.
  */
 export const DEFAULT_SECRETS_CHAIN: readonly TenantSecretsStore[] = [
   perOrgSecretsStore,

--- a/src/lib/slack/token.ts
+++ b/src/lib/slack/token.ts
@@ -1,5 +1,5 @@
 import 'server-only'
-import { perOrgSecretsStore, envSecretsStore } from '@/lib/secrets/store'
+import { perOrgSecretsStore, platformEnvCredentials } from '@/lib/secrets/store'
 import { isSlackMirrorEnabledForOrg } from '@/lib/features/slack'
 
 /** Only the conference field the Slack token resolver needs. */
@@ -42,8 +42,11 @@ export async function resolveConferenceSlackToken(
 
   if (!(await isSlackMirrorEnabledForOrg(orgId))) return undefined
 
-  // `EnvSecretsStore` is org-BLIND (it returns the platform env for any org id),
-  // so it is only ever read on the far side of the gate above.
-  const platform = await envSecretsStore.get(orgId, 'slack')
-  return platform?.botToken
+  // Deliberately `platformEnvCredentials` (the raw env accessor) and NOT the
+  // org-keyed `envSecretsStore`, which since #844 refuses every non-platform
+  // org. The gate above is BROADER than that store's rule by design: an ACTIVE
+  // `slack-mirror` override grants a non-platform pilot org the platform bot
+  // token, and the store would take it straight back. The gate is the
+  // authorization decision here; this line just reads the credential it granted.
+  return platformEnvCredentials('slack')?.botToken
 }

--- a/src/lib/speaker/ticket-email.ts
+++ b/src/lib/speaker/ticket-email.ts
@@ -1,5 +1,9 @@
 import { SpeakerTicketEmailTemplate } from '@/components/email'
-import { resend, retryWithBackoff, isTransientError } from '@/lib/email/config'
+import {
+  resolveEmailSender,
+  retryWithBackoff,
+  isTransientError,
+} from '@/lib/email/config'
 import type { Conference } from '@/lib/conference/types'
 import { formatDate } from '@/lib/time'
 import { emailBrandColor } from '@/lib/branding/theme'
@@ -12,6 +16,9 @@ export interface SendSpeakerTicketEmailParams {
   eventUrl: string
   conference: Pick<
     Conference,
+    // `organization` is what resolves the tenant's own Resend account (#843);
+    // a narrower projection would silently send on the platform's.
+    | 'organization'
     | 'title'
     | 'city'
     | 'organizer'
@@ -61,9 +68,11 @@ export async function sendSpeakerTicketEmail({
   // Retry not just rate limits but any transient provider (5xx) or network
   // failure: the coupon is created before this send, so a blip here must not
   // permanently strand the speaker without their ticket email.
+  const { client } = await resolveEmailSender(conference.organization?._ref)
+
   return retryWithBackoff(
     async () => {
-      const { data, error } = await resend.emails.send({
+      const { data, error } = await client.emails.send({
         from,
         to: [speaker.email],
         subject,

--- a/src/lib/tickets/provider/index.ts
+++ b/src/lib/tickets/provider/index.ts
@@ -76,8 +76,8 @@ export function platformCheckinCredentials(): TicketingProviderCredentials {
  * security token (`TITO_WEBHOOK_SECRET`).
  *
  * NOTE on the resolver: the env-backed `ticketing` family in `EnvSecretsStore`
- * is Checkin-shaped (it reads `CHECKIN_*`) AND org-blind, so
- * {@link resolveTicketingCredentials} does not use that store at all — it reads
+ * is CHECKIN-shaped (it reads `CHECKIN_*`), so a single (orgId, 'ticketing')
+ * lookup cannot serve Tito. {@link resolveTicketingCredentials} therefore reads
  * per-org secrets from the provider-agnostic JSON store and layers the
  * platform-org-only env fallback (this function for Tito) on top itself.
  */
@@ -125,9 +125,17 @@ export async function resolveTicketingCredentials(
   orgId: string | null | undefined,
   providerType: TicketingProviderType,
 ): Promise<TicketingProviderCredentials | null> {
-  // The env-backed `ticketing` family in `EnvSecretsStore` is Checkin-shaped AND
-  // org-blind (it returns the platform env for ANY org id), so the chain here is
-  // the per-org store ONLY; the platform env is layered back on below, gated.
+  // The chain here is the per-org store ONLY; the platform env is layered back
+  // on below. Two reasons this does not just use DEFAULT_SECRETS_CHAIN even now
+  // that `EnvSecretsStore` fails closed (#844):
+  //  1. VENDOR. The env-backed `ticketing` family is Checkin-shaped, so it
+  //     cannot answer for a Tito conference — `platformTitoCredentials()` can.
+  //  2. CONFIGURED-NESS. `platformCheckinCredentials()` returns a bag even when
+  //     every `CHECKIN_*` var is unset, which the platform org currently sees as
+  //     `configured: true` and fails at provider call time; `EnvSecretsStore`
+  //     would return `null` and render the unconfigured empty state instead.
+  //     That is arguably better, but it is a behaviour change, so it is not
+  //     smuggled in here.
   const perOrg = await resolveTenantSecrets(orgId, 'ticketing', [
     perOrgSecretsStore,
   ])

--- a/src/lib/volunteer/sanity.ts
+++ b/src/lib/volunteer/sanity.ts
@@ -37,7 +37,8 @@ export async function getVolunteersByConference(
         startDate,
         domains,
         organizer,
-        socialLinks
+        socialLinks,
+        organization
       },
       consent,
       status,
@@ -93,7 +94,8 @@ export async function getVolunteerById(
         startDate,
         domains,
         organizer,
-        socialLinks
+        socialLinks,
+        organization
       },
       consent,
       status,

--- a/src/lib/volunteer/types.ts
+++ b/src/lib/volunteer/types.ts
@@ -70,6 +70,8 @@ export interface VolunteerWithConference extends Omit<
   conference: {
     _id: string
     title: string
+    /** The owning tenant, so the approval email resolves ITS Resend account. */
+    organization?: { _ref?: string } | null
     contactEmail?: string
     cfpEmail?: string
     city?: string

--- a/src/server/routers/registration.ts
+++ b/src/server/routers/registration.ts
@@ -262,7 +262,8 @@ export const registrationRouter = router({
       // Send email
       const { SponsorPortalInviteTemplate } =
         await import('@/components/email/SponsorPortalInviteTemplate')
-      const { resend, retryWithBackoff } = await import('@/lib/email/config')
+      const { resolveEmailSender, retryWithBackoff } =
+        await import('@/lib/email/config')
       const { formatConferenceDateLong } = await import('@/lib/time')
       const React = await import('react')
 
@@ -293,8 +294,10 @@ export const registrationRouter = router({
         localPart: 'sponsors',
       })
 
+      const { client } = await resolveEmailSender(ctx.orgId)
+
       const result = await retryWithBackoff(async () => {
-        return resend.emails.send({
+        return client.emails.send({
           from,
           to: recipients,
           subject: `Sponsor Registration — ${sfc.conference!.title}`,

--- a/src/server/routers/signing.ts
+++ b/src/server/routers/signing.ts
@@ -227,7 +227,7 @@ export const signingRouter = router({
         if (doc.conference?.sponsorEmail && doc.signerEmail) {
           const { renderContractEmail, CONTRACT_EMAIL_SLUGS } =
             await import('@/lib/email/contract-email')
-          const { resend, retryWithBackoff } =
+          const { resolveEmailSender, retryWithBackoff } =
             await import('@/lib/email/config')
 
           const { formatNumber } = await import('@/lib/format')
@@ -261,8 +261,14 @@ export const signingRouter = router({
             const fromEmail = doc.conference.sponsorEmail
             const fromName = doc.conference.organizer || PLATFORM_NAME
 
+            // Public endpoint — no request org. The tenant comes off the
+            // contract's own conference, which projects `organization`.
+            const { client } = await resolveEmailSender(
+              doc.conference.organization?._ref,
+            )
+
             await retryWithBackoff(async () => {
-              return resend.emails.send({
+              return client.emails.send({
                 from: `${fromName} <${fromEmail}>`,
                 to: [doc.signerEmail],
                 subject: result.subject,

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -153,7 +153,7 @@ import {
   getSigningProvider,
   type SigningProviderType,
 } from '@/lib/contract-signing'
-import { resend, retryWithBackoff } from '@/lib/email/config'
+import { resolveEmailSender, retryWithBackoff } from '@/lib/email/config'
 import { resolveConferenceFrom } from '@/lib/email/from'
 import { sendBroadcastEmail } from '@/lib/email/broadcast'
 import { sendIndividualEmail } from '@/lib/email/broadcast'
@@ -2354,7 +2354,7 @@ export const sponsorRouter = router({
           try {
             const { renderContractEmail, CONTRACT_EMAIL_SLUGS } =
               await import('@/lib/email/contract-email')
-            const { resend, retryWithBackoff } =
+            const { resolveEmailSender, retryWithBackoff } =
               await import('@/lib/email/config')
 
             const { formatNumber } = await import('@/lib/format')
@@ -2403,8 +2403,10 @@ export const sponsorRouter = router({
                 localPart: 'sponsors',
               })
 
+              const { client } = await resolveEmailSender(ctx.orgId)
+
               await retryWithBackoff(async () => {
-                return resend.emails.send({
+                return client.emails.send({
                   from,
                   to: [input.signerEmail!],
                   subject: result.subject,
@@ -2521,8 +2523,10 @@ export const sponsorRouter = router({
           })
         }
 
+        const { client } = await resolveEmailSender(ctx.orgId)
+
         const result = await retryWithBackoff(async () => {
-          return await resend.emails.send({
+          return await client.emails.send({
             from: `${conference.organizer || PLATFORM_NAME} <${conference.sponsorEmail}>`,
             to: recipients.map((r) => r.email),
             subject: input.subject,
@@ -2674,8 +2678,10 @@ export const sponsorRouter = router({
           })
         }
 
+        const { client } = await resolveEmailSender(ctx.orgId)
+
         const result = await retryWithBackoff(async () => {
-          return await resend.emails.send({
+          return await client.emails.send({
             from: `${conference.organizer || PLATFORM_NAME} <${conference.sponsorEmail}>`,
             to: recipients.map((r) => r.email),
             subject: input.subject,

--- a/src/server/routers/status.ts
+++ b/src/server/routers/status.ts
@@ -167,6 +167,13 @@ export const statusRouter = router({
         }
       }
       try {
+        // DELIBERATELY the PLATFORM client, not `resolveEmailSender(ctx.orgId)`
+        // — the only such send left in the codebase (#843), allowlisted in
+        // `src/lib/email/platform-client-usage.test.ts`. This probe's SUBJECT is
+        // the platform account's own deliverability; resolving per org would
+        // silently report a different account's health, which is the opposite of
+        // what an operator clicking "send a test email" is asking.
+        //
         // Lazy import: `@/lib/email/config` asserts RESEND_API_KEY at module load.
         const { resend } = await import('@/lib/email/config')
         const { data, error } = await resend.emails.send({

--- a/src/server/routers/volunteer.ts
+++ b/src/server/routers/volunteer.ts
@@ -334,6 +334,7 @@ export const volunteerRouter = router({
             conferenceForEmail = {
               _id: volunteer.conference?._id || currentConf._id,
               title: volunteer.conference?.title || currentConf.title,
+              organization: currentConf.organization,
               contactEmail: currentConf.contactEmail,
               cfpEmail: currentConf.cfpEmail,
               city: currentConf.city,

--- a/src/server/routers/volunteer.ts
+++ b/src/server/routers/volunteer.ts
@@ -334,7 +334,18 @@ export const volunteerRouter = router({
             conferenceForEmail = {
               _id: volunteer.conference?._id || currentConf._id,
               title: volunteer.conference?.title || currentConf.title,
-              organization: currentConf.organization,
+              // SAME PRECEDENCE as the `_id`/`title` above, deliberately: this
+              // is the key `resolveEmailSender` resolves the Resend account
+              // from, so it must follow the identity it accompanies — the
+              // VOLUNTEER's conference — not the request's domain. Taking it
+              // from `currentConf` would send a volunteer of org A through org
+              // B's Resend account whenever B's organizer processes A's
+              // volunteer, which `getVolunteerById` (a global by-id fetch) and
+              // this procedure's missing `requireDocumentInCurrentConference`
+              // make reachable. The fallback arm is correct only in the case it
+              // now covers: a volunteer with NO conference at all.
+              organization:
+                volunteer.conference?.organization ?? currentConf.organization,
               contactEmail: currentConf.contactEmail,
               cfpEmail: currentConf.cfpEmail,
               city: currentConf.city,

--- a/src/server/routers/workshop.ts
+++ b/src/server/routers/workshop.ts
@@ -1050,7 +1050,7 @@ export const workshopRouter = router({
 
     manualSignup: workshopAdminProcedure
       .input(workshopSignupInputSchema.omit({ conference: true }))
-      .mutation(async ({ input }) => {
+      .mutation(async ({ ctx, input }) => {
         try {
           // Conference is resolved from the request domain — never client
           // input — so an organizer cannot write signups into another
@@ -1102,6 +1102,8 @@ export const workshopRouter = router({
           await sendBasicWorkshopConfirmation({
             userEmail: signup.userEmail,
             userName: signup.userName,
+            // No conference document here — the request's org IS the tenant.
+            orgId: ctx.orgId,
             workshopTitle: signup.workshop?.title ?? input.workshop._ref,
             workshopDate: (signup.workshop as { date?: string })?.date,
             workshopTime: (signup.workshop as { startTime?: string })


### PR DESCRIPTION
Closes #844. Closes #843.

Both are the same seam — which organization's credentials a request resolves — so they are fixed together rather than re-litigating the design twice.

## #844 — the chain now fails closed

`EnvSecretsStore.get()` took an `orgId` and genuinely ignored it, so `DEFAULT_SECRETS_CHAIN` handed the platform's accounts to any tenant. Nothing in the type system or the call shape distinguished a careless `resolveTenantSecrets(orgId, family)` from a correct one.

`envCredentialsBelongToOrg` now gates it, with the same three-case reading `isEmailDeliveryPlatformManaged` already uses:

| `PLATFORM_ORG_ID` | org | result |
| --- | --- | --- |
| unset | any (incl. nullish) | env credentials — single-tenant/self-hosted, the env *is* the only org's |
| set | the platform org | env credentials |
| set | any other org | `null` |
| set | nullish/unresolvable | `null` (fail closed) |

It reads `resolvePlatformOrgId()` directly rather than `isPlatformOrganization` **only** to keep `@/lib/organization/sanity` out of this module's import graph — `@/lib/email/config` imports it and is imported almost everywhere. The comparison is identical.

### No current consumer changes behaviour — this is preventive

Stating this plainly because the issue is right that there is no live leak, and it would be easy to overclaim:

- **Ticketing** never used the env store (the env `ticketing` family is Checkin-shaped, so it can't answer for Tito). Unchanged. I did **not** fold it into the default chain: `platformCheckinCredentials()` returns a bag even when every `CHECKIN_*` var is unset, which the platform org currently sees as `configured: true`, whereas `EnvSecretsStore` returns `null` and would render the unconfigured empty state. That is arguably better but it is a behaviour change, so it is not smuggled in here. The stale comments explaining the old bypass are corrected.
- **Slack** keeps its gate and now reads `platformEnvCredentials` (a new raw, org-blind accessor) on the far side of it. **This is load-bearing, not cosmetic**: an active `slack-mirror` override grants a non-platform pilot org the platform token, and the gated store would take it straight back. Proven — swapping Slack onto `envSecretsStore` fails the pre-existing `honours an explicit override granting a pilot org the platform token`.
- **Email** absorbs the `null` in `config.ts`'s own fallback (see below).
- **push / badge** have no live consumers (seam only).

## #843 — per-org email credentials are now actually used

`resolveEmailSender(orgId)` had one production caller. Every other send path imported the platform singleton, so a tenant with its own Resend key still sent all attendee/speaker/sponsor mail through the platform account.

**The issue's list of 10 was incomplete — it is 17.** The four `await import('@/lib/email/config')` sites (`registration.ts`, `signing.ts`, `sponsor.ts:2357`, `status.ts`) and the relative-path importers in `src/lib/email/*` do not show up in a static `@/lib/email/config` grep. All are converted except the allowlisted probe.

Each site resolves from what it already had: `conference.organization?._ref`, `ctx.orgId`, or the contract's own conference. Two projections that dropped the tenant were widened (`volunteer` GROQ, `ticket-email`'s `Pick`), and `NotificationEventData` / workshop confirmation gained an explicit `orgId` for the paths with no conference document.

### The audience/broadcast caveat, worked out

A Resend `audienceId` is **not** a per-message choice — it is an account-scoped handle, meaningless on any other account. So "which client" has different semantics there, and the fix is different: **the id now travels with the client that minted it.** The resolvers return `{ audienceId, client }`; the four id-taking functions take that client as a parameter; the broadcast is created on the same one. Re-resolving from an org id at the point of use would be the bug — it could resolve to a different account than the one holding the id, silently.

Nothing persists an `audienceId` (they are looked up by name via `audiences.list()` each call), so moving a tenant onto its own account is self-healing rather than a migration. This is enforced at compile time: you can no longer call `addContactToAudience` without saying which account.

### The two fixes do not conflict

Email deliberately uses the platform account as the shared T0 tier. #844 makes the chain return `null` there — but `resolveEmailSender` has its own explicit fallback, so a tenant lands on the **same cached instance by identity**. `sender-policy.ts:188` still forces a platform-verified From. Pinned by `resolveEmailSender under the #844 platform-org gate`, using `toBe` not `toEqual` (a second client built from the same key would enforce the policy too, so a shape comparison could not tell the tier from a regression).

## Sabotage proofs

Every guard was reverted, run, and restored. File **and** test counts checked each time.

| Sabotage | Result |
| --- | --- |
| `envCredentialsBelongToOrg` → `return true` | **511 files / 7492 collected**, 4 failures — exactly the four #844 guard tests |
| Slack → gated `envSecretsStore` | 1 failure — the pre-existing override test (proves the raw accessor is necessary) |
| `gallery.ts` back onto the singleton | **found a hole — see below** |
| ditto, after fixing the scanner | **512 files / 7499 collected**, 1 failure — the allowlist guard |
| `resolveEmailSender` T0 fallback → fresh client | **512 / 7499 collected**, 6 failures incl. both new tier tests |
| `volunteer.ts` org key → `currentConf.organization` | **512 / 7500 collected**, 1 failure — the new cross-tenant sender test, failing on the VALUE (`'org-test'` vs `'organization-other-tenant'`), not on an absence |

**The first version of the allowlist guard was wrong and the sabotage caught it.** It matched the import *specifier* against `/email\/config/`, which silently misses every relative `'./config'` import in `src/lib/email/` — exactly the blind spot #843 documents about the naive grep. Re-pointing `gallery.ts` at the singleton left the suite fully green. The scanner now **resolves** specifiers (`@/…` and `./…`) to a real path, and a test pins both import forms against synthetic sources.

### How these avoid passing for the wrong reason

- Every #844 refusal is asserted **together with the platform org succeeding under the identical env**, in the same test body. A bare `toBeNull()` would also pass if the env var were unset or a stub silently failed; the paired assertion makes an unconfigured env fail the test instead.
- The allowlist guard asserts the set **exactly, in both directions** — a new importer fails one assertion, and a scanner that walked an empty tree fails the other.

## Verification

Baseline is `origin/main` in a clean worktree.

| | baseline | after |
| --- | --- | --- |
| `pnpm test` | 511 files / 7486 tests (1 pre-existing flake¹) | **512 files / 7500 tests, all pass** |
| `pnpm typecheck` | 0 errors | **0 errors** |
| `npx eslint .` | 0 errors, 201 warnings | **0 errors, 201 warnings** |
| `npx prettier --check .` | clean | **clean** |

¹ `migrations/046-…/plan.test.ts` "rasterizes to a PWA icon" times out at 5s on this machine; unrelated, and it passes on reruns.

**The +14 test delta reconciles exactly**: 6 (#844 guards) + 2 (T0 tier) + 4 (allowlist guard, incl. the one added after the sabotage) + 1 (cross-tenant volunteer sender) + 1 (`email.gate.test.ts` generates one test per scanned source file, and this PR adds one).

## Cloud Native Days Norway keeps full capability

Verified against production Sanity, not inferred: the sole org is `organization-cloud-native-days`, `plan: "pro"`, `featureOverrides: null`.

All three cases are safe:
- `PLATFORM_ORG_ID` set to that id → CNDN is the platform org, env flows exactly as before.
- Unset → `resolvePlatformOrgId() === null` → env flows to everyone, unchanged.
- Set to anything else → CNDN would *already* have no ticketing and no Slack today, since both already gate on `isPlatformOrganization`. Email is unaffected regardless, because `config.ts`'s fallback is independent of the chain.

## A defect review caught in this PR's own new code

Recording it because it is the most instructive thing here, and because I did not spot it myself.

Threading `resolveEmailSender` through `volunteer.ts` meant adding an `organization` field to a conference object the procedure rebuilds when the volunteer's own conference has no `contactEmail`. I took it from `currentConf` — **the request domain's org** — while the adjacent `_id` and `title` lines take theirs from the volunteer's conference. Since `organization` is the key `resolveEmailSender` resolves the Resend account from, a volunteer of org A processed from org B's domain would have sent **org A's mail through org B's Resend account**.

That is the same shape this PR names as the enemy: a scope key taken from the *request* rather than from the *document*. Fixed to use the same precedence as the lines around it:

```ts
organization: volunteer.conference?.organization ?? currentConf.organization,
```

**It was reachable, not theoretical.** `sendEmail` is the one volunteer procedure without `requireDocumentInCurrentConference` (its four siblings have it), and `getVolunteerById` is a global by-id fetch with no conference or org predicate — so an organizer of org B can pass a volunteer id from org A. Production data makes it inexpressible today (one org, every conference has a `contactEmail`), which is precisely the "no live leak, fail-open shape anyway" standard #844 itself is justified on.

The missing tenancy guard is **pre-existing on `main`** and is the root cause rather than the symptom, so it is filed as #858 rather than fixed here. With the guard in place the whole rebuild becomes harmless by construction. #858 also records a correctness bug independent of credentials: the rebuild pairs conference A's `_id`/`title` with conference B's `contactEmail`, `city`, `country`, `startDate`, `domains`, `organizer` and `socialLinks`, so a recipient can get mail titled for one event carrying another's date, location and reply address. Only the `organization` field is fixed here, because only that one is a credential-isolation issue.

## Holes I am not claiming to have closed

- **`status.ts` still sends on the platform account** by design (it probes that account's deliverability). It is allowlisted with a written reason, not silently skipped.
- The allowlist guard is a **source scan**, so it sees imports, not runtime behaviour. A send path that received a `Resend` instance as a parameter from elsewhere would not be caught. Every current path resolves its own.
- `TENANT_SECRETS_JSON`'s shape guard checks "non-empty object", not that `apiKey` is a string. Pre-existing; out of scope here.
- Nothing here gates per-org email on the `dedicated-email` PRO entitlement — that is still RunKonf/platform#26, deliberately untouched.
- **The residue of the above**: the seven non-credential fields of the volunteer email's rebuilt conference are still hybridised, and `volunteer.admin.sendEmail` still has no ownership check. Both are pre-existing and tracked in #858. This PR leaves the credential key correct even without that guard; it does not make the procedure tenant-safe.

Not merged — for review.
