### PR TITLE
fix(volunteer): scope sendEmail to the request's conference

### DIFF
--- a/src/server/routers/tenancy.writes.more.test.ts
+++ b/src/server/routers/tenancy.writes.more.test.ts
@@ -127,6 +127,10 @@ const vol = vi.hoisted(() => ({
   updateVolunteerStatus: vi.fn(),
   updateVolunteerDetails: vi.fn(),
   deleteVolunteer: vi.fn(),
+  sendVolunteerApprovalEmail: vi.fn(),
+}))
+vi.mock('@/lib/email/volunteer', () => ({
+  sendVolunteerApprovalEmail: vol.sendVolunteerApprovalEmail,
 }))
 vi.mock('@/lib/volunteer/sanity', () => ({
   getVolunteersByConference: vi.fn(),
@@ -233,6 +237,10 @@ beforeEach(() => {
   vol.updateVolunteerStatus.mockResolvedValue({ success: true, error: null })
   vol.updateVolunteerDetails.mockResolvedValue({ success: true, error: null })
   vol.deleteVolunteer.mockResolvedValue({ success: true, error: null })
+  vol.sendVolunteerApprovalEmail.mockResolvedValue({
+    data: { emailId: 'email-1' },
+    error: null,
+  })
   vi.spyOn(console, 'warn').mockImplementation(() => {})
   vi.spyOn(console, 'error').mockImplementation(() => {})
 })
@@ -435,5 +443,177 @@ describe('volunteer mutations are conference-scoped (#730)', () => {
       volunteer().admin.delete({ volunteerId: 'vol-A' }),
     ).resolves.toBeTruthy()
     expect(vol.deleteVolunteer).toHaveBeenCalledWith('vol-A')
+  })
+})
+
+/**
+ * `sendEmail` was the ONE volunteer procedure the #730 sweep skipped (#858) —
+ * its four siblings above all carry the guard.
+ *
+ * Every case here hands the procedure a volunteer that would otherwise sail
+ * through: APPROVED (so the status check cannot be what refuses) and carrying a
+ * complete conference (so the conference lookup cannot be what refuses). The
+ * refusal asserted is therefore the guard's own MESSAGE, not merely its code —
+ * `NOT_FOUND` alone is ambiguous here, because 'Volunteer not found' and the
+ * authz waist both use it. Only `requireDocumentInCurrentConference` says
+ * "No volunteer with that id for this request".
+ */
+describe('volunteer.sendEmail is conference-scoped (#858)', () => {
+  const GUARD_REFUSAL = 'No volunteer with that id for this request'
+
+  /** A volunteer that nothing BUT the ownership guard could refuse. */
+  function approvedVolunteer(conference: Record<string, unknown> | null) {
+    vol.getVolunteerById.mockResolvedValue({
+      volunteer: {
+        _id: 'vol-B',
+        name: 'Foreign Volunteer',
+        email: 'foreign@example.com',
+        status: 'approved',
+        conference,
+      },
+      error: null,
+    })
+  }
+
+  const send = () =>
+    volunteer().admin.sendEmail({
+      volunteerId: 'vol-B',
+      subject: 'Hello',
+      message: 'You are in',
+    })
+
+  it('refuses another tenant’s volunteer, reads nothing and sends nothing', async () => {
+    foreign('volunteer')
+    approvedVolunteer({
+      _id: 'conf-OTHER',
+      title: 'Their Conference',
+      contactEmail: 'them@example.com',
+    })
+    await expect(send()).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+      message: GUARD_REFUSAL,
+    })
+    // The guard runs BEFORE the lookup, so the foreign volunteer's name and
+    // email address never enter this request at all.
+    expect(vol.getVolunteerById).not.toHaveBeenCalled()
+    expect(vol.sendVolunteerApprovalEmail).not.toHaveBeenCalled()
+  })
+
+  it('refuses ANOTHER EDITION OF OUR OWN ORG — the boundary is the conference', async () => {
+    // Same organization, different conference. An org-level guard would admit
+    // this; only the conference-level one refuses it. This is the case that
+    // produced the identity hybrid without needing a second tenant at all.
+    h.tenant = {
+      _type: 'volunteer',
+      orgId: ORG_A,
+      conferenceId: 'conf-A-2024',
+      conferenceOrgId: ORG_A,
+      memberOrgIds: [],
+    }
+    approvedVolunteer({
+      _id: 'conf-A-2024',
+      title: 'Our 2024 Edition',
+      contactEmail: 'hello@example.com',
+    })
+    await expect(send()).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+      message: GUARD_REFUSAL,
+    })
+    expect(vol.sendVolunteerApprovalEmail).not.toHaveBeenCalled()
+  })
+
+  it('refuses on the exact input that used to build the identity hybrid', async () => {
+    // A foreign volunteer whose conference has NO `contactEmail` is what took
+    // the `currentConf` rebuild branch: conference A's `_id`/`title` paired with
+    // the request domain's venue, dates, reply address and links. The guard
+    // makes that branch unreachable with mismatched conferences.
+    foreign('volunteer')
+    approvedVolunteer({ _id: 'conf-OTHER', title: 'Their Conference' })
+    h.getConference.mockResolvedValue({
+      conference: {
+        _id: CONF_A,
+        title: 'Our Conference',
+        organization: { _ref: ORG_A },
+        contactEmail: 'us@example.com',
+        city: 'Bergen',
+        country: 'Norway',
+      },
+      domain: 'localhost',
+      error: null,
+    })
+    await expect(send()).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+      message: GUARD_REFUSAL,
+    })
+    expect(vol.sendVolunteerApprovalEmail).not.toHaveBeenCalled()
+  })
+
+  it('still emails OUR OWN volunteer — the guard is not a blanket deny', async () => {
+    owned('volunteer')
+    approvedVolunteer({
+      _id: CONF_A,
+      title: 'Our Conference',
+      contactEmail: 'us@example.com',
+    })
+    await expect(send()).resolves.toMatchObject({
+      success: true,
+      emailId: 'email-1',
+    })
+    expect(vol.sendVolunteerApprovalEmail).toHaveBeenCalledTimes(1)
+  })
+
+  it('the rebuild branch, now that it can only fire in-conference, agrees with itself', async () => {
+    // Our own volunteer, our own conference, but no `contactEmail` on it — so
+    // the rebuild still runs. With the guard, both sides are the SAME document,
+    // so the email's identity and its venue/reply address cannot disagree.
+    owned('volunteer')
+    approvedVolunteer({ _id: CONF_A, title: 'Our Conference' })
+    h.getConference.mockResolvedValue({
+      conference: {
+        _id: CONF_A,
+        title: 'Our Conference',
+        organization: { _ref: ORG_A },
+        contactEmail: 'us@example.com',
+        city: 'Bergen',
+        country: 'Norway',
+      },
+      domain: 'localhost',
+      error: null,
+    })
+    await expect(send()).resolves.toMatchObject({ success: true })
+    const conferenceForEmail = vol.sendVolunteerApprovalEmail.mock.calls[0][1]
+    expect(conferenceForEmail).toMatchObject({
+      _id: CONF_A,
+      title: 'Our Conference',
+      contactEmail: 'us@example.com',
+      city: 'Bergen',
+      country: 'Norway',
+    })
+  })
+})
+
+/**
+ * SURFACE TRIPWIRE for the volunteer router, the mechanism that would have
+ * caught #858 four months earlier. `tenancy.writes.test.ts` pins `topic`,
+ * `staff` and `speaker` this way; volunteer had no such pin, so `sendEmail`
+ * could sit unguarded next to four guarded siblings without anything noticing.
+ * Adding a procedure here forces an explicit decision about its ownership guard.
+ */
+describe('the volunteer procedure surface is pinned (#858)', () => {
+  it('lists every procedure that takes a client-supplied id', () => {
+    const procedures = (
+      volunteerRouter as unknown as {
+        _def: { procedures: Record<string, unknown> }
+      }
+    )._def.procedures
+    expect(Object.keys(procedures).sort()).toEqual([
+      'admin.delete',
+      'admin.getById',
+      'admin.list',
+      'admin.sendEmail',
+      'admin.update',
+      'admin.updateStatus',
+      'create',
+    ])
   })
 })

