### PR TITLE
fix(badges): make "could not evaluate" representable in signature verification

### DIFF
--- a/__tests__/api/badge/badge-e2e.test.ts
+++ b/__tests__/api/badge/badge-e2e.test.ts
@@ -329,9 +329,9 @@ describe('Badge System E2E', () => {
         return
       }
 
-      const verified = await verifyCredential(signedCredential, publicKey)
+      const outcome = await verifyCredential(signedCredential, publicKey)
 
-      expect(verified).toBe(true)
+      expect(outcome.status).toBe('verified')
       console.log('✓ Credential signature verified successfully')
     })
   })

--- a/__tests__/api/badge/badge-endpoints.test.ts
+++ b/__tests__/api/badge/badge-endpoints.test.ts
@@ -349,5 +349,146 @@ describe('Badge endpoints - dual format', () => {
         expect((await response.json()).error).toBe('Badge not found')
       })
     })
+
+    /**
+     * #859. The same seam, one layer down: the CRYPTOGRAPHIC path. A botched
+     * `BADGE_ISSUER_ED25519_PUBLIC_KEY` rotation used to report every genuine
+     * badge as unverified — to Credly, the 1EdTech validator and LinkedIn
+     * importers — and `Cache-Control: public, max-age=3600` meant they kept
+     * serving that answer for an hour after the key was fixed.
+     */
+    describe('a broken issuer key is not a verdict on the credential', () => {
+      const KEY = 'BADGE_ISSUER_ED25519_PUBLIC_KEY'
+      const RSA_KEY = 'BADGE_ISSUER_RSA_PUBLIC_KEY'
+      let savedKey: string | undefined
+      let savedRsaKey: string | undefined
+
+      beforeEach(() => {
+        savedKey = process.env[KEY]
+        savedRsaKey = process.env[RSA_KEY]
+      })
+
+      afterEach(() => {
+        if (savedKey === undefined) delete process.env[KEY]
+        else process.env[KEY] = savedKey
+        if (savedRsaKey === undefined) delete process.env[RSA_KEY]
+        else process.env[RSA_KEY] = savedRsaKey
+      })
+
+      it('does NOT report a genuine badge as unverified when the key is corrupt', async () => {
+        // THE BUG. Same real, correctly-signed credential as the passing test
+        // above; only our own env var is sabotaged.
+        mockedGetBadgeById.mockResolvedValue({
+          badge: badgeRecord({
+            badgeJson: credentialJsonString,
+            badgeJwt: credentialJwt,
+          }),
+        })
+        process.env[KEY] = savedKey!.slice(0, 20) // truncated in transit
+
+        const { GET } = await import('@/app/api/badge/[badgeId]/verify/route')
+        const response = await GET(request, routeParams())
+
+        expect(response.status).toBe(503)
+
+        const body = await response.json()
+        // No verdict of any kind reached the verifier.
+        expect(body.valid).toBeUndefined()
+        expect(body.verified).toBeUndefined()
+
+        // And above all: a non-answer must not be cached as a definitive one.
+        expect(response.headers.get('Cache-Control')).toBe('no-store')
+        expect(response.headers.get('Cache-Control')).not.toContain('max-age')
+        expect(response.headers.get('Retry-After')).toBe('30')
+      })
+
+      it('answers 503/no-store when the key is missing entirely', async () => {
+        mockedGetBadgeById.mockResolvedValue({
+          badge: badgeRecord({ badgeJson: credentialJsonString }),
+        })
+        delete process.env[KEY]
+
+        const { GET } = await import('@/app/api/badge/[badgeId]/verify/route')
+        const response = await GET(request, routeParams())
+
+        expect(response.status).toBe(503)
+        expect(response.headers.get('Cache-Control')).toBe('no-store')
+        expect((await response.json()).valid).toBeUndefined()
+      })
+
+      it('answers 503/no-store when the legacy RSA key will not import', async () => {
+        // The JWT branch collapsed the same way: an unimportable key was
+        // caught alongside a bad signature and cached as `verified: false`.
+        mockedGetBadgeById.mockResolvedValue({
+          badge: badgeRecord({ badgeJson: credentialJwt }),
+        })
+        process.env[RSA_KEY] =
+          '-----BEGIN PUBLIC KEY-----\nnot-a-key\n-----END PUBLIC KEY-----\n'
+
+        const { GET } = await import('@/app/api/badge/[badgeId]/verify/route')
+        const response = await GET(request, routeParams())
+
+        expect(response.status).toBe(503)
+        expect(response.headers.get('Cache-Control')).toBe('no-store')
+        expect((await response.json()).verified).toBeUndefined()
+      })
+
+      /**
+       * The decisive counterweight. If the fix leaked into the generous
+       * direction, a forged badge would come back as "we couldn't tell" — a
+       * worse bug than the one being fixed — and the tests above would prove
+       * nothing.
+       */
+      it('STILL reports a tampered badge as invalid, with the normal cache', async () => {
+        const tampered = JSON.parse(credentialJsonString)
+        tampered.name = 'Tampered Badge'
+        mockedGetBadgeById.mockResolvedValue({
+          badge: badgeRecord({ badgeJson: JSON.stringify(tampered) }),
+        })
+        // Key untouched: our configuration is fine, the credential is not.
+
+        const { GET } = await import('@/app/api/badge/[badgeId]/verify/route')
+        const response = await GET(request, routeParams())
+
+        expect(response.status).toBe(200)
+        expect((await response.json()).valid).toBe(false)
+        expect(response.headers.get('Cache-Control')).toBe(
+          'public, max-age=3600',
+        )
+      })
+
+      it('STILL caches a genuine positive verdict for an hour', async () => {
+        mockedGetBadgeById.mockResolvedValue({
+          badge: badgeRecord({
+            badgeJson: credentialJsonString,
+            badgeJwt: credentialJwt,
+          }),
+        })
+
+        const { GET } = await import('@/app/api/badge/[badgeId]/verify/route')
+        const response = await GET(request, routeParams())
+
+        expect(response.status).toBe(200)
+        expect((await response.json()).valid).toBe(true)
+        expect(response.headers.get('Cache-Control')).toBe(
+          'public, max-age=3600',
+        )
+      })
+
+      it('STILL reports a foreign did:key badge as invalid, not indeterminate', async () => {
+        const foreign = JSON.parse(credentialJsonString)
+        foreign.proof[0].verificationMethod =
+          'did:key:z6MkvRQ7bnwBVzwozkkbasYzntpfnWJBsHfB1EfWFeFErgoy#z6MkvRQ7bnwBVzwozkkbasYzntpfnWJBsHfB1EfWFeFErgoy'
+        mockedGetBadgeById.mockResolvedValue({
+          badge: badgeRecord({ badgeJson: JSON.stringify(foreign) }),
+        })
+
+        const { GET } = await import('@/app/api/badge/[badgeId]/verify/route')
+        const response = await GET(request, routeParams())
+
+        expect(response.status).toBe(200)
+        expect((await response.json()).valid).toBe(false)
+      })
+    })
   })
 })

