### PR TITLE
fix(travel-support,badge): guard the two HIGH by-id admin procedures the #730 sweep skipped

### DIFF
--- a/src/components/travel-support/TravelSupportAdminPage.tsx
+++ b/src/components/travel-support/TravelSupportAdminPage.tsx
@@ -8,6 +8,7 @@ import {
   TravelSupportStatus,
   ExpenseStatus,
   TravelSupportWithSpeaker,
+  TravelSupportDetail,
   TravelExpense,
 } from '@/lib/travel-support/types'
 import { TravelSupportService } from '@/lib/travel-support/service'
@@ -437,7 +438,11 @@ function RequestDetails({
   onUpdateExpenseStatus,
   isUpdating,
 }: {
-  request: TravelSupportWithSpeaker & { expenses: TravelExpense[] }
+  // The DETAIL payload (`admin.getById`), which is explicitly projected and so
+  // narrower than the list rows above (#863) — it carries only the fields this
+  // pane reads. Widening it means widening the query too; see
+  // `TravelSupportDetail`.
+  request: TravelSupportDetail
   currentUserId?: string
   onUpdateStatus: (
     id: string,

--- a/src/lib/badge/sanity.scoped.test.ts
+++ b/src/lib/badge/sanity.scoped.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+/**
+ * #863. `badge.admin.resendEmail` mailed whichever speaker `getBadgeById`
+ * returned, and that lookup filters on the PUBLIC `badgeId` alone. The fix is
+ * `getBadgeForConference`, whose predicate is the tenant boundary — so the
+ * predicate itself is what has to be pinned. The router tests
+ * (`src/server/routers/badge.tenancy.test.ts`) mock this function; without the
+ * cases below, that mock would be the only place the conference predicate exists.
+ */
+const badgeFetch = vi.fn()
+vi.mock('../sanity/client', () => ({
+  clientRead: { fetch: (...a: unknown[]) => badgeFetch(...a) },
+  clientWrite: { fetch: (...a: unknown[]) => badgeFetch(...a) },
+  clientReadUncached: { fetch: (...a: unknown[]) => badgeFetch(...a) },
+}))
+
+import { getBadgeForConference } from './sanity'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('getBadgeForConference is tenant-scoped at the query', () => {
+  it('constrains the read to the given conference', async () => {
+    badgeFetch.mockResolvedValue({ badgeId: 'b-1' })
+
+    await getBadgeForConference('b-1', 'conf-A')
+
+    const [query, params] = badgeFetch.mock.calls[0]
+    expect(query).toContain('conference._ref == $conferenceId')
+    expect(params).toEqual({ badgeId: 'b-1', conferenceId: 'conf-A' })
+  })
+
+  it('carries the predicate UNCONDITIONALLY', async () => {
+    // The fail-open shape this must never become is a predicate guarded by its
+    // own parameter (`!defined($conferenceId) || …`), which reads every tenant
+    // whenever the argument is absent — `optionalTenantFilter` in
+    // `eslint-rules/no-unscoped-groq.js`.
+    badgeFetch.mockResolvedValue({ badgeId: 'b-1' })
+
+    await getBadgeForConference('b-1', 'conf-A')
+
+    const [query] = badgeFetch.mock.calls[0]
+    expect(query).not.toContain('defined($conferenceId)')
+  })
+
+  it('reads NOTHING when the conference is missing', async () => {
+    // An unresolved tenant has no scope to read within, so it must refuse
+    // rather than issue a query that would match across tenants.
+    const result = await getBadgeForConference('b-1', '')
+
+    expect(badgeFetch).not.toHaveBeenCalled()
+    expect(result.badge).toBeUndefined()
+    expect(result.reason).toBe('not-found')
+  })
+
+  it('reports not-found for a badge outside the conference, like any absence', async () => {
+    // The predicate does the refusing, so the caller cannot tell a foreign badge
+    // from a nonexistent one — no existence oracle over other tenants' ids.
+    badgeFetch.mockResolvedValue(null)
+
+    const result = await getBadgeForConference('b-theirs', 'conf-A')
+
+    expect(result.badge).toBeUndefined()
+    expect(result.reason).toBe('not-found')
+    expect(result.error?.message).toBe('Badge not found')
+  })
+
+  it('still separates a failed read from an absent badge (#848)', async () => {
+    badgeFetch.mockRejectedValue(new Error('ECONNREFUSED sanity.io'))
+
+    const result = await getBadgeForConference('b-1', 'conf-A')
+
+    expect(result.reason).toBe('unavailable')
+    expect(result.reason).not.toBe('not-found')
+  })
+})

--- a/src/lib/badge/sanity.ts
+++ b/src/lib/badge/sanity.ts
@@ -239,6 +239,57 @@ export async function getBadgeById(badgeId: string): Promise<{
   }
 }
 
+/**
+ * The TENANT-SCOPED form of {@link getBadgeById}: one badge by its public
+ * `badgeId`, but only if it belongs to `conferenceId`.
+ *
+ * WHY IT IS A SEPARATE FUNCTION (#863). `getBadgeById` looks a badge up by a
+ * PUBLIC identifier with no conference predicate, which is right for the public
+ * surface — `/api/badge/[badgeId]/verify` and friends must answer for any
+ * issuer's badge. It is wrong for an admin action, and `badge.admin.resendEmail`
+ * used it: an organizer of tenant A could pass tenant B's badge id and have us
+ * MAIL B's speaker. That one ACTS rather than reads, which is why the fix scopes
+ * the lookup itself instead of filtering afterwards.
+ *
+ * The predicate is UNCONDITIONAL, and `conferenceId` is required. An optional
+ * `conferenceId` that degrades to "all tenants" when absent is the fail-open
+ * shape `eslint-rules/no-unscoped-groq.js` classifies as `optionalTenantFilter`
+ * — visible scoping that is visibly wrong. A caller with no resolved conference
+ * has no business reading a badge and must refuse before it gets here.
+ *
+ * A foreign badge is therefore INDISTINGUISHABLE from a nonexistent one: both
+ * return `not-found`. That is deliberate — a caller is not entitled to learn
+ * that a badge id it does not own exists.
+ */
+export async function getBadgeForConference(
+  badgeId: string,
+  conferenceId: string,
+): Promise<{
+  badge?: BadgeRecord
+  error?: Error
+  reason?: BadgeLookupReason
+}> {
+  if (!badgeId || !conferenceId) {
+    return { error: new Error('Badge not found'), reason: 'not-found' }
+  }
+
+  try {
+    const badge = await clientRead.fetch<BadgeRecord>(
+      `*[_type == "speakerBadge" && badgeId == $badgeId && conference._ref == $conferenceId][0]{${BADGE_FIELDS}}`,
+      { badgeId, conferenceId },
+    )
+
+    if (!badge) {
+      return { error: new Error('Badge not found'), reason: 'not-found' }
+    }
+
+    return { badge }
+  } catch (error) {
+    console.error('Failed to fetch badge for conference:', error)
+    return { error: error as Error, reason: 'unavailable' }
+  }
+}
+
 export async function listBadgesForConference(
   conferenceId: string,
 ): Promise<{ badges?: BadgeRecord[]; error?: Error }> {

--- a/src/lib/travel-support/auth.ts
+++ b/src/lib/travel-support/auth.ts
@@ -2,11 +2,7 @@ import { TRPCError } from '@trpc/server'
 import { getSpeaker } from '@/lib/speaker/sanity'
 import { Flags } from '@/lib/speaker/types'
 import { getTravelSupportById } from './sanity'
-import {
-  TravelSupportStatus,
-  TravelSupportWithSpeaker,
-  TravelExpense,
-} from './types'
+import { TravelSupportStatus, TravelSupportDetail } from './types'
 import { AppEnvironment } from '@/lib/environment/config'
 import { isOrganizerForOrg } from '@/lib/authz/organizer'
 
@@ -70,8 +66,7 @@ export async function verifyTravelSupportOwnership(
   travelSupportId: string,
   speaker: TravelSupportAuthSpeaker,
 ): Promise<{
-  travelSupport:
-    (TravelSupportWithSpeaker & { expenses: TravelExpense[] }) | null
+  travelSupport: TravelSupportDetail | null
   hasAccess: boolean
   /**
    * The ORG-SCOPED organizer decision for THIS request (the caller organizes the
@@ -182,7 +177,7 @@ export async function authorizeTravelSupportOperation(
   operation: 'read' | 'modify' | 'submit' | 'approve',
 ): Promise<{
   authorized: boolean
-  travelSupport?: TravelSupportWithSpeaker & { expenses: TravelExpense[] }
+  travelSupport?: TravelSupportDetail
   /**
    * The ORG-SCOPED organizer decision for this request (see
    * {@link verifyTravelSupportOwnership}), surfaced on success so callers (e.g.

--- a/src/lib/travel-support/sanity.projection.test.ts
+++ b/src/lib/travel-support/sanity.projection.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+/**
+ * #863. `getTravelSupportById` opened with a bare `...` spread over a document
+ * carrying `bankingDetails` — beneficiary, IBAN, account number, SWIFT — so it
+ * returned every field the schema has, and every field it ever grows, to
+ * whoever called it. The guard on `travelSupport.admin.getById` decides WHO may
+ * read; this projection decides WHAT is read, and the two are independent
+ * controls.
+ *
+ * TypeScript cannot enforce the second one: a field the query forgot and a field
+ * the document lacks both arrive `undefined`, so a projection that silently
+ * drops something a consumer needs type-checks perfectly. Hence these cases —
+ * the field list is asserted against the query text, and `FIELDS` below must
+ * mirror `TravelSupportDetail` exactly.
+ */
+const fetchMock = vi.fn()
+vi.mock('../sanity/client', () => ({
+  clientRead: { fetch: (...a: unknown[]) => fetchMock(...a) },
+  clientReadUncached: { fetch: (...a: unknown[]) => fetchMock(...a) },
+  clientWrite: { fetch: (...a: unknown[]) => fetchMock(...a) },
+}))
+vi.mock('@/lib/sanity/scoped', () => ({ scopedFetch: vi.fn() }))
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationRefViaParentConference: vi.fn(),
+  organizationField: vi.fn(),
+}))
+
+import { getTravelSupportById } from './sanity'
+
+/** Every member of `TravelSupportDetail`, which the query must project. */
+const FIELDS = [
+  '_id',
+  'status',
+  'bankingDetails',
+  'totalAmount',
+  'approvedAmount',
+  'expectedPaymentDate',
+  'reviewNotes',
+  'speaker',
+  'conference',
+  'conferenceOrgId',
+  'expenses',
+]
+
+/** Every member of `BankingDetails`. */
+const BANKING_FIELDS = [
+  'beneficiaryName',
+  'bankName',
+  'iban',
+  'accountNumber',
+  'swiftCode',
+  'country',
+  'preferredCurrency',
+]
+
+async function capturedQuery(): Promise<string> {
+  fetchMock.mockResolvedValue(null)
+  await getTravelSupportById('ts-1')
+  return fetchMock.mock.calls[0][0] as string
+}
+
+/**
+ * The projection of the travelSupport DOCUMENT itself — everything before the
+ * `expenses` sub-query, which projects a different type (`travelExpense`,
+ * which carries no banking fields) and is deliberately left as it was.
+ */
+async function documentProjection(): Promise<string> {
+  const query = await capturedQuery()
+  return query.slice(query.indexOf('[0]'), query.indexOf('"expenses"'))
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('getTravelSupportById projects explicitly (#863)', () => {
+  it('does not spread the document', async () => {
+    expect(await documentProjection()).not.toContain('...')
+  })
+
+  it('projects every field its type promises', async () => {
+    const projection = await documentProjection()
+    for (const field of FIELDS.filter((f) => f !== 'expenses')) {
+      expect(projection).toContain(field)
+    }
+    expect(await capturedQuery()).toContain('"expenses"')
+  })
+
+  it('projects the banking fields the payout pane renders', async () => {
+    // Explicit here too: `bankingDetails` as a bare field would re-open the
+    // same spread one level down.
+    const projection = await documentProjection()
+    for (const field of BANKING_FIELDS) {
+      expect(projection).toContain(field)
+    }
+  })
+
+  it('resolves the tenant key the ownership guard decides on', async () => {
+    // Losing this one fails OPEN rather than loudly: `conferenceOrgId` would be
+    // `undefined`, `isOrganizerForOrg` would see a null org, and every organizer
+    // would be refused — or, if the comparison ever flips, admitted.
+    expect(await documentProjection()).toContain(
+      '"conferenceOrgId": conference->organization._ref',
+    )
+  })
+
+  it('is still a by-id read, so the caller must guard it', async () => {
+    // No tenant predicate, deliberately: `authorizeTravelSupportOperation` is
+    // built on this read and has to SEE a foreign document to refuse it.
+    const query = await capturedQuery()
+    expect(query).toContain('_id == $id')
+    expect(query).not.toContain('conference._ref == $conferenceId')
+  })
+})

--- a/src/lib/travel-support/sanity.ts
+++ b/src/lib/travel-support/sanity.ts
@@ -7,6 +7,7 @@ import {
   TravelSupportInput,
   TravelSupportWithExpenses,
   TravelSupportWithSpeaker,
+  TravelSupportDetail,
   TravelExpense,
   TravelExpenseInput,
   BankingDetails,
@@ -48,9 +49,26 @@ export async function getTravelSupport(
   }
 }
 
+/**
+ * One travel-support request by document id.
+ *
+ * EXPLICITLY PROJECTED (#863). This used to open with a bare `...` spread, which
+ * returned every field of a document that carries the speaker's BANKING DETAILS
+ * — beneficiary, IBAN, account number, SWIFT. A spread is an open-ended
+ * disclosure contract: whatever the schema grows next ships too, to every caller
+ * of this function, without anyone deciding it should. The field list below is
+ * the contract instead, and {@link TravelSupportDetail} is its type; the two are
+ * one unit and must be edited together.
+ *
+ * IT IS A GLOBAL BY-ID READ, AND THE CALLER MUST GUARD IT. The id comes from
+ * client input and this query has no tenant predicate — deliberately, because
+ * `authorizeTravelSupportOperation` is built ON this read: it needs to SEE a
+ * foreign document in order to refuse it. Every caller must therefore go through
+ * that guard (`travelSupport.admin.getById` did not, which was #863's HIGH), or
+ * be the guard itself.
+ */
 export async function getTravelSupportById(id: string): Promise<{
-  travelSupport:
-    (TravelSupportWithSpeaker & { expenses: TravelExpense[] }) | null
+  travelSupport: TravelSupportDetail | null
   error: Error | null
 }> {
   try {
@@ -58,11 +76,23 @@ export async function getTravelSupportById(id: string): Promise<{
       throw new Error('Travel support ID is required')
     }
 
-    const travelSupport = await clientRead.fetch<
-      (TravelSupportWithSpeaker & { expenses: TravelExpense[] }) | null
-    >(
+    const travelSupport = await clientRead.fetch<TravelSupportDetail | null>(
       `*[_type == "travelSupport" && _id == $id][0] {
-        ...,
+        _id,
+        status,
+        bankingDetails {
+          beneficiaryName,
+          bankName,
+          iban,
+          accountNumber,
+          swiftCode,
+          country,
+          preferredCurrency
+        },
+        totalAmount,
+        approvedAmount,
+        expectedPaymentDate,
+        reviewNotes,
         speaker-> {
           _id,
           name,

--- a/src/lib/travel-support/types.ts
+++ b/src/lib/travel-support/types.ts
@@ -129,3 +129,47 @@ export interface TravelSupportWithSpeaker extends Omit<
    */
   conferenceOrgId?: string | null
 }
+
+/**
+ * What the BY-ID read (`getTravelSupportById`) returns — and therefore what
+ * `travelSupport.admin.getById` puts on the wire.
+ *
+ * IT IS DELIBERATELY NARROWER THAN {@link TravelSupportWithSpeaker} (#863). That
+ * query used a bare `...` spread over a document whose `bankingDetails` holds
+ * IBAN, account number and SWIFT, so it shipped every field the schema has —
+ * present and future — to whoever asked. This type is the PROJECTION CONTRACT:
+ * the query lists exactly these fields and nothing else, so a field added to
+ * `sanity/schemaTypes/travelSupport.ts` tomorrow does not silently join the
+ * payload. Its members are the union of what the consumers actually read —
+ * `TravelSupportAdminPage`'s detail pane, the ownership check in
+ * {@link ../auth}, and the status/expense notification emitters.
+ *
+ * `bankingDetails` STAYS. It is not residue: the detail pane renders
+ * beneficiary, bank, IBAN/account, SWIFT and country so an organizer can pay the
+ * speaker. The fix for that exposure is the ownership guard, not the projection.
+ *
+ * ADD A FIELD HERE ONLY TOGETHER WITH THE QUERY. TypeScript cannot tell a field
+ * the query forgot from one the document lacks — both arrive `undefined` — so
+ * the two must be edited as one unit.
+ */
+export interface TravelSupportDetail {
+  _id: string
+  status: TravelSupportStatus
+  bankingDetails: BankingDetails
+  totalAmount?: number
+  approvedAmount?: number
+  expectedPaymentDate?: string
+  reviewNotes?: string
+  speaker: {
+    _id: string
+    name: string
+    email: string
+  }
+  conference: {
+    _id: string
+    name: string
+  }
+  /** See {@link TravelSupportWithSpeaker.conferenceOrgId} — the tenant key. */
+  conferenceOrgId?: string | null
+  expenses: TravelExpense[]
+}

--- a/src/server/routers/badge.tenancy.test.ts
+++ b/src/server/routers/badge.tenancy.test.ts
@@ -1,0 +1,262 @@
+/**
+ * @vitest-environment node
+ *
+ * CROSS-TENANT DELIVERY for badges (#863, HIGH).
+ *
+ * `badge.admin.resendEmail` looked a badge up with `getBadgeById` — a by-PUBLIC-id
+ * read with no conference predicate — and then MAILED whichever speaker came
+ * back. It is the only procedure in the #863 census that ACTS rather than reads:
+ * an organizer of tenant A could put tenant B's badge id on the wire and cause
+ * delivery to B's speaker, from our infrastructure, without B doing anything.
+ * Its siblings `rebake` and `delete` were both guarded.
+ *
+ * WHAT THE MOCKS DO AND DO NOT DECIDE. `getBadgeForConference` is mocked with the
+ * PREDICATE IT ACTUALLY CARRIES (`conference._ref == $conferenceId`) rather than
+ * a canned answer, and `getBadgeById` with the global read it actually is — so
+ * swapping the router back to the unscoped lookup really does surface the
+ * foreign badge, and these tests fail on the ADDRESS THAT GETS MAILED, not on an
+ * error message that moved. The predicate itself is pinned separately, at the
+ * query, in `src/lib/badge/sanity.scoped.test.ts`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/auth', () => ({
+  getAuthSession: vi.fn().mockResolvedValue(null),
+}))
+vi.mock('@/lib/events/registry', () => ({}))
+vi.mock('next/cache', () => ({
+  revalidateTag: vi.fn(),
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
+}))
+
+const h = vi.hoisted(() => ({
+  getConference: vi.fn(),
+  getBadgeById: vi.fn(),
+  getBadgeForConference: vi.fn(),
+  sendBadgeEmailWithRetry: vi.fn(),
+  getSpeaker: vi.fn(),
+}))
+
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: h.getConference,
+}))
+vi.mock('@/lib/badge/sanity', () => ({
+  getBadgeById: h.getBadgeById,
+  getBadgeForConference: h.getBadgeForConference,
+  listBadgesForConference: vi.fn(),
+  listBadgesForSpeaker: vi.fn(),
+  deleteBadge: vi.fn(),
+}))
+vi.mock('@/lib/email/badge', () => ({
+  sendBadgeEmailWithRetry: h.sendBadgeEmailWithRetry,
+}))
+vi.mock('@/lib/speaker/sanity', () => ({ getSpeaker: h.getSpeaker }))
+vi.mock('@/lib/badge/issuance', () => ({ issueBadgeForSpeaker: vi.fn() }))
+vi.mock('@/lib/badge/rebake', () => ({ rebakeBadge: vi.fn() }))
+// The procedure refuses outright on localhost. That gate is real and has its own
+// reason to exist; these cases are about TENANCY, so put us on a deployed host —
+// otherwise every one of them would stop at FORBIDDEN and assert nothing.
+vi.mock('@/lib/environment/localhost', () => ({
+  isLocalhostEnvironment: () => false,
+}))
+
+import { initTRPC } from '@trpc/server'
+import type { Context } from '@/server/trpc'
+import { badgeRouter } from './badge'
+
+const t = initTRPC.context<Context>().create()
+const ORG_A = 'org-A'
+const CONF_A = 'conf-A'
+const CONF_B = 'conf-B'
+const FOREIGN_EMAIL = 'their-speaker@other.test'
+const OUR_EMAIL = 'our-speaker@example.test'
+
+function ctx(): Context {
+  const speaker = {
+    _id: 'sp-admin-A',
+    name: 'Admin A',
+    isOrganizer: true,
+    organizerOrgIds: [ORG_A],
+  }
+  const user = { email: 'a@example.com', name: 'Admin A', picture: '' }
+  return {
+    req: {
+      headers: new Headers(),
+      url: 'http://localhost:3000',
+    } as unknown as Context['req'],
+    session: {
+      expires: new Date(Date.now() + 86_400_000).toISOString(),
+      user,
+      speaker,
+    } as unknown as Context['session'],
+    speaker: speaker as unknown as Context['speaker'],
+    user,
+    workosUser: null,
+    ipAddress: '127.0.0.1',
+  } as unknown as Context
+}
+
+const badge = () => t.createCallerFactory(badgeRouter)(ctx())
+
+function badgeRecord(badgeId: string, conferenceId: string, email: string) {
+  return {
+    _id: `doc-${badgeId}`,
+    badgeId,
+    speaker: { _id: `sp-${badgeId}`, name: 'Speaker', email },
+    conference: {
+      _id: conferenceId,
+      title: 'Their Conference',
+      startDate: '2026-03-01',
+    },
+    badgeType: 'speaker',
+  }
+}
+
+/** The whole dataset, keyed by the public badge id the caller supplies. */
+const dataset: Record<string, ReturnType<typeof badgeRecord>> = {
+  'badge-ours': badgeRecord('badge-ours', CONF_A, OUR_EMAIL),
+  'badge-theirs': badgeRecord('badge-theirs', CONF_B, FOREIGN_EMAIL),
+}
+
+/** Every address `sendBadgeEmailWithRetry` was asked to deliver to. */
+const recipients = () =>
+  h.sendBadgeEmailWithRetry.mock.calls.map(
+    (call) => (call[0] as { speakerEmail: string }).speakerEmail,
+  )
+
+async function settle<T>(
+  promise: Promise<T>,
+): Promise<{ value?: T; error?: unknown }> {
+  try {
+    return { value: await promise }
+  } catch (error) {
+    return { error }
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.getConference.mockResolvedValue({
+    conference: {
+      _id: CONF_A,
+      title: 'Our Conference',
+      startDate: '2026-06-01',
+      organization: { _ref: ORG_A },
+    },
+    domain: 'ours.example',
+    error: null,
+  })
+
+  // The GLOBAL read, as written: any tenant's badge, by public id.
+  h.getBadgeById.mockImplementation(async (badgeId: string) =>
+    dataset[badgeId]
+      ? { badge: dataset[badgeId] }
+      : { error: new Error('Badge not found'), reason: 'not-found' },
+  )
+  // The SCOPED read, carrying the predicate the query carries.
+  h.getBadgeForConference.mockImplementation(
+    async (badgeId: string, conferenceId: string) => {
+      const found = dataset[badgeId]
+      if (!found || found.conference._id !== conferenceId) {
+        return { error: new Error('Badge not found'), reason: 'not-found' }
+      }
+      return { badge: found }
+    },
+  )
+  h.sendBadgeEmailWithRetry.mockResolvedValue({ success: true, emailId: 'e-1' })
+  h.getSpeaker.mockResolvedValue({ speaker: null, err: null })
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('badge.admin.resendEmail is conference-scoped (#863)', () => {
+  it('refuses another tenant’s badge and mails nobody', async () => {
+    const outcome = await settle(
+      badge().admin.resendEmail({ badgeId: 'badge-theirs' }),
+    )
+
+    // Unguarded this resolves `{ success: true }`, and `recipients()` holds the
+    // other tenant's speaker — so both lines fail on what actually happened,
+    // not on a differently-worded refusal.
+    expect(recipients()).toEqual([])
+    expect(outcome.value).toBeUndefined()
+    expect(outcome.error).toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'Badge not found',
+    })
+  })
+
+  it('asks for the badge WITHIN the request’s conference, never globally', async () => {
+    await settle(badge().admin.resendEmail({ badgeId: 'badge-theirs' }))
+
+    expect(h.getBadgeForConference).toHaveBeenCalledWith('badge-theirs', CONF_A)
+    expect(h.getBadgeById).not.toHaveBeenCalled()
+  })
+
+  it('answers a foreign badge exactly as it answers a nonexistent one', async () => {
+    // No existence oracle: the two refusals are the same code AND the same
+    // message, so a caller cannot enumerate other tenants' badge ids by
+    // comparing them. `volunteer.update`/`delete` (#863, LOW) still can.
+    const foreign = await settle(
+      badge().admin.resendEmail({ badgeId: 'badge-theirs' }),
+    )
+    const missing = await settle(
+      badge().admin.resendEmail({ badgeId: 'no-such-badge' }),
+    )
+
+    expect(foreign.error).toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'Badge not found',
+    })
+    expect(missing.error).toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'Badge not found',
+    })
+    expect(recipients()).toEqual([])
+  })
+
+  it('refuses BEFORE any lookup when the conference cannot be resolved', async () => {
+    // GUARD BEFORE FETCH (#863). The foreign document must not enter the
+    // request at all — not be fetched and then declined. With an unresolvable
+    // tenant there is nothing to scope to, so nothing is read.
+    h.getConference.mockResolvedValue({
+      conference: null,
+      domain: 'unknown.example',
+      error: new Error('domain lookup failed'),
+    })
+
+    const outcome = await settle(
+      badge().admin.resendEmail({ badgeId: 'badge-ours' }),
+    )
+
+    expect(outcome.value).toBeUndefined()
+    expect(h.getBadgeForConference).not.toHaveBeenCalled()
+    expect(h.getBadgeById).not.toHaveBeenCalled()
+    expect(recipients()).toEqual([])
+  })
+
+  it('still mails OUR OWN badge — the guard is not a blanket deny', async () => {
+    const outcome = await settle(
+      badge().admin.resendEmail({ badgeId: 'badge-ours' }),
+    )
+
+    expect(outcome.error).toBeUndefined()
+    expect(outcome.value).toMatchObject({ success: true })
+    expect(recipients()).toEqual([OUR_EMAIL])
+  })
+
+  it('brands the mail with the conference the badge belongs to', async () => {
+    // The `conferenceData` fallback takes the DOMAIN conference when the badge's
+    // own is not dereferenced. That is only coherent because the badge is now
+    // guaranteed to be this conference's — the same reasoning as #858's
+    // `currentConf` branch. Pin it so the fallback cannot silently start
+    // branding one tenant's badge with another's identity.
+    await badge().admin.resendEmail({ badgeId: 'badge-ours' })
+
+    expect(h.sendBadgeEmailWithRetry.mock.calls[0][0]).toMatchObject({
+      speakerEmail: OUR_EMAIL,
+      conferenceName: 'Their Conference',
+    })
+  })
+})

--- a/src/server/routers/badge.ts
+++ b/src/server/routers/badge.ts
@@ -29,6 +29,7 @@ import { isJWTFormat } from '@/lib/openbadges'
 import { getSpeaker } from '@/lib/speaker/sanity'
 import {
   getBadgeById,
+  getBadgeForConference,
   listBadgesForConference,
   listBadgesForSpeaker,
   deleteBadge,
@@ -356,7 +357,27 @@ export const badgeRouter = router({
         }
 
         try {
-          const { badge, error } = await getBadgeById(input.badgeId)
+          // OWNERSHIP (#863). This used the PUBLIC by-id lookup — no conference
+          // predicate — and then mailed whichever speaker came back, so an
+          // organizer of tenant A could trigger delivery to tenant B's speaker.
+          // Its siblings `rebake` and `delete` were guarded; this one was not.
+          //
+          // The conference is resolved FIRST and the lookup itself carries the
+          // predicate, so a foreign badge never enters this request: there is no
+          // moment at which we hold another tenant's speaker's email address and
+          // are relying on a later branch not to use it. It also removes the
+          // existence oracle — a foreign badge id and a nonexistent one are the
+          // same 'Badge not found'.
+          //
+          // It additionally makes the `conferenceData` fallback below SAFE BY
+          // CONSTRUCTION: the badge is now guaranteed to belong to the request's
+          // conference, so falling back to the domain conference cannot brand
+          // one tenant's badge email with another tenant's identity.
+          const conferenceId = await resolveConferenceId()
+          const { badge, error } = await getBadgeForConference(
+            input.badgeId,
+            conferenceId,
+          )
 
           if (error || !badge) {
             throw new TRPCError({

--- a/src/server/routers/travelSupport.tenancy.test.ts
+++ b/src/server/routers/travelSupport.tenancy.test.ts
@@ -1,0 +1,276 @@
+/**
+ * @vitest-environment node
+ *
+ * CROSS-TENANT READ ISOLATION for travel support (#863, HIGH).
+ *
+ * `travelSupport.admin.getById` was a plain `adminProcedure` with no tenancy
+ * guard while its SIX siblings in the same router all call
+ * `authorizeTravelSupportOperation`. `adminProcedure` proves only that the
+ * caller organizes SOME org, so an organizer of tenant A could hand us tenant
+ * B's document id and receive that speaker's name, email, IBAN, SWIFT code and
+ * full expense history — the most sensitive data in the system, and present on
+ * all six production records.
+ *
+ * The org-scoped decision itself already had tests
+ * (`src/lib/travel-support/auth.orgscope.test.ts`, B3/#642). What was missing was
+ * anything asserting that THIS PROCEDURE reaches it. These cases run the REAL
+ * guard and the REAL `isOrganizerForOrg` — only the data layer is mocked — so
+ * removing the guard from the router makes them fail on the CALL SUCCEEDING and
+ * on the returned banking VALUES, not on a changed error message.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/auth', () => ({
+  getAuthSession: vi.fn().mockResolvedValue(null),
+}))
+vi.mock('@/lib/events/registry', () => ({}))
+vi.mock('next/cache', () => ({
+  revalidateTag: vi.fn(),
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
+}))
+
+const h = vi.hoisted(() => ({
+  getConference: vi.fn(),
+  getTravelSupportById: vi.fn(),
+}))
+
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: h.getConference,
+}))
+
+// The whole data layer of the router is mocked; `@/lib/travel-support/auth` is
+// NOT — it is the subject. `auth.ts` reads through this same module, so the one
+// mock covers the guard's own lookup too, which is what lets the call-count
+// assertion below distinguish "the guard fetched it" from "the handler did".
+vi.mock('@/lib/travel-support/sanity', () => ({
+  getTravelSupport: vi.fn(),
+  getTravelSupportById: h.getTravelSupportById,
+  getAllTravelSupport: vi.fn(),
+  createTravelSupport: vi.fn(),
+  updateBankingDetails: vi.fn(),
+  submitTravelSupport: vi.fn(),
+  updateTravelSupportStatus: vi.fn(),
+  addTravelExpense: vi.fn(),
+  updateTravelExpense: vi.fn(),
+  updateExpenseStatus: vi.fn(),
+  deleteTravelExpense: vi.fn(),
+  deleteReceipt: vi.fn(),
+  getSpeakersRequiringTravelSupport: vi.fn(),
+  getTravelExpenseById: vi.fn(),
+  getTravelExpenseRef: vi.fn(),
+}))
+vi.mock('@/lib/speaker/sanity', () => ({ getSpeaker: vi.fn() }))
+vi.mock('@/lib/notification/sanity', () => ({
+  createNotifications: vi.fn(),
+  getOrganizerSpeakerIds: vi.fn().mockResolvedValue([]),
+}))
+vi.mock('@/lib/teams', () => ({
+  resolveRoutedOrganizerIds: vi.fn().mockResolvedValue([]),
+}))
+
+import { initTRPC } from '@trpc/server'
+import type { Context } from '@/server/trpc'
+import { travelSupportRouter } from './travelSupport'
+
+const t = initTRPC.context<Context>().create()
+const ORG_A = 'org-A'
+const CONF_A = 'conf-A'
+
+/** Fake, but shaped like the real thing — this is what an unguarded read shipped. */
+const FOREIGN_IBAN = 'NO9386011117947'
+const FOREIGN_SWIFT = 'DNBANOKKXXX'
+
+function ctx(): Context {
+  const speaker = {
+    _id: 'sp-admin-A',
+    name: 'Admin A',
+    isOrganizer: true,
+    organizerOrgIds: [ORG_A],
+  }
+  const user = { email: 'a@example.com', name: 'Admin A', picture: '' }
+  return {
+    req: {
+      headers: new Headers(),
+      url: 'http://localhost:3000',
+    } as unknown as Context['req'],
+    session: {
+      expires: new Date(Date.now() + 86_400_000).toISOString(),
+      user,
+      speaker,
+    } as unknown as Context['session'],
+    speaker: speaker as unknown as Context['speaker'],
+    user,
+    workosUser: null,
+    ipAddress: '127.0.0.1',
+  } as unknown as Context
+}
+
+const travelSupport = () => t.createCallerFactory(travelSupportRouter)(ctx())
+
+/**
+ * A complete travel-support record, banking details and all, owned by
+ * `conferenceOrgId`. Nothing about it EXCEPT its org can make the read refuse:
+ * it exists, it is submitted, it has a speaker and a conference. So a refusal
+ * here is the ownership guard's and nothing else's.
+ */
+function record(conferenceOrgId: string, conferenceId: string) {
+  return {
+    _id: 'ts-1',
+    status: 'submitted',
+    speaker: {
+      _id: 'sp-speaker',
+      name: 'Foreign Speaker',
+      email: 'speaker@other.test',
+    },
+    conference: { _id: conferenceId, name: 'Their Conference' },
+    conferenceOrgId,
+    bankingDetails: {
+      beneficiaryName: 'Foreign Speaker',
+      bankName: 'Their Bank',
+      iban: FOREIGN_IBAN,
+      accountNumber: '12345678903',
+      swiftCode: FOREIGN_SWIFT,
+      country: 'NO',
+      preferredCurrency: 'NOK',
+    },
+    expenses: [
+      {
+        _id: 'exp-1',
+        description: 'Flight',
+        amount: 4200,
+        currency: 'NOK',
+        status: 'pending',
+      },
+    ],
+  }
+}
+
+/** Resolve a call to either arm so the assertion can name what came back. */
+async function settle<T>(
+  promise: Promise<T>,
+): Promise<{ value?: T; error?: unknown }> {
+  try {
+    return { value: await promise }
+  } catch (error) {
+    return { error }
+  }
+}
+
+const getById = () => travelSupport().admin.getById({ id: 'ts-1' })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.getConference.mockResolvedValue({
+    conference: { _id: CONF_A, organization: { _ref: ORG_A } },
+    domain: 'localhost',
+    error: null,
+  })
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('travelSupport.admin.getById is org-scoped (#863)', () => {
+  const DENIED = 'Access denied to this travel support request'
+
+  it('refuses another tenant’s request and returns no banking details', async () => {
+    h.getTravelSupportById.mockResolvedValue({
+      travelSupport: record('org-B', 'conf-B'),
+      error: null,
+    })
+
+    const outcome = await settle(getById())
+
+    // Unguarded, `value` IS the foreign document — so this line fails on the
+    // call succeeding, and prints the IBAN it handed over.
+    expect(outcome.value).toBeUndefined()
+    expect(outcome.error).toMatchObject({ code: 'FORBIDDEN', message: DENIED })
+    expect(JSON.stringify(outcome.value ?? null)).not.toContain(FOREIGN_IBAN)
+    expect(JSON.stringify(outcome.value ?? null)).not.toContain(FOREIGN_SWIFT)
+  })
+
+  it('refuses when the request’s conference resolves to no org at all', async () => {
+    // FAIL CLOSED. An unresolvable domain must not read as "organizer of
+    // everything" — the authz waist denies before the handler runs.
+    h.getConference.mockResolvedValue({
+      conference: null,
+      domain: 'localhost',
+      error: new Error('domain lookup failed'),
+    })
+    h.getTravelSupportById.mockResolvedValue({
+      travelSupport: record(ORG_A, CONF_A),
+      error: null,
+    })
+
+    const outcome = await settle(getById())
+
+    expect(outcome.value).toBeUndefined()
+    expect(outcome.error).toMatchObject({ code: 'FORBIDDEN' })
+    expect(h.getTravelSupportById).not.toHaveBeenCalled()
+  })
+
+  it('refuses a document with NO resolvable owner', async () => {
+    // A pre-044-backfill conference carries no `organization._ref`. Ownership
+    // cannot be established, so it belongs to no tenant and no tenant may read
+    // its banking details.
+    h.getTravelSupportById.mockResolvedValue({
+      travelSupport: { ...record(ORG_A, CONF_A), conferenceOrgId: null },
+      error: null,
+    })
+
+    const outcome = await settle(getById())
+
+    expect(outcome.value).toBeUndefined()
+    expect(outcome.error).toMatchObject({ code: 'FORBIDDEN', message: DENIED })
+  })
+
+  it('still returns OUR OWN request in full — the guard is not a blanket deny', async () => {
+    h.getTravelSupportById.mockResolvedValue({
+      travelSupport: record(ORG_A, CONF_A),
+      error: null,
+    })
+
+    const outcome = await settle(getById())
+
+    expect(outcome.error).toBeUndefined()
+    // The payout pane renders these; the fix must not have quietly emptied them.
+    expect(outcome.value).toMatchObject({
+      _id: 'ts-1',
+      status: 'submitted',
+      bankingDetails: { iban: FOREIGN_IBAN, swiftCode: FOREIGN_SWIFT },
+      speaker: { email: 'speaker@other.test' },
+    })
+  })
+
+  it('admits ANOTHER EDITION of our own org — the boundary here is the ORG', async () => {
+    // Deliberate, and different from `volunteer.sendEmail` (#858), whose
+    // boundary is the conference. Travel support's six guarded siblings all
+    // decide on `conference->organization._ref`, so an organizer works across
+    // their own editions; pinning it here means narrowing it later is a visible
+    // decision rather than an accident.
+    h.getTravelSupportById.mockResolvedValue({
+      travelSupport: record(ORG_A, 'conf-A-2024'),
+      error: null,
+    })
+
+    const outcome = await settle(getById())
+
+    expect(outcome.error).toBeUndefined()
+    expect(outcome.value).toMatchObject({ _id: 'ts-1' })
+  })
+
+  it('reads the document exactly once — the guard’s fetch IS the handler’s', async () => {
+    // The guard cannot be moved after the fetch without this failing: an
+    // unguarded document must never be read twice, and must never be read by
+    // the handler ahead of the decision.
+    h.getTravelSupportById.mockResolvedValue({
+      travelSupport: record(ORG_A, CONF_A),
+      error: null,
+    })
+
+    await getById()
+
+    expect(h.getTravelSupportById).toHaveBeenCalledTimes(1)
+    expect(h.getTravelSupportById).toHaveBeenCalledWith('ts-1')
+  })
+})

--- a/src/server/routers/travelSupport.ts
+++ b/src/server/routers/travelSupport.ts
@@ -590,23 +590,35 @@ export const travelSupportRouter = router({
   admin: router({
     getById: adminProcedure
       .input(GetTravelSupportByIdSchema)
-      .query(async ({ input }) => {
+      .query(async ({ input, ctx }) => {
         try {
-          const { travelSupport, error } = await getTravelSupportById(input.id)
+          // OWNERSHIP (#863). This read went straight to `getTravelSupportById`
+          // — a GLOBAL by-id fetch — while its six siblings in this router all
+          // route through `authorizeTravelSupportOperation`. `adminProcedure`
+          // only proves the caller organizes SOME org, so any organizer could
+          // hand us another tenant's id and receive that speaker's name, email,
+          // IBAN, SWIFT and expense history. The guard org-scopes the grant to
+          // the REQUEST DOCUMENT'S own org (B3, #642), and it is what returns
+          // the record: there is no second read, and no path on which this
+          // procedure fetches a document it has not been authorized for.
+          const {
+            authorized,
+            travelSupport,
+            error: authError,
+          } = await authorizeTravelSupportOperation(
+            input.id,
+            ctx.speaker,
+            'read',
+          )
 
-          if (error) {
-            throw new TRPCError({
-              code: 'INTERNAL_SERVER_ERROR',
-              message: 'Failed to fetch travel support',
-              cause: error,
-            })
-          }
-
-          if (!travelSupport) {
-            throw new TRPCError({
-              code: 'NOT_FOUND',
-              message: 'Travel support request not found',
-            })
+          if (!authorized || authError || !travelSupport) {
+            throw (
+              authError ||
+              createAuthError(
+                'FORBIDDEN',
+                'Access denied to this travel support request',
+              )
+            )
           }
 
           return travelSupport


### PR DESCRIPTION
Fixes the two **HIGH** rows of #863. The MEDIUM/LOW rows are deliberately untouched — they are sequenced behind the structural work, and a live exposure needs a fix rather than a redesign.

## Row 1 — `travelSupport.admin.getById` disclosed banking details cross-tenant

`adminProcedure` proves only that the caller organizes *some* org. This procedure had no tenancy guard while its **six siblings in the same file** all call `authorizeTravelSupportOperation`, so an organizer of any tenant could supply another tenant's travel-support id and receive that speaker's name, email, IBAN, account number, SWIFT code and full expense history. All six production records carry banking details.

Fixed on both halves, because the guard alone would not have been enough:

**WHO may read.** The procedure now goes through `authorizeTravelSupportOperation(id, ctx.speaker, 'read')`, which org-scopes the grant to the request *document's* own org (B3, #642). The guard is also what **returns** the record — one read, not two, and no path on which this procedure fetches a document it has not been authorized for.

**WHAT is read.** `getTravelSupportById` opened with a bare `...` over a document carrying `bankingDetails`, so it shipped every field the schema has and every field it ever grows. It now projects explicitly against the new `TravelSupportDetail` type — the union of what the consumers actually read.

`bankingDetails` **stays in the projection**, and that is the honest result of checking the consumers rather than the assumed one: `RequestDetails` in `TravelSupportAdminPage.tsx` renders beneficiary, bank, IBAN/account, SWIFT and country under a "Banking Details" heading so an organizer can pay the speaker. Removing them would break the payout pane; the fix for *that* exposure is the ownership guard. What the projection does remove is the open-endedness, plus the fields nothing reads: `_rev`, `_createdAt`, `_updatedAt`, `_type`, `submittedAt`, `reviewedAt`, `reviewedBy`, `paidAt`.

**How I checked the projection loses nothing.** An explicit projection that drops a needed field fails *silently* — `undefined`, not an error — so I made the compiler the check rather than my reading. The return type was narrowed in lockstep with the query, so any consumer still reading a dropped field is a type error, not a blank field at runtime. `pnpm typecheck` is clean, and the one consumer whose prop type had to move (`RequestDetails`) is in the diff. The field list is additionally asserted against the query text in `sanity.projection.test.ts`, because TypeScript cannot tell a field the query forgot from one the document lacks.

## Row 2 — `badge.admin.resendEmail` mailed another tenant's speaker

`getBadgeById` filters on the **public** `badgeId` with no conference predicate, and the procedure mailed whichever speaker came back. The only one of the set that *acts* rather than reads. Its siblings `rebake` and `delete` were both guarded.

The conference is now resolved **first**, and the lookup itself carries the predicate (`getBadgeForConference`). A foreign badge therefore never enters the request — there is no moment where we hold another tenant's speaker's address and rely on a later branch not to use it — and a foreign badge id is indistinguishable from a nonexistent one, so there is no existence oracle. It also makes the `conferenceData` fallback safe by construction, the same argument #862 made for `currentConf`.

`getBadgeById` is untouched: `/api/badge/[badgeId]/verify` and friends must answer for any issuer's badge. The scoped read is a **separate function** rather than an optional argument, which would be the fail-open `optionalTenantFilter` shape `no-unscoped-groq` explicitly reports.

## Verification

Sabotage-proven, in the style of #862 — each one restored and re-run green, file **and** test counts checked every time so a broken import cannot read as a pass:

| Sabotage | Result |
|---|---|
| Remove the `authorizeTravelSupportOperation` call from `getById` | 1 file / 6 tests, **2 failed** — `AssertionError: expected { _id: 'ts-1', …(6) } to be undefined`. It fails because the foreign document *is returned*. |
| Point `resendEmail` back at `getBadgeById` | 1 file / 6 tests, **3 failed** — `expected [ 'their-speaker@other.test' ] to deeply equal []`. It fails because the mail *is sent*, to the address it was sent to. |
| Re-add `...` to the travel-support projection | 1 file / 5 tests, **3 failed** on the missing field names. |
| Drop `conference._ref == $conferenceId` from the scoped query | 2 files / 11 tests, **1 failed** — and note the *router* tests stayed green, which is exactly why the query-level test exists. |

Guard-before-fetch is asserted directly, not assumed: with an unresolvable tenant, `expect(getBadgeForConference).not.toHaveBeenCalled()` and `expect(getBadgeById).not.toHaveBeenCalled()`. The #863 comment's `volunteer.update`/`delete` ordering is not reproduced here.

The mocks are written to be *fair* to the sabotage: `getBadgeForConference` is mocked with the predicate it actually carries and `getBadgeById` with the global read it actually is, over one shared fixture dataset — so swapping the router back really does surface the foreign badge.

**Numbers**, against `origin/main`:

| | before | after |
|---|---|---|
| `pnpm test` | 515 files / 7544 tests | **519 files / 7566 tests**, all passing |
| `pnpm typecheck` | clean | clean |
| `npx prettier --check .` | clean | clean |
| `npx eslint .` | 0 errors, 201 warnings | 0 errors, 201 warnings |
| `tenancy/no-unscoped-groq` | 201 in 51 files | **201 in 51 files** |

## Residue — named, not hidden

- **The lint count did not move, and I did not make it move.** Both leaks are by-id reads that cannot carry a tenant predicate: `authorizeTravelSupportOperation` is *built on* `getTravelSupportById` and has to see a foreign document in order to refuse it. The new badge read *is* scoped and adds no warning, but `getBadgeById` legitimately remains for the public surface. `getTravelSupportById` could be annotated `// groq-global:` — the vocabulary fits, and `getDocumentTenant` carries exactly that marker — which would drop the count by 2. I left it out: a suppression is not a fix, and moving a soon-to-be-ratcheted number inside a security PR is the wrong place to spend that judgement.
- **The nested spreads in the same query are unchanged.** `"expenses": *[…]{ ..., receipts[]{ ... } }` still spreads, over `travelExpense`, which carries no banking or identity fields. Left alone to keep this diff reviewable.
- **`travelSupport.admin.updateStatus` still fetches before it guards** (`travelSupport.ts`, `getTravelSupportById` then `authorizeTravelSupportOperation`). A wasted read plus the same 1-bit existence oracle the #863 comment describes for `volunteer` — the guard already returns the document, so the fetch is removable. Not touched: it is the LOW row, and it is a different procedure.
- **The travel-support boundary is the ORG, not the conference** — deliberately, matching the six guarded siblings, and now pinned by a test so narrowing it later is a decision rather than an accident. It differs from `volunteer.sendEmail` (#858), whose boundary is the conference.
- The `read` grant also admits the request's **owner speaker**, cross-org — pre-existing `authorizeTravelSupportOperation` behaviour, unchanged, and correct for a person reading their own record.

Refs #863