--- a/src/server/routers/volunteer.ts
+++ b/src/server/routers/volunteer.ts
@@ -293,6 +293,16 @@ export const volunteerRouter = router({
       .input(SendVolunteerEmailSchema)
       .mutation(async ({ input }) => {
         try {
+          // OWNERSHIP (#858) — see `updateStatus` above. Unguarded, this read
+          // any tenant's volunteer application and mailed its owner. It also
+          // makes the `currentConf` fallback below SAFE BY CONSTRUCTION: the
+          // volunteer's conference is now the request's conference, so the two
+          // sides of that rebuilt object are the same document and cannot
+          // disagree on venue, dates, reply address or links.
+          await requireDocumentInCurrentConference(
+            input.volunteerId,
+            'volunteer',
+          )
           const { volunteer, error: fetchError } = await getVolunteerById(
             input.volunteerId,
           )
@@ -340,10 +350,12 @@ export const volunteerRouter = router({
               // VOLUNTEER's conference — not the request's domain. Taking it
               // from `currentConf` would send a volunteer of org A through org
               // B's Resend account whenever B's organizer processes A's
-              // volunteer, which `getVolunteerById` (a global by-id fetch) and
-              // this procedure's missing `requireDocumentInCurrentConference`
-              // make reachable. The fallback arm is correct only in the case it
-              // now covers: a volunteer with NO conference at all.
+              // volunteer, which `getVolunteerById` (a global by-id fetch) made
+              // reachable while this procedure had no ownership guard (#856,
+              // #858). The guard above now closes that door — the precedence
+              // stays because it is what makes this object's identity coherent
+              // regardless, and it must not silently regress if the guard ever
+              // moves.
               organization:
                 volunteer.conference?.organization ?? currentConf.organization,
               contactEmail: currentConf.contactEmail,


### PR DESCRIPTION
Fixes #858.

## The change

One guard, matching the four siblings exactly:

```ts
await requireDocumentInCurrentConference(input.volunteerId, 'volunteer')
```

`volunteer.admin.sendEmail` was the only one of the five volunteer admin procedures without it. Because `getVolunteerById` is a global by-id fetch — `*[_type == "volunteer" && _id == $id][0]`, an existence check wearing an ownership check's clothes — an organizer of any org could pass a volunteer id belonging to another, read that volunteer's name and email address, and send them mail.

It is placed **before** the lookup, so the foreign volunteer's contact details never enter the request at all.

## The identity hybrid is dead by construction, not by patching

When the volunteer's own conference carries no `contactEmail`, the procedure rebuilds the conference object for the email: `_id`/`title` from the **volunteer's** conference, `contactEmail`, `cfpEmail`, `city`, `country`, `startDate`, `domains`, `organizer` and `socialLinks` from the **request domain's**. An email titled for one event carrying another event's venue, dates and reply address — reachable within a single tenant across two of its own editions, not only across tenants.

With the guard, `volunteer.conference._id == resolveConferenceId()`, and the fallback's `getConferenceForCurrentDomain()` is the *same request-cached read* `resolveConferenceId()` itself uses. The two sides of the rebuilt object are therefore the same document and cannot disagree, whichever side each field is taken from. Patching the seven fields individually would have left the underlying foreign read wide open, which is the actual defect.

`volunteerRouter` is the sole caller of both `getVolunteerById` and `sendVolunteerApprovalEmail`, so there is no second path to the fallback.

The stale half-sentence in the `organization` comment from #856 — which described this procedure's *missing* guard as a live hazard — is updated rather than left to mislead.

## Why the tests can only pass because of this guard

`NOT_FOUND` alone does not attribute a refusal here: `'Volunteer not found'` and the authz waist both use that code. So every case asserts the guard's own **message value**, `No volunteer with that id for this request`, and each hands the procedure a volunteer that nothing else in the body could refuse — `status: 'approved'` and a complete conference.

The sabotage confirms it the strongest way available: with the guard removed the three refusal tests do not fail on a *different* error, they fail because **the call succeeds and sends the mail**.

```
AssertionError: promise resolved "{ success: true, emailId: 'email-1' }" instead of rejecting
```

One case uses a **second conference of the same org** — an org-level guard would admit it; only the conference-level one refuses. That is the case that produced the hybrid without needing a second tenant.

Plus a surface tripwire pinning the volunteer router's procedure list. `tenancy.writes.test.ts` pins `topic`, `staff` and `speaker` that way; volunteer had no such pin, which is how `sendEmail` sat unguarded next to four guarded siblings.

## Verification

Baseline is `origin/main` @ `23461ae1`.

| | before | after |
| --- | --- | --- |
| `pnpm test` | 515 files, 7538 tests, 0 failures | 515 files, **7544** tests, 0 failures |
| `pnpm typecheck` | clean | clean |
| `npx prettier --check .` | clean | clean |
| `npx eslint .` | 0 errors, 201 warnings | 0 errors, 201 warnings |

`eslint` was run directly rather than through `next lint`, which is vacuous on Next 16. Neither touched file appears in its output. Sabotage runs kept the file count at 1 and the test count at 26 throughout, so no broken import silently stopped the suite; the tree was verified clean afterwards.

## Residue

Named rather than glossed:

- **`update` and `delete` still fetch before they guard.** Both call `getVolunteerById` first and only then `requireDocumentInCurrentConference`, so a foreign volunteer's record is read into the request before the refusal. The *write* is correctly blocked and nothing is returned to the caller, so this is a wasted read and not a disclosure — but the ordering is wrong, and `sendEmail` and `getById` now show the right shape. Left alone here to keep this diff to the one defect #858 names.
- **The rebuild block itself remains.** Its `||` fallbacks are now unreachable in the sense that mattered; they can only fire when the current conference is missing its own `title`, in which case both sides are still the same document. Deleting the block is a separate simplification, not a fix.
- **This PR fixes `volunteer.sendEmail` only.** A sweep for the same shape across the other routers turned up further unguarded procedures — travel-support banking PII, badge resend, speaker by-id, sponsor CRM — which are being reported separately rather than folded in here.