--- a/__tests__/api/trpc/badge-verify.test.ts
+++ b/__tests__/api/trpc/badge-verify.test.ts
@@ -95,8 +95,9 @@ describe('tRPC badge.verify - embedded proof branch', () => {
   })
 
   it('returns valid:false (not a 500) when the credential carries multiple proofs', async () => {
-    // verifyCredential throws on a proof array with length != 1 BEFORE its
-    // internal try/catch; this must be caught locally and reported not-valid.
+    // A proof set is a VERDICT on the credential (#859): verifyCredential
+    // reports `invalid`/`proof-set` rather than throwing, so the router can
+    // still hand back the credential it judged.
     const multiProof = JSON.parse(credentialJsonString)
     multiProof.proof = [multiProof.proof[0], { ...multiProof.proof[0] }]
     mockedGetBadgeById.mockResolvedValue({
@@ -108,7 +109,6 @@ describe('tRPC badge.verify - embedded proof branch', () => {
 
     expect(result.valid).toBe(false)
     expect(result.signatureValid).toBe(false)
-    expect(result.credential).toBeNull()
   })
 
   it('returns valid:false (not a 500) for malformed badgeJson', async () => {

--- a/__tests__/api/trpc/badge-verify.test.ts
+++ b/__tests__/api/trpc/badge-verify.test.ts
@@ -40,6 +40,7 @@ function badgeRecord(badgeJson: string): BadgeRecord {
 
 describe('tRPC badge.verify - embedded proof branch', () => {
   let credentialJsonString: string
+  let credentialJwt: string
 
   beforeAll(async () => {
     const config = createTestConfiguration()
@@ -60,6 +61,7 @@ describe('tRPC badge.verify - embedded proof branch', () => {
       config,
     )
     credentialJsonString = JSON.stringify(generated.credentialJson)
+    credentialJwt = generated.credentialJwt
   })
 
   beforeEach(() => {
@@ -122,5 +124,124 @@ describe('tRPC badge.verify - embedded proof branch', () => {
     expect(result.valid).toBe(false)
     expect(result.signatureValid).toBe(false)
     expect(result.credential).toBeNull()
+  })
+})
+
+/**
+ * #859, tRPC edition. `badge.verify` is a PUBLIC procedure, and both of its
+ * branches must distinguish "this badge is bad" from "we could not evaluate
+ * it". The JWT branch is the one that matters most in practice: half the
+ * issued badges are legacy JWT.
+ *
+ * Caught by an unresolved Copilot thread on #864, not by me — the bare
+ * `catch { return { valid: false } }` predates the PR, but the PR is what made
+ * `verifyCredentialJWT` throw TrustAnchorError into it.
+ */
+describe('tRPC badge.verify - a broken issuer key is not a verdict', () => {
+  const ED_KEY = 'BADGE_ISSUER_ED25519_PUBLIC_KEY'
+  const RSA_KEY = 'BADGE_ISSUER_RSA_PUBLIC_KEY'
+  let savedEd: string | undefined
+  let savedRsa: string | undefined
+  let credentialJsonString: string
+  let credentialJwt: string
+
+  beforeAll(async () => {
+    const config = createTestConfiguration()
+    const generated = await generateBadgeCredential(
+      {
+        speakerId: 'speaker-1',
+        speakerName: 'Jane Doe',
+        speakerEmail: 'jane.doe@example.com',
+        speakerSlug: 'jane-doe',
+        conferenceId: 'conference-1',
+        conferenceTitle: 'Test Conference 2026',
+        conferenceYear: '2026',
+        conferenceDate: 'June 15, 2026',
+        badgeType: 'speaker',
+        talkId: 'talk-1',
+        talkTitle: 'Kubernetes at Scale',
+      },
+      config,
+    )
+    credentialJsonString = JSON.stringify(generated.credentialJson)
+    credentialJwt = generated.credentialJwt
+  })
+
+  beforeEach(() => {
+    mockedGetBadgeById.mockReset()
+    savedEd = process.env[ED_KEY]
+    savedRsa = process.env[RSA_KEY]
+  })
+
+  afterEach(() => {
+    if (savedEd === undefined) delete process.env[ED_KEY]
+    else process.env[ED_KEY] = savedEd
+    if (savedRsa === undefined) delete process.env[RSA_KEY]
+    else process.env[RSA_KEY] = savedRsa
+  })
+
+  it('LEGACY JWT: does not report a genuine badge invalid when the RSA key is unusable', async () => {
+    mockedGetBadgeById.mockResolvedValue({ badge: badgeRecord(credentialJwt) })
+    process.env[RSA_KEY] =
+      '-----BEGIN PUBLIC KEY-----\nnot-a-key\n-----END PUBLIC KEY-----\n'
+
+    const caller = createAnonymousCaller()
+
+    // It must FAIL the call, not answer with a verdict.
+    await expect(
+      caller.badge.verify({ badgeId: 'test-badge-id' }),
+    ).rejects.toMatchObject({ code: 'PRECONDITION_FAILED' })
+  })
+
+  it('LEGACY JWT: STILL verifies a genuine badge when the key is fine', async () => {
+    mockedGetBadgeById.mockResolvedValue({ badge: badgeRecord(credentialJwt) })
+
+    const caller = createAnonymousCaller()
+    const result = await caller.badge.verify({ badgeId: 'test-badge-id' })
+
+    expect(result.valid).toBe(true)
+    expect(result.signatureValid).toBe(true)
+  })
+
+  it('LEGACY JWT: STILL reports a tampered badge as invalid, not as a failure', async () => {
+    // The counterweight. If TrustAnchorError handling leaked into the generic
+    // catch, a forged JWT would raise PRECONDITION_FAILED instead of a verdict.
+    const [header, payload] = credentialJwt.split('.')
+    mockedGetBadgeById.mockResolvedValue({
+      badge: badgeRecord(`${header}.${payload}.AAAAAAAAAAAAAAAAAAAAAA`),
+    })
+
+    const caller = createAnonymousCaller()
+    const result = await caller.badge.verify({ badgeId: 'test-badge-id' })
+
+    expect(result.valid).toBe(false)
+    expect(result.signatureValid).toBe(false)
+  })
+
+  it('EMBEDDED: does not report a genuine badge invalid when the Ed25519 key is corrupt', async () => {
+    mockedGetBadgeById.mockResolvedValue({
+      badge: badgeRecord(credentialJsonString),
+    })
+    process.env[ED_KEY] = savedEd!.slice(0, 20)
+
+    const caller = createAnonymousCaller()
+
+    await expect(
+      caller.badge.verify({ badgeId: 'test-badge-id' }),
+    ).rejects.toMatchObject({ code: 'PRECONDITION_FAILED' })
+  })
+
+  it('EMBEDDED: STILL reports a tampered badge as invalid, not as a failure', async () => {
+    const tampered = JSON.parse(credentialJsonString)
+    tampered.name = 'Tampered Badge'
+    mockedGetBadgeById.mockResolvedValue({
+      badge: badgeRecord(JSON.stringify(tampered)),
+    })
+
+    const caller = createAnonymousCaller()
+    const result = await caller.badge.verify({ badgeId: 'test-badge-id' })
+
+    expect(result.valid).toBe(false)
+    expect(result.signatureValid).toBe(false)
   })
 })

--- a/__tests__/lib/badge/generator-credential.test.ts
+++ b/__tests__/lib/badge/generator-credential.test.ts
@@ -80,7 +80,7 @@ describe('generateBadgeCredential - embedded proof', () => {
   it('round-trips through verifyCredential with the issuer public key', async () => {
     const publicKey = process.env.BADGE_ISSUER_ED25519_PUBLIC_KEY
     expect(publicKey?.startsWith('z')).toBe(true)
-    const ok = await verifyCredential(credential, publicKey!)
-    expect(ok).toBe(true)
+    const outcome = await verifyCredential(credential, publicKey!)
+    expect(outcome).toEqual({ status: 'verified' })
   })
 })

--- a/__tests__/lib/openbadges/embedded-proof.test.ts
+++ b/__tests__/lib/openbadges/embedded-proof.test.ts
@@ -18,7 +18,6 @@ import {
   bakeBadge,
   extractBadge,
   ConfigurationError,
-  VerificationError,
 } from '@/lib/openbadges'
 import type { CredentialConfig } from '@/lib/openbadges'
 
@@ -146,11 +145,13 @@ describe('Embedded proof - sign and verify round trip', () => {
 
     // Verify with the multibase public key derived from the seed
     const { publicKeyMultibase, publicKeyHex } = await seedToMultikey(TEST_SEED)
-    await expect(verifyCredential(signed, publicKeyMultibase)).resolves.toBe(
-      true,
+    await expect(verifyCredential(signed, publicKeyMultibase)).resolves.toEqual(
+      { status: 'verified' },
     )
     // Hex form of the same key also verifies
-    await expect(verifyCredential(signed, publicKeyHex)).resolves.toBe(true)
+    await expect(verifyCredential(signed, publicKeyHex)).resolves.toEqual({
+      status: 'verified',
+    })
   })
 
   it('fails verification with a different public key', async () => {
@@ -162,9 +163,10 @@ describe('Embedded proof - sign and verify round trip', () => {
 
     const otherSeed = 'ab'.repeat(32)
     const { publicKeyMultibase } = await seedToMultikey(otherSeed)
-    await expect(verifyCredential(signed, publicKeyMultibase)).resolves.toBe(
-      false,
-    )
+    expect(await verifyCredential(signed, publicKeyMultibase)).toMatchObject({
+      status: 'invalid',
+      reason: 'signature-mismatch',
+    })
   })
 
   it('fails verification when the credential is tampered with', async () => {
@@ -180,9 +182,9 @@ describe('Embedded proof - sign and verify round trip', () => {
     }
 
     const { publicKeyMultibase } = await seedToMultikey(TEST_SEED)
-    await expect(verifyCredential(tampered, publicKeyMultibase)).resolves.toBe(
-      false,
-    )
+    expect(await verifyCredential(tampered, publicKeyMultibase)).toMatchObject({
+      status: 'invalid',
+    })
   })
 
   it('rejects a public key mismatch at signing time', async () => {
@@ -235,12 +237,15 @@ describe('Embedded proof - trust anchor is the passed public key', () => {
     // the attacker's OWN key...
     await expect(
       verifyCredential(forged, attacker.publicKeyMultibase),
-    ).resolves.toBe(true)
+    ).resolves.toEqual({ status: 'verified' })
 
     // ...but MUST NOT verify against our trusted key. The did:key embedded in
     // the proof must never substitute for the passed public key.
     const { publicKeyMultibase: ourKey } = await seedToMultikey(TEST_SEED)
-    await expect(verifyCredential(forged, ourKey)).resolves.toBe(false)
+    expect(await verifyCredential(forged, ourKey)).toMatchObject({
+      status: 'invalid',
+      reason: 'untrusted-verification-method',
+    })
   })
 
   it('rejects a credential carrying more than one proof', async () => {
@@ -256,9 +261,9 @@ describe('Embedded proof - trust anchor is the passed public key', () => {
     }
 
     const { publicKeyMultibase } = await seedToMultikey(TEST_SEED)
-    await expect(
-      verifyCredential(multiProof, publicKeyMultibase),
-    ).rejects.toThrow(VerificationError)
+    expect(
+      await verifyCredential(multiProof, publicKeyMultibase),
+    ).toMatchObject({ status: 'invalid', reason: 'proof-set' })
   })
 })
 
@@ -284,9 +289,9 @@ describe('Embedded proof - baked SVG round trip', () => {
     expect(extracted).toEqual(signed)
 
     const { publicKeyMultibase } = await seedToMultikey(TEST_SEED)
-    await expect(verifyCredential(extracted, publicKeyMultibase)).resolves.toBe(
-      true,
-    )
+    await expect(
+      verifyCredential(extracted, publicKeyMultibase),
+    ).resolves.toEqual({ status: 'verified' })
   })
 
   it('round-trips and still verifies when a speaker-controlled field contains a CDATA terminator', async () => {
@@ -321,8 +326,8 @@ describe('Embedded proof - baked SVG round trip', () => {
 
     // Signature is intact after the transport-only escape round trip.
     const { publicKeyMultibase } = await seedToMultikey(TEST_SEED)
-    await expect(verifyCredential(extracted, publicKeyMultibase)).resolves.toBe(
-      true,
-    )
+    await expect(
+      verifyCredential(extracted, publicKeyMultibase),
+    ).resolves.toEqual({ status: 'verified' })
   })
 })

--- a/__tests__/lib/openbadges/openbadges.test.ts
+++ b/__tests__/lib/openbadges/openbadges.test.ts
@@ -27,6 +27,7 @@ import {
   OpenBadgesError,
   SigningError,
   VerificationError,
+  TrustAnchorError,
   ValidationError,
   BakingError,
   ExtractionError,
@@ -142,8 +143,8 @@ describe('OpenBadges 3.0 - Happy Path', () => {
     expect(() => assertValidCredential(signedCredential)).not.toThrow()
 
     // 4. Verify signature
-    const isValid = await verifyCredential(signedCredential, VALID_PUBLIC_KEY)
-    expect(isValid).toBe(true)
+    const outcome = await verifyCredential(signedCredential, VALID_PUBLIC_KEY)
+    expect(outcome.status).toBe('verified')
 
     // 5. Bake into SVG
     const bakedSvg = bakeBadge(VALID_SVG, signedCredential)
@@ -165,11 +166,11 @@ describe('OpenBadges 3.0 - Happy Path', () => {
     expect(extractedCredential.proof).toHaveLength(1)
 
     // 7. Verify extracted credential
-    const extractedIsValid = await verifyCredential(
+    const extractedOutcome = await verifyCredential(
       extractedCredential,
       VALID_PUBLIC_KEY,
     )
-    expect(extractedIsValid).toBe(true)
+    expect(extractedOutcome.status).toBe('verified')
   })
 })
 
@@ -364,9 +365,9 @@ describe('Signing - Edge Cases', () => {
 describe('Verification - Edge Cases', () => {
   it('should reject credential without proof', async () => {
     const credential = createCredential(VALID_CREDENTIAL_CONFIG)
-    await expect(
-      verifyCredential(credential as any, VALID_PUBLIC_KEY),
-    ).rejects.toThrow(VerificationError)
+    expect(
+      await verifyCredential(credential as any, VALID_PUBLIC_KEY),
+    ).toMatchObject({ status: 'invalid', reason: 'no-proof' })
   })
 
   it('should reject credential with empty proof array', async () => {
@@ -374,9 +375,9 @@ describe('Verification - Edge Cases', () => {
       ...createCredential(VALID_CREDENTIAL_CONFIG),
       proof: [],
     }
-    await expect(
-      verifyCredential(credential as any, VALID_PUBLIC_KEY),
-    ).rejects.toThrow(VerificationError)
+    expect(
+      await verifyCredential(credential as any, VALID_PUBLIC_KEY),
+    ).toMatchObject({ status: 'invalid', reason: 'no-proof' })
   })
 
   it('should reject credential with tampered signature', async () => {
@@ -386,8 +387,8 @@ describe('Verification - Edge Cases', () => {
     // Tamper with signature by removing the last character
     signed.proof[0].proofValue = signed.proof[0].proofValue.slice(0, -1)
 
-    const isValid = await verifyCredential(signed, VALID_PUBLIC_KEY)
-    expect(isValid).toBe(false)
+    const outcome = await verifyCredential(signed, VALID_PUBLIC_KEY)
+    expect(outcome.status).toBe('invalid')
   })
 
   it('should verify external OpenBadgeFactory credential', async () => {
@@ -472,11 +473,13 @@ describe('Verification - Edge Cases', () => {
     // external badges with different canonicalization or additional contexts.
     // This is expected behavior as different implementations may use different
     // document loaders and canonicalization approaches.
-    const isValid = await verifyCredential(externalBadge as any, publicKey)
+    const outcome = await verifyCredential(externalBadge as any, publicKey)
 
     // We expect this to fail for now since we may not have full context support
-    // This serves as documentation of current limitations
-    expect(typeof isValid).toBe('boolean')
+    // This serves as documentation of current limitations. What it must NEVER
+    // be is `indeterminate`: the trust anchor came out of the badge's own
+    // did:key, so any failure here is the badge's, not our configuration's.
+    expect(['verified', 'invalid']).toContain(outcome.status)
   })
 })
 
@@ -748,10 +751,16 @@ describe('JWT Proof Format', () => {
   })
 
   describe('Edge Cases - JWT Verification', () => {
-    it('should reject missing public key', async () => {
+    it('reports a missing public key as a trust-anchor fault, not a verdict', async () => {
+      // #859. The key is OURS. Throwing a VerificationError here made "we have
+      // no key" indistinguishable from "this credential is forged", and the
+      // route cached the latter for an hour.
       const jwt = 'eyJhbGciOiJFZERTQSJ9.eyJ2YyI6e319.c2lnbmF0dXJl'
 
       await expect(verifyCredentialJWT(jwt, '')).rejects.toThrow(
+        TrustAnchorError,
+      )
+      await expect(verifyCredentialJWT(jwt, '')).rejects.not.toThrow(
         VerificationError,
       )
     })
@@ -825,8 +834,8 @@ describe('JWT Proof Format', () => {
       expect(signedWithJWT.split('.')).toHaveLength(3)
 
       // Both should verify successfully
-      const diValid = await verifyCredential(signedWithDI, VALID_PUBLIC_KEY)
-      expect(diValid).toBe(true)
+      const diOutcome = await verifyCredential(signedWithDI, VALID_PUBLIC_KEY)
+      expect(diOutcome.status).toBe('verified')
 
       const jwtCredential = await verifyCredentialJWT(
         signedWithJWT,

--- a/__tests__/lib/openbadges/verification-outcome.test.ts
+++ b/__tests__/lib/openbadges/verification-outcome.test.ts
@@ -1,0 +1,378 @@
+/**
+ * #859. `verifyCredential` returned a `boolean`, and its catch arm returned
+ * `false`. A boolean cannot say "I could not evaluate this", so a malformed
+ * key or a missing env var was indistinguishable from "this credential is
+ * forged" — served to Credly, the 1EdTech validator and LinkedIn importers,
+ * and cached by them for an hour.
+ *
+ * The classification is the whole fix, so these tests pin every failure mode
+ * individually. The rule they encode:
+ *
+ *   indeterminate  <=  the TRUST ANCHOR (our key) is unusable
+ *   invalid        <=  anything determined by the credential bytes
+ *
+ * The asymmetry is deliberate. Credential bytes are presenter-controlled: if a
+ * hostile credential could push us into `indeterminate`, a forger would have a
+ * button that suppresses the negative verdict. Our own key is not something a
+ * presenter can touch, so it is the only safe source of "we don't know".
+ */
+
+import {
+  createCredential,
+  signCredential,
+  signCredentialJWT,
+  verifyCredential,
+  verifyCredentialJWT,
+  seedToMultikey,
+  TrustAnchorError,
+  VerificationError,
+} from '@/lib/openbadges'
+import type { CredentialConfig, SignedCredential } from '@/lib/openbadges'
+
+const TEST_SEED =
+  '4f7d2c1a9b3e5d806142f3a8c5b7e9d0112233445566778899aabbccddeeff00'
+const BASE_URL = 'https://example.com'
+const ISSUER_ID = `${BASE_URL}/api/badge/issuer`
+const VERIFICATION_METHOD = `${BASE_URL}/api/badge/keys/key-ed25519`
+
+const CREDENTIAL_CONFIG: CredentialConfig = {
+  credentialId: `${BASE_URL}/api/badge/test-badge-1`,
+  name: 'Speaker Badge for Test Conference 2026',
+  issuer: {
+    id: ISSUER_ID,
+    name: 'Test Conference Org',
+    url: BASE_URL,
+    email: 'badges@example.com',
+    description: 'Test issuer',
+  },
+  subject: {
+    id: 'mailto:speaker.name@example.com',
+    type: ['AchievementSubject'],
+  },
+  achievement: {
+    id: `${BASE_URL}/api/badge/test-badge-1/achievement`,
+    name: 'Speaker at Test Conference 2026',
+    description: 'Recognizes a speaker at Test Conference 2026.',
+    criteria: { narrative: 'Presented a talk at Test Conference 2026.' },
+    image: {
+      id: `${BASE_URL}/api/badge/test-badge-1/image`,
+      type: 'Image',
+    },
+  },
+  validFrom: '2026-01-01T00:00:00Z',
+}
+
+let signed: SignedCredential
+let ourKeyMultibase: string
+let ourKeyHex: string
+
+beforeAll(async () => {
+  signed = await signCredential(createCredential(CREDENTIAL_CONFIG), {
+    privateKey: TEST_SEED,
+    verificationMethod: VERIFICATION_METHOD,
+  })
+  const key = await seedToMultikey(TEST_SEED)
+  ourKeyMultibase = key.publicKeyMultibase
+  ourKeyHex = key.publicKeyHex
+})
+
+describe('verifyCredential: a genuine badge verifies', () => {
+  it('accepts the multibase form of the issuer key', async () => {
+    expect(await verifyCredential(signed, ourKeyMultibase)).toEqual({
+      status: 'verified',
+    })
+  })
+
+  it('accepts the hex form of the same key', async () => {
+    expect(await verifyCredential(signed, ourKeyHex)).toEqual({
+      status: 'verified',
+    })
+  })
+})
+
+/**
+ * OUR configuration is broken. None of these say anything about the badge, so
+ * none of them may produce a verdict.
+ */
+describe('verifyCredential: an unusable trust anchor is indeterminate', () => {
+  const unusableKeys: Array<[string, string]> = [
+    // The literal rotation accident: the env var was cleared.
+    ['an empty string', ''],
+    // Truncated during a copy/paste out of a secrets manager.
+    ['a truncated multibase key', 'z6MkttqCZq2u9Jc1jvuUSffPwukNMKNY'],
+    // Base58 excludes 0/O/I/l, so a mangled key often is not even base58.
+    ['a multibase key with non-base58 characters', 'z6Mk0OIl++++'],
+    // The multicodec prefix says this is not Ed25519.
+    ['a multibase key that is not an Ed25519 Multikey', 'z2DrjgbFY1sr'],
+    // Hex, but not 32 bytes.
+    ['a short hex key', 'deadbeef'],
+    // Right length, wrong alphabet.
+    ['a 64-character string that is not hex', 'g'.repeat(64)],
+    // Someone pasted the RSA PEM into the Ed25519 variable.
+    ['a PEM public key in the Ed25519 slot', '-----BEGIN PUBLIC KEY-----'],
+  ]
+
+  it.each(unusableKeys)(
+    'reports indeterminate, not invalid, for %s',
+    async (_label, key) => {
+      const outcome = await verifyCredential(signed, key)
+
+      expect(outcome.status).toBe('indeterminate')
+      // The bug, stated as an assertion: a genuine badge must never be called
+      // forged because OUR key is broken.
+      expect(outcome.status).not.toBe('invalid')
+    },
+  )
+
+  it('names a missing key separately from a corrupt one', async () => {
+    expect(await verifyCredential(signed, '')).toMatchObject({
+      status: 'indeterminate',
+      reason: 'missing-trust-anchor',
+    })
+    expect(
+      await verifyCredential(signed, 'z6MkttqCZq2u9Jc1jvuUSffPwukNMKNY'),
+    ).toMatchObject({
+      status: 'indeterminate',
+      reason: 'unusable-trust-anchor',
+    })
+  })
+
+  it('treats a non-string key as missing rather than crashing', async () => {
+    expect(
+      await verifyCredential(signed, undefined as unknown as string),
+    ).toMatchObject({ status: 'indeterminate', reason: 'missing-trust-anchor' })
+  })
+
+  /**
+   * The honest limit. A trust anchor that is well-formed but simply WRONG is
+   * indistinguishable from a bad signature from inside this function — there
+   * is no second anchor to check it against — so it still reports `invalid`.
+   * Detectable corruption (truncation, wrong alphabet, wrong codec, empty)
+   * covers the realistic rotation accidents; substituting one valid Ed25519
+   * key for another does not.
+   */
+  it('DOCUMENTED LIMIT: a valid-but-wrong key is still reported invalid', async () => {
+    const { publicKeyMultibase: someoneElsesKey } = await seedToMultikey(
+      'ab'.repeat(32),
+    )
+
+    expect(await verifyCredential(signed, someoneElsesKey)).toMatchObject({
+      status: 'invalid',
+      reason: 'signature-mismatch',
+    })
+  })
+})
+
+/**
+ * The other direction — the one that makes the tests above mean something.
+ * Everything a presenter controls stays a verdict.
+ */
+describe('verifyCredential: credential-caused failures stay verdicts', () => {
+  it('reports a tampered credential as invalid', async () => {
+    const tampered = { ...signed, name: 'Organizer Badge for Someone Else' }
+
+    expect(await verifyCredential(tampered, ourKeyMultibase)).toMatchObject({
+      status: 'invalid',
+    })
+  })
+
+  it('reports a corrupted proofValue as invalid', async () => {
+    const corrupted = {
+      ...signed,
+      proof: [{ ...signed.proof[0], proofValue: 'zAAAAAAAAAAAAAAAAAAAA' }],
+    }
+
+    expect(await verifyCredential(corrupted, ourKeyMultibase)).toMatchObject({
+      status: 'invalid',
+    })
+  })
+
+  it('reports a missing proof as invalid/no-proof', async () => {
+    const { proof: _proof, ...unsigned } = signed
+
+    expect(
+      await verifyCredential(unsigned as SignedCredential, ourKeyMultibase),
+    ).toMatchObject({ status: 'invalid', reason: 'no-proof' })
+  })
+
+  it('reports an empty proof array as invalid/no-proof', async () => {
+    expect(
+      await verifyCredential({ ...signed, proof: [] }, ourKeyMultibase),
+    ).toMatchObject({ status: 'invalid', reason: 'no-proof' })
+  })
+
+  it('reports a proof set as invalid/proof-set', async () => {
+    const multiProof = {
+      ...signed,
+      proof: [signed.proof[0], { ...signed.proof[0] }],
+    }
+
+    expect(await verifyCredential(multiProof, ourKeyMultibase)).toMatchObject({
+      status: 'invalid',
+      reason: 'proof-set',
+    })
+  })
+
+  it('reports an unsupported proof type as invalid, NOT indeterminate', async () => {
+    // proof.type is presenter-chosen. If "we do not implement that" were
+    // indeterminate, a forger could pick an exotic type to dodge the verdict.
+    const other = {
+      ...signed,
+      proof: [{ ...signed.proof[0], type: 'Ed25519Signature2020' }],
+    } as unknown as SignedCredential
+
+    expect(await verifyCredential(other, ourKeyMultibase)).toMatchObject({
+      status: 'invalid',
+      reason: 'unsupported-proof-type',
+    })
+  })
+
+  it('reports an unsupported cryptosuite as invalid, NOT indeterminate', async () => {
+    const other = {
+      ...signed,
+      proof: [{ ...signed.proof[0], cryptosuite: 'ecdsa-rdfc-2019' }],
+    } as unknown as SignedCredential
+
+    expect(await verifyCredential(other, ourKeyMultibase)).toMatchObject({
+      status: 'invalid',
+      reason: 'unsupported-cryptosuite',
+    })
+  })
+
+  it('reports a foreign did:key verification method as invalid', async () => {
+    const attackerSeed = 'cd'.repeat(32)
+    const attacker = await seedToMultikey(attackerSeed)
+    const forged = await signCredential(createCredential(CREDENTIAL_CONFIG), {
+      privateKey: attackerSeed,
+      verificationMethod: `did:key:${attacker.publicKeyMultibase}#${attacker.publicKeyMultibase}`,
+    })
+
+    expect(await verifyCredential(forged, ourKeyMultibase)).toMatchObject({
+      status: 'invalid',
+      reason: 'untrusted-verification-method',
+    })
+  })
+
+  it('reports a malformed did: verification method as invalid', async () => {
+    const bogus = {
+      ...signed,
+      proof: [
+        { ...signed.proof[0], verificationMethod: 'did:example:not-a-key' },
+      ],
+    }
+
+    expect(await verifyCredential(bogus, ourKeyMultibase)).toMatchObject({
+      status: 'invalid',
+      reason: 'untrusted-verification-method',
+    })
+  })
+
+  it('reports a credential naming an unresolvable context as invalid', async () => {
+    // The loader is fully offline; the DB stack reports this as a failed
+    // proof rather than throwing. Either way it is the credential's doing.
+    const badContext = {
+      ...signed,
+      '@context': ['https://example.invalid/nope.jsonld'],
+    }
+
+    expect(
+      await verifyCredential(
+        badContext as unknown as SignedCredential,
+        ourKeyMultibase,
+      ),
+    ).toMatchObject({ status: 'invalid' })
+  })
+
+  it('routes an unexpected throw to invalid/malformed-credential', async () => {
+    // A non-string verificationMethod blows up on `.startsWith` inside the
+    // try. That catch-all used to `return false`; it must stay a verdict and
+    // must never be laundered into "we could not tell".
+    const hostile = {
+      ...signed,
+      proof: [{ ...signed.proof[0], verificationMethod: null }],
+    } as unknown as SignedCredential
+
+    expect(await verifyCredential(hostile, ourKeyMultibase)).toMatchObject({
+      status: 'invalid',
+      reason: 'malformed-credential',
+    })
+  })
+
+  it('never returns indeterminate for any credential-shaped input', async () => {
+    const hostileVariants: SignedCredential[] = [
+      { ...signed, proof: [] } as SignedCredential,
+      { ...signed, proof: 'not-an-array' } as unknown as SignedCredential,
+      { ...signed, issuer: undefined } as unknown as SignedCredential,
+      { ...signed, credentialSubject: null } as unknown as SignedCredential,
+      {
+        ...signed,
+        proof: [{ ...signed.proof[0], verificationMethod: '' }],
+      } as SignedCredential,
+    ]
+
+    for (const variant of hostileVariants) {
+      const outcome = await verifyCredential(variant, ourKeyMultibase)
+      expect(outcome.status).not.toBe('indeterminate')
+    }
+  })
+})
+
+/**
+ * The legacy JWT path (RS256, still how the 1EdTech validator reads our
+ * badges) collapsed the same way: an unusable key threw the very same
+ * VerificationError as a forged signature, and the route cached the result.
+ */
+describe('verifyCredentialJWT: an unusable key is not a bad signature', () => {
+  let jwt: string
+
+  beforeAll(async () => {
+    jwt = await signCredentialJWT(createCredential(CREDENTIAL_CONFIG), {
+      privateKey: TEST_SEED,
+      publicKey: ourKeyHex,
+      verificationMethod: VERIFICATION_METHOD,
+    })
+  })
+
+  it('verifies the genuine JWT with the genuine key', async () => {
+    const credential = await verifyCredentialJWT(jwt, ourKeyHex)
+    expect(credential.id).toBe(CREDENTIAL_CONFIG.credentialId)
+  })
+
+  it('throws TrustAnchorError for a PEM that will not parse', async () => {
+    // jose accepts this PEM and only fails later inside jwtVerify — wearing
+    // the disguise of a bad signature. The key must be parsed eagerly.
+    const brokenPem =
+      '-----BEGIN PUBLIC KEY-----\nnot-a-key\n-----END PUBLIC KEY-----\n'
+
+    await expect(verifyCredentialJWT(jwt, brokenPem)).rejects.toThrow(
+      TrustAnchorError,
+    )
+  })
+
+  it('throws TrustAnchorError for a corrupt Ed25519 hex key', async () => {
+    await expect(
+      verifyCredentialJWT(jwt, ourKeyHex.slice(0, 40)),
+    ).rejects.toThrow(TrustAnchorError)
+  })
+
+  /**
+   * The counterweight: with a usable key, a tampered JWT is still a verdict.
+   *
+   * NOTE ON REACH: `jose` is aliased to `__tests__/mocks/jose.ts` suite-wide,
+   * so this asserts the CLASSIFICATION (verdict vs non-answer), not Ed25519
+   * mathematics. That is the part #859 is about; real signature checking is
+   * covered by the Data Integrity tests above, which use the unmocked
+   * Digital Bazaar stack.
+   */
+  it('STILL throws VerificationError for a genuinely bad signature', async () => {
+    const [header, payload] = jwt.split('.')
+    const forged = `${header}.${payload}.AAAAAAAAAAAAAAAAAAAAAA`
+
+    await expect(verifyCredentialJWT(forged, ourKeyHex)).rejects.toThrow(
+      VerificationError,
+    )
+    await expect(verifyCredentialJWT(forged, ourKeyHex)).rejects.not.toThrow(
+      TrustAnchorError,
+    )
+  })
+})

--- a/__tests__/lib/openbadges/verification-outcome.test.ts
+++ b/__tests__/lib/openbadges/verification-outcome.test.ts
@@ -298,6 +298,38 @@ describe('verifyCredential: credential-caused failures stay verdicts', () => {
     })
   })
 
+  /**
+   * These shapes used to TypeError on the field reads before the try block and
+   * escape as a THROW, which made the "does not throw" claim in the JSDoc an
+   * overclaim (caught in review of #864). Not a security defect — the route's
+   * verification-method gate short-circuits them to a verdict first, and every
+   * caller wraps in try/catch — but a verdict is what they should get here.
+   */
+  it.each([
+    ['a null proof entry', null],
+    ['a string proof entry', 'not-an-object'],
+    ['a numeric proof entry', 42],
+  ])('returns a verdict, not a throw, for %s', async (_label, proofEntry) => {
+    const hostile = {
+      ...signed,
+      proof: [proofEntry],
+    } as unknown as SignedCredential
+
+    expect(await verifyCredential(hostile, ourKeyMultibase)).toMatchObject({
+      status: 'invalid',
+      reason: 'malformed-credential',
+    })
+  })
+
+  it('returns a verdict, not a throw, for a non-object credential', async () => {
+    expect(
+      await verifyCredential(
+        null as unknown as SignedCredential,
+        ourKeyMultibase,
+      ),
+    ).toMatchObject({ status: 'invalid', reason: 'malformed-credential' })
+  })
+
   it('never returns indeterminate for any credential-shaped input', async () => {
     const hostileVariants: SignedCredential[] = [
       { ...signed, proof: [] } as SignedCredential,

--- a/__tests__/lib/openbadges/verification-outcome.test.ts
+++ b/__tests__/lib/openbadges/verification-outcome.test.ts
@@ -371,8 +371,12 @@ describe('verifyCredentialJWT: an unusable key is not a bad signature', () => {
   })
 
   it('throws TrustAnchorError for a PEM that will not parse', async () => {
-    // jose accepts this PEM and only fails later inside jwtVerify — wearing
-    // the disguise of a bad signature. The key must be parsed eagerly.
+    // NOTE: real jose 6.2.8 rejects this PEM eagerly too (DOMException:
+    // Invalid character). Under the suite-wide jose mock its importers accept
+    // anything, so what this test actually pins is that OUR eager
+    // createPublicKey parse classifies the fault as a trust-anchor fault
+    // rather than letting it reach jwtVerify wearing the disguise of a bad
+    // signature. See #866.
     const brokenPem =
       '-----BEGIN PUBLIC KEY-----\nnot-a-key\n-----END PUBLIC KEY-----\n'
 

--- a/src/app/api/badge/[badgeId]/verify/route.ts
+++ b/src/app/api/badge/[badgeId]/verify/route.ts
@@ -7,8 +7,34 @@ import {
   generateVerificationResponse,
   generateErrorResponse,
   isJWTFormat,
+  TrustAnchorError,
+  type VerificationOutcome,
 } from '@/lib/openbadges'
 import { acceptedEd25519VerificationMethods } from '@/lib/badge/verification-method'
+
+/**
+ * "We could not evaluate this credential" — never a verdict, never cached.
+ *
+ * Used for BOTH a failed badge lookup (#848/#855) and a failed cryptographic
+ * evaluation (#859). The shared shape is the point: an external verifier gets
+ * one unambiguous signal — come back later — instead of a negative answer that
+ * intermediaries would then serve for an hour after we fixed the cause.
+ */
+const UNAVAILABLE_MESSAGE =
+  'Badge verification is temporarily unavailable; this is not a statement about the credential'
+
+function verificationUnavailable() {
+  return NextResponse.json(generateErrorResponse(UNAVAILABLE_MESSAGE, 503), {
+    status: 503,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET',
+      // Never cache a non-answer as though it were one.
+      'Cache-Control': 'no-store',
+      'Retry-After': '30',
+    },
+  })
+}
 
 /**
  * GET /api/badge/[badgeId]/verify
@@ -47,22 +73,7 @@ export async function GET(
     // know, so say 503 and invite a retry rather than impugn a real badge.
     if (reason === 'unavailable') {
       console.error('Badge lookup unavailable during verification:', error)
-      return NextResponse.json(
-        generateErrorResponse(
-          'Badge verification is temporarily unavailable; this is not a statement about the credential',
-          503,
-        ),
-        {
-          status: 503,
-          headers: {
-            'Access-Control-Allow-Origin': '*',
-            'Access-Control-Allow-Methods': 'GET',
-            // Never cache a non-answer as though it were one.
-            'Cache-Control': 'no-store',
-            'Retry-After': '30',
-          },
-        },
-      )
+      return verificationUnavailable()
     }
 
     if (error || !badge) {
@@ -73,10 +84,10 @@ export async function GET(
       const publicKey = process.env.BADGE_ISSUER_RSA_PUBLIC_KEY
 
       if (!publicKey) {
-        return NextResponse.json(
-          generateErrorResponse('RSA public key not configured', 500),
-          { status: 500 },
+        console.error(
+          'BADGE_ISSUER_RSA_PUBLIC_KEY is not configured; cannot evaluate legacy JWT badges',
         )
+        return verificationUnavailable()
       }
 
       try {
@@ -101,6 +112,16 @@ export async function GET(
           },
         })
       } catch (verifyError) {
+        // Our RSA key would not import: nothing about this credential was
+        // evaluated, so we must not answer with a cached "not verified".
+        if (verifyError instanceof TrustAnchorError) {
+          console.error(
+            'Legacy JWT badge could not be evaluated (trust anchor unusable):',
+            verifyError,
+          )
+          return verificationUnavailable()
+        }
+
         console.error('JWT verification failed:', verifyError)
         return NextResponse.json(
           {
@@ -140,13 +161,15 @@ export async function GET(
     // never requires the secret seed.
     const publicKey = process.env.BADGE_ISSUER_ED25519_PUBLIC_KEY
     if (!publicKey) {
-      return NextResponse.json(
-        generateErrorResponse('Ed25519 issuer public key not configured', 500),
-        { status: 500 },
+      // A missing key is OUR deployment, not the badge. Answering with a
+      // verdict here would report every genuine badge as unverified.
+      console.error(
+        'BADGE_ISSUER_ED25519_PUBLIC_KEY is not configured; cannot evaluate embedded-proof badges',
       )
+      return verificationUnavailable()
     }
 
-    let signatureValid = false
+    let outcome: VerificationOutcome
     try {
       // Pin the verification method to OUR issuer's embedded VM. A badge
       // presented with a foreign / did:key VM must never earn a green check
@@ -160,19 +183,38 @@ export async function GET(
       const proofVm = assertion.proof?.[0]?.verificationMethod
 
       if (!acceptedEd25519VerificationMethods(issuerId).includes(proofVm)) {
-        signatureValid = false
+        outcome = {
+          status: 'invalid',
+          reason: 'untrusted-verification-method',
+        }
       } else {
-        signatureValid = await verifyCredential(
+        outcome = await verifyCredential(
           assertion as Parameters<typeof verifyCredential>[0],
           publicKey,
         )
       }
     } catch (error) {
+      // verifyCredential is total for credential-caused failures, so this is
+      // the badge-shaped fallback (e.g. reading fields off a hostile
+      // assertion). Credential bytes are presenter-controlled: verdict.
       console.error('Verification error:', error)
-      signatureValid = false
+      outcome = { status: 'invalid', reason: 'malformed-credential' }
     }
 
-    const isValid = validation.valid && signatureValid
+    // #859. A `boolean` could not say "I could not evaluate this", so a
+    // botched key rotation reported every genuine badge as forged — and the
+    // `max-age=3600` below meant intermediaries kept serving that answer for
+    // an hour after the fix. Answer 503/no-store instead.
+    if (outcome.status === 'indeterminate') {
+      console.error(
+        'Badge signature could not be evaluated:',
+        outcome.reason,
+        outcome.detail,
+      )
+      return verificationUnavailable()
+    }
+
+    const isValid = validation.valid && outcome.status === 'verified'
     const response = generateVerificationResponse(
       isValid,
       assertion as Parameters<typeof verifyCredential>[0],

--- a/src/lib/badge/validation.ts
+++ b/src/lib/badge/validation.ts
@@ -197,9 +197,24 @@ async function validateIssuerAndProof(
       } else {
         try {
           const publicKeyHex = didKeyToPublicKeyHex(issuerId)
-          const isValid = await verifyCredential(credential, publicKeyHex)
+          const outcome = await verifyCredential(credential, publicKeyHex)
 
-          if (isValid) {
+          if (outcome.status === 'indeterminate') {
+            // #859. Not a verdict: the key we verified against was unusable,
+            // so report "could not evaluate" rather than a red X on a
+            // credential we never actually checked.
+            checks.push({
+              name: 'proof',
+              status: 'warning',
+              message: `Could not evaluate the signature (${outcome.reason}) — this is not a statement about the credential`,
+              details: {
+                cryptosuite: proof.cryptosuite,
+                verificationMethod: proof.verificationMethod,
+                reason: outcome.reason,
+                detail: outcome.detail,
+              },
+            })
+          } else if (outcome.status === 'verified') {
             // The signature is cryptographically valid, but the trust anchor
             // is the credential's OWN did:key — i.e. it is self-asserted, not
             // verified against the conference's published issuer key. Surface
@@ -223,11 +238,12 @@ async function validateIssuerAndProof(
             checks.push({
               name: 'proof',
               status: 'error',
-              message: 'Cryptographic signature verification failed',
+              message: `Cryptographic signature verification failed (${outcome.reason})`,
               details: {
                 cryptosuite: proof.cryptosuite,
                 verificationMethod: proof.verificationMethod,
                 signatureValid: false,
+                reason: outcome.reason,
                 trust: 'self-asserted',
               },
             })
@@ -314,24 +330,43 @@ async function validateIssuerAndProof(
 
             if (publicKeyHex) {
               try {
-                const isValid = await verifyCredential(credential, publicKeyHex)
-                checks.push({
-                  name: 'proof',
-                  status: isValid ? 'success' : 'error',
-                  message: isValid
-                    ? `Proof signature verified against the issuer's published key (${proof.cryptosuite})`
-                    : `Proof signature invalid (${proof.cryptosuite})`,
-                  details: {
-                    cryptosuite: proof.cryptosuite,
-                    created: proof.created,
-                    verificationMethod: proof.verificationMethod,
-                    signatureValid: isValid,
-                    // Trust anchor is the issuer's published key document,
-                    // fetched from the HTTP(S) issuer profile — not the
-                    // credential itself.
-                    trust: isValid ? 'issuer-key-verified' : 'unverified',
-                  },
-                })
+                const outcome = await verifyCredential(credential, publicKeyHex)
+                const verified = outcome.status === 'verified'
+
+                if (outcome.status === 'indeterminate') {
+                  // #859. The published key we fetched is unusable, so the
+                  // proof was never evaluated — a warning, not a red X.
+                  checks.push({
+                    name: 'proof',
+                    status: 'warning',
+                    message: `Could not evaluate the proof (${outcome.reason}) — this is not a statement about the credential`,
+                    details: {
+                      cryptosuite: proof.cryptosuite,
+                      verificationMethod: proof.verificationMethod,
+                      reason: outcome.reason,
+                      detail: outcome.detail,
+                    },
+                  })
+                } else {
+                  checks.push({
+                    name: 'proof',
+                    status: verified ? 'success' : 'error',
+                    message: verified
+                      ? `Proof signature verified against the issuer's published key (${proof.cryptosuite})`
+                      : `Proof signature invalid (${proof.cryptosuite}: ${outcome.reason})`,
+                    details: {
+                      cryptosuite: proof.cryptosuite,
+                      created: proof.created,
+                      verificationMethod: proof.verificationMethod,
+                      signatureValid: verified,
+                      ...(verified ? {} : { reason: outcome.reason }),
+                      // Trust anchor is the issuer's published key document,
+                      // fetched from the HTTP(S) issuer profile — not the
+                      // credential itself.
+                      trust: verified ? 'issuer-key-verified' : 'unverified',
+                    },
+                  })
+                }
               } catch (error) {
                 checks.push({
                   name: 'proof',

--- a/src/lib/openbadges/crypto.ts
+++ b/src/lib/openbadges/crypto.ts
@@ -27,8 +27,17 @@ import {
 } from 'jose'
 import { createPublicKey } from 'crypto'
 import { hexToBytes, bytesToHex } from './encoding'
-import { publicKeyToMultibase, didKeyToPublicKeyHex } from './keys'
-import { SigningError, VerificationError, ConfigurationError } from './errors'
+import {
+  publicKeyToMultibase,
+  didKeyToPublicKeyHex,
+  validatePublicKey,
+} from './keys'
+import {
+  SigningError,
+  VerificationError,
+  ConfigurationError,
+  TrustAnchorError,
+} from './errors'
 import obContext from './data/ob-v3p0-context-3.0.3.json'
 import type {
   Credential,
@@ -262,6 +271,101 @@ export async function signCredential(
 }
 
 /**
+ * Why a credential did not verify, or why we could not tell (#859).
+ *
+ * The dividing line is WHO CONTROLS THE INPUT that failed:
+ *
+ *  - `invalid` — the failure is determined by the credential bytes, which the
+ *    presenter fully controls. A forger must not be able to talk their way out
+ *    of a negative verdict by feeding us something we choke on, so everything
+ *    downstream of the credential is a verdict.
+ *  - `indeterminate` — the failure is in OUR trust anchor (the issuer public
+ *    key we verify against). Nothing the presenter did caused it, retrying
+ *    after we fix our configuration may well produce `verified`, and saying
+ *    "invalid" here would brand every genuine badge we ever issued a forgery.
+ */
+type VerificationInvalidReason =
+  /** No proof at all, or an empty proof array. */
+  | 'no-proof'
+  /** More than one proof; we only ever issue exactly one. */
+  | 'proof-set'
+  /** proof.type is not DataIntegrityProof. */
+  | 'unsupported-proof-type'
+  /** proof.cryptosuite is not eddsa-rdfc-2022. */
+  | 'unsupported-cryptosuite'
+  /** The proof's verificationMethod does not bind to the trust anchor. */
+  | 'untrusted-verification-method'
+  /** The proof was evaluated and does not match. */
+  | 'signature-mismatch'
+  /** The credential could not be canonicalized / evaluated as written. */
+  | 'malformed-credential'
+
+type VerificationIndeterminateReason =
+  /** No issuer public key was supplied to verify against. */
+  | 'missing-trust-anchor'
+  /** The supplied issuer public key is not a usable Ed25519 key. */
+  | 'unusable-trust-anchor'
+
+/**
+ * Three-valued verification result.
+ *
+ * A `boolean` could not express "I could not evaluate this", so an internal
+ * failure — a botched key rotation, a missing env var — was indistinguishable
+ * from "this credential is forged". That matters because this verdict is
+ * consumed by platforms we do not control (Credly, the 1EdTech validator,
+ * LinkedIn importers) and is cached by intermediaries.
+ */
+export type VerificationOutcome =
+  | { status: 'verified' }
+  | { status: 'invalid'; reason: VerificationInvalidReason; detail?: string }
+  | {
+      status: 'indeterminate'
+      reason: VerificationIndeterminateReason
+      detail?: string
+    }
+
+function invalid(
+  reason: VerificationInvalidReason,
+  detail?: string,
+): VerificationOutcome {
+  return { status: 'invalid', reason, ...(detail && { detail }) }
+}
+
+function indeterminate(
+  reason: VerificationIndeterminateReason,
+  detail?: string,
+): VerificationOutcome {
+  return { status: 'indeterminate', reason, ...(detail && { detail }) }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * Normalize the trust anchor to a multibase Multikey, PROVING it is a usable
+ * 32-byte Ed25519 key on the way through.
+ *
+ * The `z...` branch used to pass through unchecked, so a truncated or
+ * corrupted `BADGE_ISSUER_ED25519_PUBLIC_KEY` silently became a key that
+ * matches nothing — reported as a bad signature on genuine badges. Decoding it
+ * turns that into a detectable configuration fault.
+ *
+ * @throws {KeyFormatError | EncodingError} when the key is not a usable
+ *   Ed25519 public key in either multibase or hex form.
+ */
+function normalizeTrustAnchor(publicKey: string): string {
+  if (publicKey.startsWith('z')) {
+    // Round-trips the multibase through base58 + the Ed25519 multicodec check
+    // and asserts a 32-byte key; throws otherwise.
+    didKeyToPublicKeyHex(`did:key:${publicKey}`)
+    return publicKey
+  }
+  // Validates 64 hex characters.
+  return publicKeyToMultibase(publicKey)
+}
+
+/**
  * Verify a credential's embedded Data Integrity Proof (eddsa-rdfc-2022)
  * using the Digital Bazaar reference stack with a fully offline loader.
  *
@@ -271,29 +375,50 @@ export async function signCredential(
  * verification methods are resolved locally by the loader (the supplied
  * public key is implied by the DID itself).
  *
+ * Total by construction: it does not throw for anything the credential can
+ * cause. Callers must branch on `status`, and must NOT turn `indeterminate`
+ * into a negative verdict — see {@link VerificationOutcome}.
+ *
+ * KNOWN LIMIT: a trust anchor that is well-formed but WRONG (a rotation to a
+ * different valid Ed25519 key) is indistinguishable from a bad signature from
+ * in here — there is no second anchor to check it against — so it still
+ * reports `invalid`. Only unusable keys are detectable as `indeterminate`.
+ *
  * @param credential - Signed credential with a proof array
  * @param publicKey - Ed25519 public key as 64 hex chars or multibase (z...)
- * @returns true when the proof verifies, false otherwise
  */
 export async function verifyCredential(
   credential: SignedCredential,
   publicKey: string,
-): Promise<boolean> {
+): Promise<VerificationOutcome> {
+  // ---------------------------------------------------------------------
+  // The trust anchor is OURS. Every failure below this line is a failure to
+  // evaluate, never a verdict on the credential.
+  // ---------------------------------------------------------------------
   if (!publicKey || typeof publicKey !== 'string') {
-    throw new VerificationError(
-      'Public key is required and must be a hex string',
-      { hasPublicKey: !!publicKey },
+    return indeterminate(
+      'missing-trust-anchor',
+      'No issuer public key was supplied to verify against',
     )
   }
 
+  let trustedMultibase: string
+  try {
+    trustedMultibase = normalizeTrustAnchor(publicKey)
+  } catch (error) {
+    return indeterminate('unusable-trust-anchor', errorMessage(error))
+  }
+
+  // ---------------------------------------------------------------------
+  // Everything below is determined by the credential bytes, which the
+  // presenter controls — so every failure is a verdict, not a shrug.
+  // ---------------------------------------------------------------------
   if (
     !credential.proof ||
     !Array.isArray(credential.proof) ||
     credential.proof.length === 0
   ) {
-    throw new VerificationError('Credential must have at least one proof', {
-      hasProof: !!credential.proof,
-    })
+    return invalid('no-proof', 'Credential must have at least one proof')
   }
 
   // We only ever issue a single proof. Reject proof sets: the type /
@@ -301,25 +426,31 @@ export async function verifyCredential(
   // would select whichever proof matches the suite, so a second proof could
   // slip past the gate. Binding to exactly one proof keeps the gate honest.
   if (credential.proof.length !== 1) {
-    throw new VerificationError('Credential must have exactly one proof', {
-      proofCount: credential.proof.length,
-    })
+    return invalid(
+      'proof-set',
+      `Credential must have exactly one proof, got ${credential.proof.length}`,
+    )
   }
 
   const proof = credential.proof[0]
 
+  // An unsupported proof type / cryptosuite is deliberately a VERDICT and not
+  // `indeterminate`: these fields are attacker-chosen, and treating them as
+  // "could not evaluate" would hand any forger a way to suppress the negative
+  // answer. We only ever issue eddsa-rdfc-2022 DataIntegrityProofs, so a
+  // credential carrying anything else was not signed by this issuer.
   if (proof.type !== 'DataIntegrityProof') {
-    throw new VerificationError('Unsupported proof type', {
-      proofType: proof.type,
-      expected: 'DataIntegrityProof',
-    })
+    return invalid(
+      'unsupported-proof-type',
+      `Expected DataIntegrityProof, got ${String(proof.type)}`,
+    )
   }
 
   if (proof.cryptosuite !== 'eddsa-rdfc-2022') {
-    throw new VerificationError('Unsupported cryptosuite', {
-      cryptosuite: proof.cryptosuite,
-      expected: 'eddsa-rdfc-2022',
-    })
+    return invalid(
+      'unsupported-cryptosuite',
+      `Expected eddsa-rdfc-2022, got ${String(proof.cryptosuite)}`,
+    )
   }
 
   try {
@@ -346,30 +477,27 @@ export async function verifyCredential(
         vmPublicKeyMultibase = publicKeyToMultibase(
           didKeyToPublicKeyHex(didKeyOnly),
         )
-      } catch {
-        // Unsupported / malformed did: method — cannot bind to the trust
-        // anchor, so refuse to trust it.
-        return false
+      } catch (error) {
+        // Unsupported / malformed did: method — the CREDENTIAL's own method,
+        // not ours, so this is a verdict: it cannot bind to the trust anchor.
+        return invalid('untrusted-verification-method', errorMessage(error))
       }
-      const trustedMultibase = publicKey.startsWith('z')
-        ? publicKey
-        : publicKeyToMultibase(publicKey)
       if (vmPublicKeyMultibase !== trustedMultibase) {
         // The DID's embedded key differs from the trusted public key: do NOT
         // let the DID resolve its own (untrusted) key.
-        return false
+        return invalid(
+          'untrusted-verification-method',
+          'The did:key verification method does not carry the trusted issuer key',
+        )
       }
       purpose = new jsigs.purposes.AssertionProofPurpose()
     } else {
-      const publicKeyMultibase = publicKey.startsWith('z')
-        ? publicKey
-        : publicKeyToMultibase(publicKey)
       staticDocuments.set(verificationMethodId, {
         '@context': 'https://w3id.org/security/multikey/v1',
         id: verificationMethodId,
         type: 'Multikey',
         controller: issuerId,
-        publicKeyMultibase,
+        publicKeyMultibase: trustedMultibase,
       })
       // Provide the controller document directly: the issuer authorizes the
       // verification method for assertions (mirrors the public issuer
@@ -392,9 +520,14 @@ export async function verifyCredential(
     })
 
     return result.verified === true
-  } catch {
-    // Return false for invalid signatures or unresolvable documents
-    return false
+      ? { status: 'verified' }
+      : invalid('signature-mismatch', 'The proof does not verify')
+  } catch (error) {
+    // The trust anchor was already proven usable and the loader is fully
+    // offline, so anything thrown here came out of the credential's own
+    // bytes (canonicalization, an unresolvable context it names, a proof that
+    // will not decode). Classify it as a verdict: the conservative direction.
+    return invalid('malformed-credential', errorMessage(error))
   }
 }
 
@@ -583,17 +716,23 @@ export async function signCredentialJWT(
 
 /**
  * Verify a JWT credential signature and extract the credential
- * Returns the decoded credential if valid, throws VerificationError if invalid
  * Supports both RS256 (RSA) and EdDSA (Ed25519) algorithms
+ *
+ * @returns the decoded credential when the signature verifies
+ * @throws {VerificationError} the credential is bad — a VERDICT
+ * @throws {TrustAnchorError} OUR key is unusable, so nothing was evaluated —
+ *   callers must answer "temporarily unavailable", never "not verified" (#859)
  */
 export async function verifyCredentialJWT(
   jwt: string,
   publicKey: string,
 ): Promise<Credential> {
+  // The key is ours, so a missing one is a failure to evaluate, not a verdict.
   if (!publicKey || typeof publicKey !== 'string') {
-    throw new VerificationError('Public key is required and must be a string', {
-      hasPublicKey: !!publicKey,
-    })
+    throw new TrustAnchorError(
+      'No issuer public key was supplied to verify against',
+      { hasPublicKey: !!publicKey },
+    )
   }
 
   if (!jwt || typeof jwt !== 'string') {
@@ -602,25 +741,48 @@ export async function verifyCredentialJWT(
     })
   }
 
+  // Check if we have RSA key (PEM format) or Ed25519 key (hex format)
+  const isRSA = publicKey.includes('BEGIN') && publicKey.includes('PUBLIC KEY')
+
+  // Loading the key happens OUTSIDE the verification try: a key that will not
+  // parse is a broken deployment, and folding it into the same catch is
+  // exactly what let a botched rotation report genuine badges as forged.
+  //
+  // The key is parsed EAGERLY (node's createPublicKey / an explicit hex check)
+  // rather than left to jose, whose importers accept a malformed PEM and only
+  // surface the fault later inside jwtVerify — i.e. wearing the disguise of a
+  // bad signature.
+  let publicKeyObj: CryptoKey
+  let algorithms: string[]
   try {
-    // Check if we have RSA key (PEM format) or Ed25519 key (hex format)
-    const isRSA =
-      publicKey.includes('BEGIN') && publicKey.includes('PUBLIC KEY')
-
-    let publicKeyObj: CryptoKey
-    let algorithms: string[]
-
     if (isRSA) {
       // Use RS256 with RSA keys
+      const parsed = createPublicKey(publicKey)
+      if (parsed.asymmetricKeyType !== 'rsa') {
+        throw new Error(
+          `Expected an RSA public key, got ${String(parsed.asymmetricKeyType)}`,
+        )
+      }
       publicKeyObj = await importSPKI(publicKey, 'RS256')
       algorithms = ['RS256']
     } else {
       // Use EdDSA with Ed25519 keys
+      validatePublicKey(publicKey)
       const jwk = publicKeyToJWK(publicKey)
       publicKeyObj = (await importJWK(jwk, 'EdDSA')) as CryptoKey
       algorithms = ['EdDSA']
     }
+  } catch (error) {
+    throw new TrustAnchorError(
+      'The configured issuer public key could not be loaded; the credential was not evaluated',
+      {
+        isRSA,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    )
+  }
 
+  try {
     const { payload } = await jwtVerify(jwt, publicKeyObj, {
       algorithms,
     })
@@ -641,7 +803,10 @@ export async function verifyCredentialJWT(
 
     return credential
   } catch (error) {
-    if (error instanceof VerificationError) {
+    if (
+      error instanceof VerificationError ||
+      error instanceof TrustAnchorError
+    ) {
       throw error
     }
     throw new VerificationError('JWT verification failed', {

--- a/src/lib/openbadges/crypto.ts
+++ b/src/lib/openbadges/crypto.ts
@@ -768,14 +768,17 @@ export async function verifyCredentialJWT(
   // parse is a broken deployment, and folding it into the same catch is
   // exactly what let a botched rotation report genuine badges as forged.
   //
-  // jose's importSPKI ALREADY fails eagerly on a malformed PEM (verified
-  // against jose 6.2.8: invalid base64, garbage DER and a wrong key type each
-  // throw a DOMException), so this block is what makes the classification
-  // independent of that: the fault is caught HERE, named TrustAnchorError, and
-  // stays one regardless of how a future jose version defers. The explicit
-  // `asymmetricKeyType` check adds a case jose does not cover on its own, and
-  // the eager parse keeps the classification honest under the suite-wide jose
-  // mock (see __tests__/mocks/jose.ts), whose importers accept anything.
+  // jose's importSPKI ALREADY fails eagerly on every malformation tested
+  // against jose 6.2.8 — invalid base64, garbage DER, and each of ed25519,
+  // rsa-pss, ec-P256, x25519, dsa, ed448 and x448 presented as RS256. Its
+  // validation is a superset of the checks below; they catch nothing it
+  // misses.
+  //
+  // They are kept for two reasons that do NOT depend on that remaining true:
+  // the fault is named TrustAnchorError HERE, in our code, so the
+  // classification survives a future jose version that defers instead; and it
+  // stays correct under the suite-wide jose mock (__tests__/mocks/jose.ts,
+  // see #866), whose importers accept anything.
   let publicKeyObj: CryptoKey
   let algorithms: string[]
   try {

--- a/src/lib/openbadges/crypto.ts
+++ b/src/lib/openbadges/crypto.ts
@@ -375,9 +375,15 @@ function normalizeTrustAnchor(publicKey: string): string {
  * verification methods are resolved locally by the loader (the supplied
  * public key is implied by the DID itself).
  *
- * Total by construction: it does not throw for anything the credential can
- * cause. Callers must branch on `status`, and must NOT turn `indeterminate`
- * into a negative verdict — see {@link VerificationOutcome}.
+ * Every credential-caused failure is RETURNED as an `invalid` outcome rather
+ * than thrown, including hostile shapes (`proof: [null]`, a non-object
+ * credential). That is a promise about CLASSIFICATION, not an absolute no-throw
+ * guarantee — an unforeseen shape reaching the inner `try` is still mapped to
+ * `invalid`, but callers should keep their own try/catch and treat any escape
+ * as a verdict, never as `indeterminate`.
+ *
+ * Callers must branch on `status`, and must NOT turn `indeterminate` into a
+ * negative verdict — see {@link VerificationOutcome}.
  *
  * KNOWN LIMIT: a trust anchor that is well-formed but WRONG (a rotation to a
  * different valid Ed25519 key) is indistinguishable from a bad signature from
@@ -413,6 +419,10 @@ export async function verifyCredential(
   // Everything below is determined by the credential bytes, which the
   // presenter controls — so every failure is a verdict, not a shrug.
   // ---------------------------------------------------------------------
+  if (!credential || typeof credential !== 'object') {
+    return invalid('malformed-credential', 'Credential is not an object')
+  }
+
   if (
     !credential.proof ||
     !Array.isArray(credential.proof) ||
@@ -433,6 +443,16 @@ export async function verifyCredential(
   }
 
   const proof = credential.proof[0]
+
+  // `proof: [null]` / `proof: ['...']` would otherwise TypeError on the field
+  // reads below and escape as a throw. It is presenter-supplied JSON, so it
+  // gets a verdict like every other credential shape.
+  if (!proof || typeof proof !== 'object') {
+    return invalid(
+      'malformed-credential',
+      `Proof must be an object, got ${proof === null ? 'null' : typeof proof}`,
+    )
+  }
 
   // An unsupported proof type / cryptosuite is deliberately a VERDICT and not
   // `indeterminate`: these fields are attacker-chosen, and treating them as
@@ -748,10 +768,14 @@ export async function verifyCredentialJWT(
   // parse is a broken deployment, and folding it into the same catch is
   // exactly what let a botched rotation report genuine badges as forged.
   //
-  // The key is parsed EAGERLY (node's createPublicKey / an explicit hex check)
-  // rather than left to jose, whose importers accept a malformed PEM and only
-  // surface the fault later inside jwtVerify — i.e. wearing the disguise of a
-  // bad signature.
+  // jose's importSPKI ALREADY fails eagerly on a malformed PEM (verified
+  // against jose 6.2.8: invalid base64, garbage DER and a wrong key type each
+  // throw a DOMException), so this block is what makes the classification
+  // independent of that: the fault is caught HERE, named TrustAnchorError, and
+  // stays one regardless of how a future jose version defers. The explicit
+  // `asymmetricKeyType` check adds a case jose does not cover on its own, and
+  // the eager parse keeps the classification honest under the suite-wide jose
+  // mock (see __tests__/mocks/jose.ts), whose importers accept anything.
   let publicKeyObj: CryptoKey
   let algorithms: string[]
   try {

--- a/src/lib/openbadges/errors.ts
+++ b/src/lib/openbadges/errors.ts
@@ -6,6 +6,7 @@ export const ERROR_CODES = {
   INVALID_CREDENTIAL_CONFIG: 'INVALID_CREDENTIAL_CONFIG',
   SIGNING_FAILED: 'SIGNING_FAILED',
   VERIFICATION_FAILED: 'VERIFICATION_FAILED',
+  TRUST_ANCHOR_UNUSABLE: 'TRUST_ANCHOR_UNUSABLE',
   INVALID_SIGNATURE: 'INVALID_SIGNATURE',
   INVALID_KEY_FORMAT: 'INVALID_KEY_FORMAT',
   INVALID_MULTIBASE: 'INVALID_MULTIBASE',
@@ -63,6 +64,23 @@ export class VerificationError extends OpenBadgesError {
   constructor(message: string, context?: Record<string, unknown>) {
     super(ERROR_CODES.VERIFICATION_FAILED, message, context)
     this.name = 'VerificationError'
+  }
+}
+
+/**
+ * The key we were asked to verify AGAINST is unusable — missing, malformed, or
+ * not importable. This is OUR configuration, never the credential (#859).
+ *
+ * It is deliberately NOT a `VerificationError`: a VerificationError is a
+ * verdict on the credential, and callers turn it into "not verified". A
+ * TrustAnchorError means the credential was never evaluated at all, so callers
+ * must answer "temporarily unavailable" — 503, never cached — instead of
+ * telling an external verifier that a real badge is a forgery.
+ */
+export class TrustAnchorError extends OpenBadgesError {
+  constructor(message: string, context?: Record<string, unknown>) {
+    super(ERROR_CODES.TRUST_ANCHOR_UNUSABLE, message, context)
+    this.name = 'TrustAnchorError'
   }
 }
 

--- a/src/lib/openbadges/index.ts
+++ b/src/lib/openbadges/index.ts
@@ -6,6 +6,7 @@ export {
   verifyCredentialJWT,
   seedToMultikey,
 } from './crypto'
+export type { VerificationOutcome } from './crypto'
 
 export { validateCredential, assertValidCredential } from './validator'
 
@@ -41,6 +42,7 @@ export {
   OpenBadgesError,
   SigningError,
   VerificationError,
+  TrustAnchorError,
   ValidationError,
   BakingError,
   ExtractionError,

--- a/src/server/routers/badge.ts
+++ b/src/server/routers/badge.ts
@@ -50,7 +50,8 @@ export const badgeRouter = router({
       let badgeAssertion
       if (isJWTFormat(badge.badgeJson)) {
         // Legacy badge: badgeJson holds the RS256 JWT credential
-        const { verifyCredentialJWT } = await import('@/lib/openbadges')
+        const { verifyCredentialJWT, TrustAnchorError } =
+          await import('@/lib/openbadges')
         const publicKey = process.env.BADGE_ISSUER_RSA_PUBLIC_KEY
         if (!publicKey) {
           throw new TRPCError({
@@ -68,7 +69,21 @@ export const badgeRouter = router({
             credential: badgeAssertion,
             verifiedAt: new Date().toISOString(),
           }
-        } catch {
+        } catch (error) {
+          // #859. An unusable RSA key means this credential was NEVER
+          // evaluated, so `valid: false` would be the very misclassification
+          // this PR exists to remove — on a public procedure, for the legacy
+          // JWT format that covers half the issued badges. Fail the call the
+          // way a MISSING key already does seven lines up, and the way the
+          // embedded branch below handles `indeterminate`.
+          if (error instanceof TrustAnchorError) {
+            throw new TRPCError({
+              code: 'PRECONDITION_FAILED',
+              message:
+                'Badge signature could not be evaluated (unusable issuer key); this is not a statement about the credential',
+            })
+          }
+
           return {
             valid: false,
             signatureValid: false,

--- a/src/server/routers/badge.ts
+++ b/src/server/routers/badge.ts
@@ -116,7 +116,20 @@ export const badgeRouter = router({
             if (
               acceptedEd25519VerificationMethods(issuerId).includes(proofVm)
             ) {
-              signatureValid = await verifyCredential(badgeAssertion, publicKey)
+              const outcome = await verifyCredential(badgeAssertion, publicKey)
+
+              // #859. "We could not evaluate this" is not `signatureValid:
+              // false`. An unusable issuer key is our deployment, so fail the
+              // call the same way a missing key does rather than telling an
+              // organizer their speaker's real badge is bad.
+              if (outcome.status === 'indeterminate') {
+                throw new TRPCError({
+                  code: 'PRECONDITION_FAILED',
+                  message: `Badge signature could not be evaluated (${outcome.reason}); this is not a statement about the credential`,
+                })
+              }
+
+              signatureValid = outcome.status === 'verified'
             }
           }
 
@@ -126,9 +139,14 @@ export const badgeRouter = router({
             credential: badgeAssertion,
             verifiedAt,
           }
-        } catch {
-          // Malformed badgeJson or a throwing verifyCredential (e.g. multiple
-          // proofs, wrong type/cryptosuite) is a not-valid badge, not a 500.
+        } catch (error) {
+          // A failure to evaluate must not be laundered into a verdict by the
+          // catch-all below.
+          if (error instanceof TRPCError) throw error
+
+          // Malformed badgeJson is a not-valid badge, not a 500. (Proof sets
+          // and wrong type/cryptosuite no longer throw — verifyCredential
+          // returns them as `invalid` outcomes.)
           return {
             valid: false,
             signatureValid: false,


### PR DESCRIPTION
Fixes #859.

> [!IMPORTANT]
> **Correction (34808d2a).** An earlier revision of this PR claimed jose's `importSPKI` accepts a malformed PEM and only fails later inside `jwtVerify`. **That is false** against the repo's jose 6.2.8 — it throws eagerly for invalid base64 (`DOMException: Invalid character`), garbage DER (`Invalid keyData`) and a wrong key type (`Invalid key type`). The observation came from the suite-wide jose **mock**, whose importers accept anything: I trusted a mocked library to describe the real one. Corrected in the commit message, in the source comment at `crypto.ts`, and in the "strengthenings" section below. No behaviour change — real `importSPKI` throws inside the same try block, so production yields `TrustAnchorError` → 503 either way. A second correction (`verifyCredential` was not "total by construction") is described under [Contract hardening](#contract-hardening).


## The defect

`verifyCredential` returned a `boolean`, and its catch arm returned `false`. A boolean cannot say **"I could not evaluate this"**, so an internal failure — a malformed key, a missing env var — was indistinguishable from **"this credential is forged"**.

That verdict is read by platforms we do not control (Credly, the 1EdTech validator, LinkedIn importers), and `/api/badge/[badgeId]/verify` served it with `Cache-Control: public, max-age=3600`. A botched `BADGE_ISSUER_ED25519_PUBLIC_KEY` rotation would have told all of them our genuine badges were fake — and intermediaries would have kept saying so for an hour after we fixed the key.

## The fix

Verification is now three-valued — `verified | invalid | indeterminate`, each with a `reason` — and the route answers **503 + `no-store` + `Retry-After: 30`** on indeterminate. This is deliberately the same shape #855 established one layer up for `getBadgeById`; both paths now funnel through one `verificationUnavailable()` helper in the route, so a lookup outage and a crypto outage are one signal to an external verifier.

## The classification (the actual work)

The rule, applied to every throw site and every `false`-return on the verify path:

> **`indeterminate` is reserved for OUR trust anchor being unusable. Everything determined by the credential bytes stays a verdict.**

The asymmetry is the point: credential bytes are **presenter-controlled**. If a hostile credential could push us into `indeterminate`, a forger would have a button that suppresses the negative answer. Our own key is not something a presenter can touch, so it is the only safe source of "we don't know".

| failure mode | classification | reason |
| --- | --- | --- |
| no public key supplied | indeterminate | `missing-trust-anchor` |
| key not a usable Ed25519 key (truncated, non-base58, wrong multicodec, bad hex, PEM in the wrong slot) | indeterminate | `unusable-trust-anchor` |
| RSA PEM will not parse (JWT path) | indeterminate | `TrustAnchorError` |
| no proof / empty proof array | invalid | `no-proof` |
| more than one proof | invalid | `proof-set` |
| `proof.type` not `DataIntegrityProof` | invalid | `unsupported-proof-type` |
| `cryptosuite` not `eddsa-rdfc-2022` | invalid | `unsupported-cryptosuite` |
| foreign / malformed `did:key` verification method | invalid | `untrusted-verification-method` |
| proof evaluated and does not match | invalid | `signature-mismatch` |
| anything else thrown out of the DB stack | invalid | `malformed-credential` |

Two judgement calls, stated rather than papered over:

- **Unsupported proof type / cryptosuite are `invalid`, not `indeterminate`.** They are attacker-chosen fields. The cost is a narrow one: if we ever add a cryptosuite, an old instance mid-rolling-deploy would report a newly-issued badge `invalid`. That risk is smaller than handing every forger a way to dodge the verdict, and the back-compat constraint here is not to change the signing scheme anyway.
- **The catch-all around `vc.verifyCredential` is `invalid`.** The trust anchor is already proven usable by that point and the document loader is fully offline, so anything thrown there came out of the credential's own bytes. This is the conservative direction.

## One real strengthening, plus a defensible belt-and-braces

1. **The `z...` trust anchor used to pass through unvalidated.** Production stores the key as a multibase (`z6Mk…`), so the most likely corruption — truncation in transit — silently became a key that matches nothing, i.e. the exact false negative in the issue. `normalizeTrustAnchor` now decodes it (base58 → Ed25519 multicodec → 32 bytes) and a failure is `indeterminate`. **This one is real and verified.**
2. ~~`jose` accepts a malformed PEM at import and only fails later inside `jwtVerify`.~~ **False — see the correction above.** jose 6.2.8 fails eagerly in every malformation class I could construct. The eager `createPublicKey` parse is **kept** for reasons that are actually true: it pins the classification in OUR code rather than depending on jose internals staying eager, and it keeps the classification honest under the suite-wide jose mock. Belt-and-braces, not a discovered hazard.
>
> **Second correction (6072855f):** the source comment also claimed the explicit `asymmetricKeyType !== 'rsa'` check "adds a case jose does not cover on its own". Also false, same species — tested in standalone node against jose 6.2.8, `importSPKI(pem, 'RS256')` throws `Invalid key type` eagerly for ed25519, rsa-pss, ec-P256, x25519, dsa, ed448 and x448. jose's validation is a superset; the check catches nothing it misses. Struck. The eager parse still stands on the two reasons that are true.

## The defect this PR nearly shipped (round-2 review, 6072855f)

`badge.verify` (a **public** tRPC procedure) wrapped `verifyCredentialJWT` in a bare `catch { return { valid: false, signatureValid: false, … } }`. That catch predates this PR — but **this PR is what made `verifyCredentialJWT` throw `TrustAnchorError`** when our RSA key is unusable. So an unusable key produced a definitive "this badge is bad", for the legacy JWT format covering **2 of the 4 production badges**: the #859 misclassification itself, surviving inside the PR that exists to eliminate it.

Stark within one file — a *missing* RSA key already threw `PRECONDITION_FAILED` seven lines up, and the embedded branch already mapped `indeterminate` the same way. Only the unusable-key case fell through. Now mirrors both, with five new tests and three sabotage rows.

Caught by [an unresolved Copilot thread](https://github.com/CloudNativeBergen/website/pull/864#discussion_r3727060422) that I walked past on the first pass.

<a id="contract-hardening"></a>
## Contract hardening (Copilot thread, `crypto.ts:380`)

Copilot was factually right that "total by construction" overclaimed: `verifyCredential({...signed, proof: [null]})` TypeError'd on the field reads before the inner `try`. Not a security defect — the route's verification-method gate short-circuits such input to a verdict before `verifyCredential` is called, and both other callers wrap in try/catch — but the contract said something the implementation did not deliver.

Fixed both ways: shape guards now return `invalid`/`malformed-credential` for a non-object proof entry and a non-object credential, **and** the JSDoc now promises classification rather than absolute no-throw.

## Known limit — stated, not hidden

A trust anchor that is **well-formed but wrong** (a rotation to a different valid Ed25519 key) is indistinguishable from a bad signature from inside the verifier — there is no second anchor to check it against — so it still reports `invalid`. There is a test named `DOCUMENTED LIMIT: a valid-but-wrong key is still reported invalid` pinning exactly that. Detectable corruption covers the realistic accidents; key substitution does not.

## Verification

Baseline is `origin/main` (23461ae1).

| check | before | after |
| --- | --- | --- |
| `pnpm test` | 515 files / 7538 tests, 0 failures | **516 files / 7581 tests, 0 failures** |
| `pnpm typecheck` | clean | clean |
| `npx prettier --check .` | clean | clean |
| `npx eslint .` | 0 errors, 201 warnings | 0 errors, 201 warnings |
| `pnpm knip` | clean | clean |

### Sabotage-proven

Each sabotage was applied to the source, the suite re-run (file **and** test counts checked so a broken import could not read as a pass), then reverted and the tree diffed byte-for-byte against a pre-sabotage copy.

| sabotage | result |
| --- | --- |
| classify an unusable key as `signature-mismatch` (the original bug) | **8 failures**, including `does NOT report a genuine badge as unverified when the key is corrupt` |
| cache the indeterminate answer (`no-store` → `max-age=3600`) | **4 failures**, including the #855 lookup-outage test |
| classify a failed signature as `indeterminate` (the generous direction) | **7 failures**, including `STILL reports a tampered badge as invalid, with the normal cache` |
| drop the eager RSA key parse | **2 failures**, including the legacy-JWT 503 test (note: under the jose mock. With real jose the parse is redundant — see the correction) |
| remove the non-object proof guard | **3 failures**, exactly the three hostile-proof rows |
| swallow `TrustAnchorError` in the tRPC JWT branch | **1 failure**, the legacy-JWT unusable-key row |
| launder the tRPC embedded `indeterminate` into a verdict | **1 failure**, the embedded corrupt-key row |
| widen the tRPC catch to every `Error` (generous direction) | **1 failure**, the tampered-JWT counterweight |

The decisive test is `does NOT report a genuine badge as unverified when the key is corrupt`: same real, correctly-signed credential as the passing case, only `BADGE_ISSUER_ED25519_PUBLIC_KEY` sabotaged. It asserts 503, `no-store`, no `max-age`, and no `valid`/`verified` field in the body.

Caching is asserted in both directions: `no-store` on every indeterminate path, and `public, max-age=3600` still on a genuine positive verdict, a tampered badge, and a foreign-VM badge.

### Back-compat

Production holds **4 badges — 2 legacy JWT, 2 embedded proof** (verified read-only via `sanity documents query`), so both branches matter and both are covered. No change to the credential format, the signing scheme, or any response field an external verifier reads on the success path. The one intentional response change is on failure: a missing issuer key now answers `503 + Retry-After` instead of `500` — both non-verdicts, the new one actionable.

## Call sites updated

`verifyCredential`'s return type changed, so every caller was updated rather than left to coerce a truthy object:

- `src/app/api/badge/[badgeId]/verify/route.ts` — 503/`no-store` on indeterminate
- `src/server/routers/badge.ts` — `PRECONDITION_FAILED` (matching how a missing key is already handled) instead of laundering a non-answer into `signatureValid: false`
- `src/lib/badge/validation.ts` (×2, the admin validator) — a `warning` check saying "could not evaluate", not a red X on a credential that was never checked

## Not done, deliberately

- `/api/badge/[badgeId]/achievement` also calls `verifyCredentialJWT`, but it answers `500` with no cache header — already a non-verdict — so it is left alone.
- A well-formed-but-wrong key *could* be caught in deployments that also hold `BADGE_ISSUER_ED25519_SEED` by cross-checking the derived key. Verify-only deployments have no seed, so this only helps some of the time; noting it as a possible follow-up rather than smuggling it in here.
- **`jose` is aliased to `__tests__/mocks/jose.ts` suite-wide** (`vitest.config.ts`, pre-existing since #336), so JWT signature *mathematics* is never exercised — a cross-key EdDSA JWT "verifies" under the mock, on the path that covers 2 of the 4 production badges. The mock's own header claims "The openbadges library tests use real jose", which is false. Filed separately as #866 rather than expanded into this PR; it is also the direct cause of the false claim corrected above.


