### PR TITLE
fix(legal): derive the subprocessor list from what each tenant actually uses

### DIFF
--- a/__tests__/app/legal-subprocessor-disclosure.test.tsx
+++ b/__tests__/app/legal-subprocessor-disclosure.test.tsx
@@ -1,0 +1,383 @@
+/**
+ * @vitest-environment node
+ *
+ * #690. The /privacy subprocessor list is a LEGAL REPRESENTATION by the tenant,
+ * not copy. It was hardcoded JSX served identically on every domain, so a tenant
+ * selling through Tito told its attendees Checkin.no processes their data, and a
+ * tenant with no workshop entitlement disclosed WorkOS as processing attendee
+ * email, name and user ID.
+ *
+ * Every case below runs the REAL page against a real resolver, varying only what
+ * the conference and organization documents say and which credentials the
+ * environment holds. Nothing about the disclosure module is stubbed.
+ *
+ * Each assertion is made in BOTH directions. A test that only proved "Tito
+ * appears" would also pass on a build that listed every vendor for everyone —
+ * which is precisely the bug — so each names the vendor that must NOT appear.
+ *
+ * The last group is the one that matters most: a FAILED read must not SHORTEN
+ * the list. Nearly every feature gate in this codebase fails closed on a
+ * rejected Sanity read, so a naive derivation would publish a shorter
+ * subprocessor list for the length of an outage. That is the #855/#848 class on
+ * the worst possible surface.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactElement } from 'react'
+
+const sanityFetch = vi.fn()
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: { fetch: (...a: unknown[]) => sanityFetch(...a) },
+  clientRead: { fetch: (...a: unknown[]) => sanityFetch(...a) },
+  clientReadUncached: { fetch: (...a: unknown[]) => sanityFetch(...a) },
+}))
+vi.mock('next/cache', () => ({ cacheLife: vi.fn(), cacheTag: vi.fn() }))
+vi.mock('next/headers', () => ({
+  headers: vi.fn(async () => new Headers({ host: 'live-tenant.example' })),
+}))
+vi.mock('@/lib/domain-verification/routing', () => ({
+  isHostRoutable: vi.fn(async () => true),
+}))
+vi.mock('@/lib/gallery/sanity', () => ({
+  getGalleryImages: vi.fn(async () => []),
+  getFeaturedGalleryImages: vi.fn(async () => []),
+}))
+vi.mock('@/lib/sponsor-crm/sanity', () => ({
+  getPublicSponsorsForConference: vi.fn(async () => []),
+}))
+
+import PrivacyPage from '@/app/(main)/privacy/page'
+import TermsPage from '@/app/(main)/terms/page'
+
+const PLATFORM_ORG = 'organization-platform'
+const OTHER_ORG = 'organization-customer'
+
+/** The names as they appear in the rendered markup. */
+const CHECKIN = 'Checkin.no'
+const TITO = 'Tito (ti.to)'
+const PIRSCH = 'Pirsch Analytics'
+const SLACK = 'Slack'
+const WORKOS = 'WorkOS (AuthKit)'
+const UNCERTAIN = 'May not apply to this event'
+
+/**
+ * The Cloud Native Days Norway shape, verified against the production dataset:
+ * `ticketingProvider` is NULL with a full Checkin binding, an analytics code is
+ * set, Slack channels are configured, and its organization IS the platform org.
+ */
+function conference(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: 'conf-1',
+    title: 'Cloud Native Days Norway 2026',
+    organizer: 'Cloud Native Bergen',
+    city: 'Bergen',
+    country: 'Norway',
+    contactEmail: 'contact@cloudnativedays.no',
+    domains: ['live-tenant.example'],
+    organization: { _ref: PLATFORM_ORG, _type: 'reference' },
+    ticketingProvider: null,
+    checkinCustomerId: 15509,
+    checkinEventId: 218308,
+    analyticsPirschCode: 'Jc72d7tD73Ai9raeYVPeXJ0OhEJrrvaK',
+    ...overrides,
+  }
+}
+
+function organization(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: PLATFORM_ORG,
+    name: 'Cloud Native Days Norway',
+    contactEmail: 'contact@cloudnativedays.no',
+    legalJurisdiction: 'Norway',
+    plan: 'pro',
+    ...overrides,
+  }
+}
+
+interface World {
+  conference?: Record<string, unknown> | null
+  organization?: Record<string, unknown> | null
+  /** Reject the CONFERENCE read (a total outage). */
+  conferenceReadFails?: boolean
+  /** Reject every ORGANIZATION read, leaving the conference read healthy. */
+  organizationReadFails?: boolean
+}
+
+/**
+ * Route each Sanity read by its query so the conference read and the two
+ * organization reads can fail independently — which is the whole point: the
+ * dangerous case is a HEALTHY conference read next to a failing org read, where
+ * the page happily renders and quietly drops the org-gated processors.
+ */
+function world({
+  conference: conf = conference(),
+  organization: org = organization(),
+  conferenceReadFails = false,
+  organizationReadFails = false,
+}: World = {}) {
+  sanityFetch.mockImplementation(async (query: string) => {
+    if (query.includes('_type == "conference"')) {
+      if (conferenceReadFails) throw new Error('ECONNREFUSED sanity.io')
+      return conf
+    }
+    // Both the legal-identity read (`*[_id == $id][0]{name,…}`) and
+    // `getOrganizationById` (`*[_type == "organization" && _id == $orgId][0]`).
+    if (organizationReadFails) throw new Error('ECONNREFUSED sanity.io')
+    return org
+  })
+}
+
+/** The pages return a nested async component; flush it to markup. */
+async function render(page: () => Promise<ReactElement>): Promise<string> {
+  const outer = (await page()) as ReactElement<{ domain: string }>
+  const inner = await (
+    outer.type as (p: { domain: string }) => Promise<ReactElement>
+  )(outer.props)
+  return renderToStaticMarkup(inner)
+}
+
+const renderPrivacy = () => render(PrivacyPage)
+const renderTerms = () => render(TermsPage)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubEnv('PLATFORM_ORG_ID', PLATFORM_ORG)
+  vi.stubEnv('SLACK_BOT_TOKEN', 'xoxb-platform-token')
+  vi.stubEnv('TENANT_SECRETS_JSON', '')
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+})
+
+describe('the ticketing vendor disclosed is the one the tenant uses', () => {
+  it('a Tito tenant does NOT disclose Checkin', async () => {
+    world({
+      conference: conference({
+        organization: { _ref: OTHER_ORG, _type: 'reference' },
+        ticketingProvider: 'tito',
+        checkinCustomerId: undefined,
+        checkinEventId: undefined,
+        titoAccountSlug: 'acme',
+        titoEventSlug: 'conf-2026',
+      }),
+      organization: organization({ _id: OTHER_ORG, name: 'Acme Events' }),
+    })
+
+    const html = await renderPrivacy()
+
+    expect(html).toContain(TITO)
+    expect(html).not.toContain(CHECKIN)
+  })
+
+  it('a Checkin tenant does NOT disclose Tito — the other direction', async () => {
+    world()
+
+    const html = await renderPrivacy()
+
+    expect(html).toContain(CHECKIN)
+    expect(html).not.toContain(TITO)
+  })
+
+  it('a tenant with no ticketing binding discloses NEITHER vendor', async () => {
+    world({
+      conference: conference({
+        checkinCustomerId: undefined,
+        checkinEventId: undefined,
+      }),
+    })
+
+    const html = await renderPrivacy()
+
+    expect(html).not.toContain(CHECKIN)
+    expect(html).not.toContain(TITO)
+    // …but the shared platform infrastructure is still there, so this is a
+    // shortened list by RESOLUTION, not by a broken render.
+    expect(html).toContain('Sanity.io')
+  })
+})
+
+describe('analytics is disclosed only when the tenant configured it', () => {
+  it('discloses Pirsch when a code is set', async () => {
+    world()
+    expect(await renderPrivacy()).toContain(PIRSCH)
+  })
+
+  it('omits Pirsch when there is no code — no script, no processor', async () => {
+    world({ conference: conference({ analyticsPirschCode: undefined }) })
+    expect(await renderPrivacy()).not.toContain(PIRSCH)
+  })
+})
+
+describe('Slack and WorkOS follow the tenant, not the platform', () => {
+  it('Cloud Native Days Norway keeps Checkin, Slack and Pirsch', async () => {
+    // The hard constraint on this change: the platform org is also a tenant and
+    // genuinely uses all three. Verified against the production documents.
+    world()
+
+    const html = await renderPrivacy()
+
+    expect(html).toContain(CHECKIN)
+    expect(html).toContain(SLACK)
+    expect(html).toContain(PIRSCH)
+    expect(html).toContain(WORKOS)
+    expect(html).not.toContain(UNCERTAIN)
+  })
+
+  it('a customer tenant on the shared deployment discloses neither', async () => {
+    world({
+      conference: conference({
+        organization: { _ref: OTHER_ORG, _type: 'reference' },
+      }),
+      organization: organization({
+        _id: OTHER_ORG,
+        name: 'Acme Events',
+        plan: 'community',
+      }),
+    })
+
+    const html = await renderPrivacy()
+
+    expect(html).not.toContain(SLACK)
+    expect(html).not.toContain(WORKOS)
+    // Its own vendors are unaffected.
+    expect(html).toContain(CHECKIN)
+  })
+})
+
+describe('the email account the organizer sends through', () => {
+  it('names the shared platform account by default', async () => {
+    world()
+    expect(await renderPrivacy()).toContain('shared platform sending account')
+  })
+
+  it('names the organizer’s OWN Resend account when it has one', async () => {
+    vi.stubEnv(
+      'TENANT_SECRETS_JSON',
+      JSON.stringify({ [OTHER_ORG]: { email: { apiKey: 're_tenant_key' } } }),
+    )
+    world({
+      conference: conference({
+        organization: { _ref: OTHER_ORG, _type: 'reference' },
+      }),
+      organization: organization({ _id: OTHER_ORG, name: 'Acme Events' }),
+    })
+
+    const html = await renderPrivacy()
+
+    expect(html).toContain('own Resend account')
+    expect(html).not.toContain('shared platform sending account')
+  })
+})
+
+describe('a failed read must NOT shorten the disclosure', () => {
+  it('keeps Slack and WorkOS, marked uncertain, when the organization read fails', async () => {
+    // A customer tenant: with a HEALTHY org read these two are correctly
+    // absent (asserted above). The gates answer `false` on a rejected read too,
+    // so a naive derivation would drop them silently. They must stay.
+    world({
+      conference: conference({
+        organization: { _ref: OTHER_ORG, _type: 'reference' },
+      }),
+      organizationReadFails: true,
+    })
+
+    const html = await renderPrivacy()
+
+    expect(html).toContain(SLACK)
+    expect(html).toContain(WORKOS)
+    expect(html).toContain(UNCERTAIN)
+    expect(html).toContain('could not be read just now')
+  })
+
+  it('renders NO uncertainty notice when every signal resolved', async () => {
+    // Without this the test above would pass on a build that marked everything
+    // uncertain unconditionally, which proves nothing.
+    world()
+
+    const html = await renderPrivacy()
+
+    expect(html).not.toContain(UNCERTAIN)
+    expect(html).not.toContain('could not be read just now')
+  })
+
+  it('never names the PLATFORM as data controller on a failed identity read', async () => {
+    // #848: `buildLegalConfig` used to fall back to `PLATFORM_NAME`, so an
+    // outage published the platform as the controller of a customer's event.
+    world({
+      conference: conference({
+        organizer: '',
+        organization: { _ref: OTHER_ORG, _type: 'reference' },
+      }),
+      organizationReadFails: true,
+    })
+
+    const html = await renderPrivacy()
+
+    expect(html).not.toContain('Konf')
+    expect(html).toContain('Could not be confirmed right now')
+  })
+
+  it('serves an error — not a shortened list — when the CONFERENCE read fails', async () => {
+    // With no conference document there is no controller to name and no
+    // configuration to read, so there is nothing to over-disclose FROM. The
+    // page must refuse rather than publish a list about a tenant it cannot see.
+    world({ conferenceReadFails: true })
+
+    const html = await renderPrivacy()
+
+    expect(html).toContain('Privacy Policy Temporarily Unavailable')
+    expect(html).not.toContain('Essential Service Providers')
+    expect(html).not.toContain(CHECKIN)
+  })
+
+  it('still serves the real policy when the read succeeds — the other direction', async () => {
+    world()
+
+    const html = await renderPrivacy()
+
+    expect(html).not.toContain('Privacy Policy Temporarily Unavailable')
+    expect(html).toContain('Essential Service Providers')
+  })
+})
+
+describe('/terms names only the sign-in routes this tenant has', () => {
+  it('mentions WorkOS AuthKit for a tenant with workshops', async () => {
+    world()
+    expect(await renderTerms()).toContain('WorkOS AuthKit')
+  })
+
+  it('does NOT mention WorkOS AuthKit for a tenant without workshops', async () => {
+    world({
+      conference: conference({
+        organization: { _ref: OTHER_ORG, _type: 'reference' },
+      }),
+      organization: organization({ _id: OTHER_ORG, name: 'Acme Events' }),
+    })
+
+    const html = await renderTerms()
+
+    expect(html).not.toContain('WorkOS AuthKit')
+    // The CFP sign-in routes it DOES have are still described.
+    expect(html).toContain('GitHub or LinkedIn')
+  })
+
+  it('does not name the platform as the counterparty on a failed identity read', async () => {
+    world({
+      conference: conference({
+        organizer: '',
+        organization: { _ref: OTHER_ORG, _type: 'reference' },
+      }),
+      organizationReadFails: true,
+    })
+
+    const html = await renderTerms()
+
+    expect(html).not.toContain('Konf')
+    expect(html).toContain('could not be confirmed right now')
+  })
+})

--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -2,8 +2,14 @@ import { BackgroundImage } from '@/components/BackgroundImage'
 import { Container } from '@/components/Container'
 import { ContentCard } from '@/components/ContentCard'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
-import { isUnknownHost } from '@/lib/conference/guard'
-import { resolveLegalConfig } from '@/lib/legal'
+import { isConferenceUnavailable, isUnknownHost } from '@/lib/conference/guard'
+import {
+  discloses,
+  internationalTransferProcessors,
+  resolveLegalConfig,
+  resolveSubprocessorDisclosure,
+} from '@/lib/legal'
+import { SubprocessorList } from '@/components/legal'
 import { resolveMetadataBrand } from '@/lib/seo/brand'
 import { ErrorDisplay } from '@/components/admin'
 import {
@@ -59,8 +65,11 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
   cacheLife('hours')
   cacheTag('content:privacy')
 
-  const { conference, error: conferenceError } =
-    await getConferenceForDomain(domain)
+  const {
+    conference,
+    error: conferenceError,
+    status,
+  } = await getConferenceForDomain(domain)
 
   if (conference?._id) {
     cacheTag(conferenceTag(conference._id))
@@ -77,7 +86,22 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
     cacheTag(organizationTag(orgRef))
   }
 
-  if (isUnknownHost({ conference, error: conferenceError })) {
+  // A FAILED conference read is checked FIRST and gets its own state (#848/#855).
+  // With no conference document there is no controller to name and no
+  // integration configuration to read, so every claim on this page — who the
+  // controller is, which processors are in the chain — would be invented. This
+  // is the one case where the honest answer is an error rather than a
+  // conservative over-disclosure: there is nothing left to over-disclose FROM.
+  if (isConferenceUnavailable({ conference, error: conferenceError, status })) {
+    return (
+      <ErrorDisplay
+        title="Privacy Policy Temporarily Unavailable"
+        message="We could not load this event's configuration, and this page must not state who processes your data unless it can confirm it. Please try again shortly."
+      />
+    )
+  }
+
+  if (isUnknownHost({ conference, error: conferenceError, status })) {
     return (
       <ErrorDisplay
         title="Error Loading Conference"
@@ -89,23 +113,23 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
     )
   }
 
-  const lastUpdated = 'July 27, 2026'
+  const lastUpdated = 'August 6, 2026'
   const legal = await resolveLegalConfig(conference)
   const contactEmail = legal.contactEmail
-  const organizationName = legal.controllerName
+  // EMPTY when no legal entity could be resolved. `legal.controllerResolved`
+  // gates every place this is printed; the neutral phrase below is used in
+  // running prose so a sentence still reads, without naming anyone.
+  const organizationName = legal.controllerResolved
+    ? legal.controllerName
+    : 'The organizer of this event'
 
-  // Per-tenant subprocessor disclosure (#690, partial). The full list is still
-  // hardcoded JSX; these are the two entries whose accuracy depends on this
-  // tenant's own configuration, so they are resolved rather than asserted.
-  // Absent `ticketingProvider` resolves to Checkin — the same default
-  // `resolveTicketProvider` applies — so an untouched conference is unchanged.
-  const ticketingSubprocessor =
-    conference?.ticketingProvider === 'tito'
-      ? 'Tito (ti.to)'
-      : conference?.ticketingProvider === undefined ||
-          conference?.ticketingProvider === 'checkin'
-        ? 'Checkin.no'
-        : null
+  // The tenant's REAL subprocessor chain (#690), derived from its ticketing
+  // binding, analytics code, Slack token and workshop entitlement. An
+  // unresolvable signal DISCLOSES rather than omits — see
+  // `@/lib/legal/subprocessors` for the two rules.
+  const subprocessors = await resolveSubprocessorDisclosure(conference)
+  const usesWorkOS = discloses(subprocessors, 'workos')
+  const overseasProcessors = internationalTransferProcessors(subprocessors)
 
   return (
     <>
@@ -165,13 +189,28 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
 
                     <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-800/50 print:border print:border-gray-300 print:bg-white print:p-3">
                       <div className="space-y-2 text-sm print:space-y-1 print:text-base">
+                        {/*
+                          NEVER a substitute name (#848). The controller used to
+                          fall back to `PLATFORM_NAME`, so a failed organization
+                          read published the PLATFORM as the data controller of a
+                          customer's event — misdirecting every Article 15-21
+                          request. An unresolved controller now says so.
+                        */}
                         <div>
                           <span className="font-medium text-gray-900 dark:text-white print:text-black">
                             Data Controller:
                           </span>{' '}
-                          <span className="text-gray-700 dark:text-gray-300 print:text-black">
-                            {organizationName}
-                          </span>
+                          {legal.controllerResolved ? (
+                            <span className="text-gray-700 dark:text-gray-300 print:text-black">
+                              {legal.controllerName}
+                            </span>
+                          ) : (
+                            <span className="font-medium text-amber-700 dark:text-amber-400 print:text-black">
+                              {legal.identityReadFailed
+                                ? 'Could not be confirmed right now — please use the contact address below.'
+                                : 'Not configured. The event organizer has not registered a legal entity for this notice.'}
+                            </span>
+                          )}
                         </div>
                         <div>
                           <span className="font-medium text-gray-900 dark:text-white print:text-black">
@@ -319,10 +358,18 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                               • Operating system preference (Windows, macOS,
                               Linux)
                             </li>
-                            <li>
-                              • WorkOS User ID (unique authentication
-                              identifier)
-                            </li>
+                            {/*
+                              Named only when WorkOS is actually in this
+                              tenant's chain (#690) — the identifier does not
+                              exist for an event whose organizer has no workshop
+                              entitlement.
+                            */}
+                            {usesWorkOS ? (
+                              <li>
+                                • WorkOS User ID (unique authentication
+                                identifier)
+                              </li>
+                            ) : null}
                           </ul>
                         </div>
                         <div>
@@ -927,170 +974,21 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
 
                   <div className="space-y-6">
                     {/*
-                      KNOWN GAP (#690): apart from the ticketing and analytics
-                      rows below, this list is hardcoded JSX rather than resolved
-                      from what this tenant actually uses — so a tenant that does
-                      not run workshops still sees WorkOS disclosed. Rendering a
-                      visible caveat is the honest interim: a subprocessor list
-                      that silently over-discloses is a legal inaccuracy the
-                      organizer puts their name to.
-                    */}
-                    <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 dark:border-amber-700 dark:bg-amber-900/20">
-                      <p className="text-sm text-amber-900 dark:text-amber-200">
-                        This list describes the services the platform can use.
-                        Some entries may not apply to this event — organizers
-                        should review it against the integrations they have
-                        actually enabled before publishing.
-                      </p>
-                    </div>
-                    <div>
-                      <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
-                        Essential Service Providers
-                      </h3>
-                      <div className="space-y-3">
-                        <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-800/50">
-                          <div className="flex items-start space-x-3">
-                            <LockClosedIcon className="mt-1 h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" />
-                            <div>
-                              <p className="font-medium text-gray-900 dark:text-white">
-                                Sanity.io
-                              </p>
-                              <p className="text-sm text-gray-600 dark:text-gray-400">
-                                Content management and database services
-                                (EU-based, GDPR compliant)
-                              </p>
-                            </div>
-                          </div>
-                        </div>
-                        <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-800/50">
-                          <div className="flex items-start space-x-3">
-                            <GlobeAltIcon className="mt-1 h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" />
-                            <div>
-                              <p className="font-medium text-gray-900 dark:text-white">
-                                Vercel.com
-                              </p>
-                              <p className="text-sm text-gray-600 dark:text-gray-400">
-                                Website hosting, infrastructure, content
-                                delivery network, and privacy-friendly analytics
-                                (Vercel Analytics & Speed Insights; cookie-less)
-                              </p>
-                            </div>
-                          </div>
-                        </div>
-                        <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-800/50">
-                          <div className="flex items-start space-x-3">
-                            <EnvelopeIcon className="mt-1 h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" />
-                            <div>
-                              <p className="font-medium text-gray-900 dark:text-white">
-                                Resend.com
-                              </p>
-                              <p className="text-sm text-gray-600 dark:text-gray-400">
-                                Email delivery service for conference
-                                communications
-                              </p>
-                            </div>
-                          </div>
-                        </div>
-                        {/*
-                          The ticketing vendor is a per-tenant choice, so it is
-                          disclosed per tenant. Absent resolves to Checkin (the
-                          resolver's own default), which is why that branch
-                          covers the untouched-configuration case.
-                        */}
-                        {ticketingSubprocessor ? (
-                          <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-800/50">
-                            <div className="flex items-start space-x-3">
-                              <DocumentTextIcon className="mt-1 h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" />
-                              <div>
-                                <p className="font-medium text-gray-900 dark:text-white">
-                                  {ticketingSubprocessor}
-                                </p>
-                                <p className="text-sm text-gray-600 dark:text-gray-400">
-                                  Ticket management and event check-in services
-                                </p>
-                              </div>
-                            </div>
-                          </div>
-                        ) : null}
-                        {/*
-                          Analytics is disclosed ONLY when this tenant has
-                          actually configured an analytics code. With none set
-                          no script is served, so naming a processor here would
-                          be a false disclosure.
-                        */}
-                        {conference?.analyticsPirschCode ? (
-                          <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-800/50">
-                            <div className="flex items-start space-x-3">
-                              <ChartBarIcon className="mt-1 h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" />
-                              <div>
-                                <p className="font-medium text-gray-900 dark:text-white">
-                                  Pirsch Analytics
-                                </p>
-                                <p className="text-sm text-gray-600 dark:text-gray-400">
-                                  Privacy-focused, cookie-less website analytics
-                                  (aggregated, no advertising profiles)
-                                </p>
-                              </div>
-                            </div>
-                          </div>
-                        ) : null}
-                        <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-800/50">
-                          <div className="flex items-start space-x-3">
-                            <ChatBubbleLeftRightIcon className="mt-1 h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" />
-                            <div>
-                              <p className="font-medium text-gray-900 dark:text-white">
-                                Slack
-                              </p>
-                              <p className="text-sm text-gray-600 dark:text-gray-400">
-                                Internal organizer notifications for operations
-                                (e.g., speaker proposal updates)
-                              </p>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
+                      THE subprocessor list, resolved from what THIS tenant
+                      actually uses (#690). It was hardcoded JSX served
+                      identically on every domain: a tenant on Tito was telling
+                      its attendees Checkin.no processes their data, and a tenant
+                      that runs no workshops was disclosing WorkOS as processing
+                      attendee email, name and user ID.
 
-                    <div>
-                      <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
-                        Authentication Services
-                      </h3>
-                      <div className="space-y-3">
-                        <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-800/50">
-                          <div className="flex items-start space-x-3">
-                            <LockClosedIcon className="mt-1 h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" />
-                            <div>
-                              <p className="font-medium text-gray-900 dark:text-white">
-                                GitHub/LinkedIn
-                              </p>
-                              <p className="text-sm text-gray-600 dark:text-gray-400">
-                                Authentication services for Call for Papers
-                                (when you choose to sign in)
-                              </p>
-                            </div>
-                          </div>
-                        </div>
-                        <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-800/50">
-                          <div className="flex items-start space-x-3">
-                            <LockClosedIcon className="mt-1 h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" />
-                            <div>
-                              <p className="font-medium text-gray-900 dark:text-white">
-                                WorkOS (AuthKit)
-                              </p>
-                              <p className="text-sm text-gray-600 dark:text-gray-400">
-                                User authentication and identity management for
-                                workshop signups (email, name, user ID,
-                                authentication sessions)
-                              </p>
-                              <p className="mt-1 text-xs text-gray-500 dark:text-gray-500">
-                                Location: United States • Protected by Standard
-                                Contractual Clauses
-                              </p>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
+                      An unresolvable signal DISCLOSES the processor, marked as
+                      possibly-not-applicable, rather than dropping it —
+                      under-disclosure is the failure with legal consequence,
+                      over-disclosure is a copy problem. See
+                      `@/lib/legal/subprocessors` for both rules and for the
+                      failure behaviour that was chosen and why.
+                    */}
+                    <SubprocessorList disclosure={subprocessors} />
 
                     <div>
                       <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
@@ -1207,40 +1105,55 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                       </div>
                     </div>
 
-                    <p className="text-sm text-gray-700 dark:text-gray-300">
-                      Some providers (e.g., Vercel, Slack, Resend, WorkOS) may
-                      process data in the United States. We rely on Standard
-                      Contractual Clauses and other safeguards required by GDPR
-                      for such transfers.
-                    </p>
-
-                    <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/20">
-                      <h4 className="mb-2 font-semibold text-amber-800 dark:text-amber-200">
-                        WorkOS Authentication
-                      </h4>
-                      <p className="text-sm text-amber-700 dark:text-amber-300">
-                        WorkOS processes workshop authentication data in the
-                        United States. We rely on:
+                    {/*
+                      Named from the SAME resolved disclosure as section 5, not
+                      from a second hardcoded list (#690). The old sentence named
+                      "Vercel, Slack, Resend, WorkOS" on every tenant — the exact
+                      defect one section up, repeated. Deriving it here means a
+                      processor cannot be listed as a transfer destination
+                      without also appearing as a subprocessor, and vice versa.
+                    */}
+                    {overseasProcessors.length > 0 ? (
+                      <p className="text-sm text-gray-700 dark:text-gray-300">
+                        The following providers may process data outside the
+                        EU/EEA:{' '}
+                        {overseasProcessors
+                          .map((p) => `${p.name} (${p.location})`)
+                          .join(', ')}
+                        . We rely on Standard Contractual Clauses and other
+                        safeguards required by GDPR for such transfers.
                       </p>
-                      <ul className="mt-2 list-inside list-disc space-y-1 text-sm text-amber-700 dark:text-amber-300">
-                        <li>
-                          Standard Contractual Clauses (SCCs) approved by the
-                          European Commission
-                        </li>
-                        <li>
-                          WorkOS&apos;s compliance with applicable data
-                          protection frameworks
-                        </li>
-                        <li>
-                          Additional safeguards including encryption at rest and
-                          in transit
-                        </li>
-                        <li>
-                          Transfer Impact Assessment documenting residual risks
-                          and mitigations
-                        </li>
-                      </ul>
-                    </div>
+                    ) : null}
+
+                    {usesWorkOS ? (
+                      <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/20">
+                        <h4 className="mb-2 font-semibold text-amber-800 dark:text-amber-200">
+                          WorkOS Authentication
+                        </h4>
+                        <p className="text-sm text-amber-700 dark:text-amber-300">
+                          WorkOS processes workshop authentication data in the
+                          United States. We rely on:
+                        </p>
+                        <ul className="mt-2 list-inside list-disc space-y-1 text-sm text-amber-700 dark:text-amber-300">
+                          <li>
+                            Standard Contractual Clauses (SCCs) approved by the
+                            European Commission
+                          </li>
+                          <li>
+                            WorkOS&apos;s compliance with applicable data
+                            protection frameworks
+                          </li>
+                          <li>
+                            Additional safeguards including encryption at rest
+                            and in transit
+                          </li>
+                          <li>
+                            Transfer Impact Assessment documenting residual
+                            risks and mitigations
+                          </li>
+                        </ul>
+                      </div>
+                    ) : null}
                   </div>
                 </section>
 
@@ -1489,31 +1402,40 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                               data (dietary restrictions)
                             </td>
                           </tr>
-                          <tr className="bg-purple-50 dark:bg-purple-900/20">
-                            <td className="px-6 py-4 text-sm font-medium text-gray-900 dark:text-gray-100">
-                              WorkOS Authentication Data
-                              <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                                (User ID, email, name, authentication sessions)
-                              </div>
-                            </td>
-                            <td className="px-6 py-4 text-sm text-gray-700 dark:text-gray-300">
-                              Duration of active workshop registration + 2 years
-                            </td>
-                            <td className="px-6 py-4 text-sm text-gray-700 dark:text-gray-300">
-                              <span className="font-medium text-blue-600 dark:text-blue-400">
-                                Legitimate Interest:
-                              </span>{' '}
-                              User account management, audit trail for capacity
-                              management, and preventing duplicate
-                              registrations.
-                              <span className="font-medium text-orange-600 dark:text-orange-400">
-                                {' '}
-                                Contract Performance:
-                              </span>{' '}
-                              Authentication required to access registered
-                              workshops
-                            </td>
-                          </tr>
+                          {/*
+                            A retention promise about data that is never
+                            collected is as inaccurate as an omitted one — gated
+                            on the same disclosure as section 5 (#690).
+                          */}
+                          {usesWorkOS ? (
+                            <tr className="bg-purple-50 dark:bg-purple-900/20">
+                              <td className="px-6 py-4 text-sm font-medium text-gray-900 dark:text-gray-100">
+                                WorkOS Authentication Data
+                                <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                  (User ID, email, name, authentication
+                                  sessions)
+                                </div>
+                              </td>
+                              <td className="px-6 py-4 text-sm text-gray-700 dark:text-gray-300">
+                                Duration of active workshop registration + 2
+                                years
+                              </td>
+                              <td className="px-6 py-4 text-sm text-gray-700 dark:text-gray-300">
+                                <span className="font-medium text-blue-600 dark:text-blue-400">
+                                  Legitimate Interest:
+                                </span>{' '}
+                                User account management, audit trail for
+                                capacity management, and preventing duplicate
+                                registrations.
+                                <span className="font-medium text-orange-600 dark:text-orange-400">
+                                  {' '}
+                                  Contract Performance:
+                                </span>{' '}
+                                Authentication required to access registered
+                                workshops
+                              </td>
+                            </tr>
+                          ) : null}
                         </tbody>
                       </table>
                     </div>

--- a/src/app/(main)/terms/page.tsx
+++ b/src/app/(main)/terms/page.tsx
@@ -2,7 +2,11 @@ import { BackgroundImage } from '@/components/BackgroundImage'
 import { Container } from '@/components/Container'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
 import { isUnknownHost } from '@/lib/conference/guard'
-import { resolveLegalConfig } from '@/lib/legal'
+import {
+  discloses,
+  resolveLegalConfig,
+  resolveSubprocessorDisclosure,
+} from '@/lib/legal'
 import { resolveMetadataBrand } from '@/lib/seo/brand'
 import { ErrorDisplay } from '@/components/admin'
 import {
@@ -39,8 +43,11 @@ async function CachedTermsContent({ domain }: { domain: string }) {
   cacheLife('hours')
   cacheTag('content:terms')
 
-  const { conference, error: conferenceError } =
-    await getConferenceForDomain(domain)
+  const {
+    conference,
+    error: conferenceError,
+    status,
+  } = await getConferenceForDomain(domain)
 
   if (conference?._id) {
     cacheTag(conferenceTag(conference._id))
@@ -59,7 +66,7 @@ async function CachedTermsContent({ domain }: { domain: string }) {
 
   // Unknown host: the (main) layout renders the platform landing in place of
   // this subtree, so bail before dereferencing an empty conference.
-  if (isUnknownHost({ conference, error: conferenceError })) {
+  if (isUnknownHost({ conference, error: conferenceError, status })) {
     return null
   }
 
@@ -72,10 +79,24 @@ async function CachedTermsContent({ domain }: { domain: string }) {
     )
   }
 
-  const lastUpdated = 'October 31, 2025'
+  const lastUpdated = 'August 6, 2026'
   const legal = await resolveLegalConfig(conference)
   const contactEmail = legal.contactEmail
-  const organizationName = legal.controllerName
+  // EMPTY when no legal entity could be resolved — these terms name a
+  // counterparty in operative clauses (licence grant, liability, indemnity), so
+  // the one thing that must never happen is naming the WRONG entity. The
+  // platform-name fallback that used to do exactly that is gone (#848); an
+  // unresolved controller degrades to a neutral phrase plus the banner below.
+  const organizationName = legal.controllerResolved
+    ? legal.controllerName
+    : 'the event organizer'
+
+  // Which authentication providers these terms may name (#690). WorkOS AuthKit
+  // is the workshop sign-in, and a tenant with no workshop entitlement never
+  // sees it — describing an account-creation route that does not exist is the
+  // same inaccuracy as the privacy page's processor list.
+  const subprocessors = await resolveSubprocessorDisclosure(conference)
+  const usesWorkOS = discloses(subprocessors, 'workos')
 
   return (
     <>
@@ -99,6 +120,21 @@ async function CachedTermsContent({ domain }: { domain: string }) {
               <p className="text-xl tracking-tight print:text-base print:font-semibold">
                 <strong>Last updated:</strong> {lastUpdated}
               </p>
+              {/*
+                These clauses bind a counterparty by name. When no legal entity
+                resolves, saying so out loud is the only honest option — the
+                alternative used to be printing the PLATFORM's name into a
+                licence grant and a limitation of liability (#848).
+              */}
+              {!legal.controllerResolved ? (
+                <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-base dark:border-amber-700 dark:bg-amber-900/20 print:border-black">
+                  <p className="text-amber-900 dark:text-amber-200">
+                    {legal.identityReadFailed
+                      ? 'The organizing entity behind these terms could not be confirmed right now. Please check back before relying on them, or contact us at the address below.'
+                      : 'The organizing entity behind these terms has not been registered yet. Contact the organizers at the address below before relying on them.'}
+                  </p>
+                </div>
+              ) : null}
             </div>
           </div>
 
@@ -150,8 +186,10 @@ async function CachedTermsContent({ domain }: { domain: string }) {
                       <ul className="space-y-2 text-sm text-blue-700 dark:text-blue-300">
                         <li>
                           • You may create an account using GitHub or LinkedIn
-                          (for Call for Papers) or WorkOS AuthKit (for workshop
-                          registration)
+                          (for Call for Papers)
+                          {usesWorkOS
+                            ? ' or WorkOS AuthKit (for workshop registration)'
+                            : ''}
                         </li>
                         <li>
                           • You must provide accurate and complete information
@@ -208,10 +246,12 @@ async function CachedTermsContent({ domain }: { domain: string }) {
                         Registration Process
                       </h3>
                       <ul className="space-y-2 text-sm text-amber-700 dark:text-amber-300">
-                        <li>
-                          • Workshop registration requires authentication
-                          through WorkOS AuthKit
-                        </li>
+                        {usesWorkOS ? (
+                          <li>
+                            • Workshop registration requires authentication
+                            through WorkOS AuthKit
+                          </li>
+                        ) : null}
                         <li>
                           • Workshops have limited capacity and are assigned on
                           a first-come, first-served basis

--- a/src/components/legal/SubprocessorList.stories.tsx
+++ b/src/components/legal/SubprocessorList.stories.tsx
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { SubprocessorList } from './SubprocessorList'
+import {
+  buildSubprocessorDisclosure,
+  type TenantProcessingFacts,
+} from '@/lib/legal/subprocessors'
+
+/**
+ * Built through the REAL resolver rather than by hand-writing rows, so a story
+ * cannot show a list the rules would never produce.
+ */
+function disclosure(overrides: Partial<TenantProcessingFacts> = {}) {
+  return buildSubprocessorDisclosure({
+    tenantKnown: true,
+    organizationReadFailed: false,
+    ticketing: {
+      provider: 'checkin',
+      bound: true,
+      explicitlySelected: false,
+      registrationLink: null,
+    },
+    analyticsCode: 'Jc72d7tD73Ai9raeYVPeXJ0OhEJrrvaK',
+    slackToken: true,
+    workshops: true,
+    dedicatedEmailAccount: false,
+    ...overrides,
+  })
+}
+
+const meta = {
+  title: 'Components/SubprocessorList',
+  component: SubprocessorList,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The /privacy subprocessor list, resolved from what a tenant actually uses (#690). It used to be hardcoded JSX served identically on every domain, so a tenant on Tito told its attendees that Checkin.no processes their data. An unresolvable signal DISCLOSES the processor with a "may not apply" badge rather than dropping it — under-disclosure is the failure with legal consequence.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SubprocessorList>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** The platform organization, which is also a tenant: Checkin, Slack, Pirsch, workshops. */
+export const PlatformTenant: Story = {
+  args: { disclosure: disclosure() },
+}
+
+/** A customer on Tito with no Slack, no workshops and no analytics code. */
+export const TitoCustomer: Story = {
+  args: {
+    disclosure: disclosure({
+      ticketing: {
+        provider: 'tito',
+        bound: true,
+        explicitlySelected: true,
+        registrationLink: null,
+      },
+      analyticsCode: null,
+      slackToken: false,
+      workshops: false,
+    }),
+  },
+}
+
+/** A tenant sending from its own Resend account rather than the shared one. */
+export const OwnEmailAccount: Story = {
+  args: { disclosure: disclosure({ dedicatedEmailAccount: true }) },
+}
+
+/** No ticketing binding at all — neither vendor is named. */
+export const NoTicketingVendor: Story = {
+  args: {
+    disclosure: disclosure({
+      ticketing: {
+        provider: 'checkin',
+        bound: false,
+        explicitlySelected: false,
+        registrationLink: null,
+      },
+      analyticsCode: null,
+      slackToken: false,
+      workshops: false,
+    }),
+  },
+}
+
+/**
+ * The organization read FAILED. The org-gated processors stay on the list,
+ * badged as uncertain, rather than silently disappearing for the length of an
+ * outage — the state this whole change exists to make impossible.
+ */
+export const OrganizationReadFailed: Story = {
+  args: {
+    disclosure: disclosure({
+      organizationReadFailed: true,
+      slackToken: null,
+      workshops: null,
+      dedicatedEmailAccount: null,
+    }),
+  },
+}
+
+/** Nothing about the tenant could be read: the full possible set, all uncertain. */
+export const NothingKnown: Story = {
+  args: {
+    disclosure: disclosure({
+      tenantKnown: false,
+      ticketing: null,
+      analyticsCode: null,
+      slackToken: null,
+      workshops: null,
+      dedicatedEmailAccount: null,
+    }),
+  },
+}

--- a/src/components/legal/SubprocessorList.tsx
+++ b/src/components/legal/SubprocessorList.tsx
@@ -1,0 +1,137 @@
+import {
+  ChartBarIcon,
+  ChatBubbleLeftRightIcon,
+  DocumentTextIcon,
+  EnvelopeIcon,
+  ExclamationTriangleIcon,
+  GlobeAltIcon,
+  LockClosedIcon,
+} from '@heroicons/react/24/outline'
+// Imported from the MODULE, not the `@/lib/legal` barrel: the barrel re-exports
+// `resolveSubprocessorDisclosure` from a `server-only` file, and this component
+// also renders in Storybook. `./subprocessors` is pure and client-safe.
+import type {
+  DisclosedSubprocessor,
+  SubprocessorDisclosure,
+  SubprocessorId,
+} from '@/lib/legal/subprocessors'
+
+/**
+ * The /privacy subprocessor list, rendered from the RESOLVED disclosure rather
+ * than hardcoded per vendor (#690).
+ *
+ * PRESENTATION ONLY — every decision about what belongs in the list is made in
+ * `@/lib/legal/subprocessors`. This component's one job on top of rendering is
+ * to make UNCERTAINTY VISIBLE: an entry the resolver could not confirm carries a
+ * "may not apply" badge and the list carries a notice, because an over-long list
+ * presented as fact is its own inaccuracy — smaller than omitting a processor,
+ * but still a claim the organizer signs their name to.
+ */
+
+const ICONS: Record<SubprocessorId, typeof LockClosedIcon> = {
+  sanity: LockClosedIcon,
+  vercel: GlobeAltIcon,
+  resend: EnvelopeIcon,
+  checkin: DocumentTextIcon,
+  tito: DocumentTextIcon,
+  pirsch: ChartBarIcon,
+  slack: ChatBubbleLeftRightIcon,
+  'oauth-providers': LockClosedIcon,
+  workos: LockClosedIcon,
+}
+
+const GROUP_TITLES = {
+  infrastructure: 'Essential Service Providers',
+  authentication: 'Authentication Services',
+} as const
+
+function SubprocessorRow({ processor }: { processor: DisclosedSubprocessor }) {
+  const Icon = ICONS[processor.id]
+  return (
+    <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-800/50">
+      <div className="flex items-start space-x-3">
+        <Icon className="mt-1 h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" />
+        <div>
+          <p className="font-medium text-gray-900 dark:text-white">
+            {processor.name}
+            {processor.certainty === 'possible' ? (
+              <span className="ml-2 inline-block rounded-sm bg-amber-100 px-1.5 py-0.5 align-middle text-xs font-normal text-amber-900 dark:bg-amber-900/40 dark:text-amber-200">
+                May not apply to this event
+              </span>
+            ) : null}
+          </p>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            {processor.purpose}
+            {processor.detail ? ` ${processor.detail}` : ''}
+          </p>
+          {/*
+            WHO CHOSE THIS PROCESSOR is the question a DPA review is actually
+            asking. Some of these are shared platform infrastructure the
+            organizer never selected (our hosting, our content dataset) and some
+            are vendors they picked; publishing the list without the distinction
+            reads as though the organizer chose all of them.
+          */}
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-500">
+            {processor.chosenBy === 'organizer'
+              ? 'Selected by the event organizer'
+              : 'Shared platform infrastructure'}
+            {processor.location
+              ? ` • Location: ${processor.location} • Protected by Standard Contractual Clauses`
+              : ''}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function SubprocessorList({
+  disclosure,
+}: {
+  disclosure: SubprocessorDisclosure
+}) {
+  const groups = (['infrastructure', 'authentication'] as const)
+    .map((group) => ({
+      group,
+      processors: disclosure.processors.filter((p) => p.group === group),
+    }))
+    .filter(({ processors }) => processors.length > 0)
+
+  return (
+    <div className="space-y-6">
+      {/*
+        Rendered only when something could NOT be determined. The previous
+        blanket caveat ("this list describes the services the platform can use")
+        was on the page unconditionally, which trained the reader to discount the
+        whole list. A notice that appears only when it is true is worth reading.
+      */}
+      {disclosure.incomplete ? (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 dark:border-amber-700 dark:bg-amber-900/20">
+          <div className="flex items-start space-x-3">
+            <ExclamationTriangleIcon className="mt-0.5 h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400" />
+            <p className="text-sm text-amber-900 dark:text-amber-200">
+              Some of this event&apos;s integration settings could not be read
+              just now, so the entries marked{' '}
+              <span className="font-semibold">may not apply to this event</span>{' '}
+              are listed as a precaution. We would rather name a provider that
+              turns out not to process your data than leave one out.
+            </p>
+          </div>
+        </div>
+      ) : null}
+
+      {groups.map(({ group, processors }) => (
+        <div key={group}>
+          <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+            {GROUP_TITLES[group]}
+          </h3>
+          <div className="space-y-3">
+            {processors.map((processor) => (
+              <SubprocessorRow key={processor.id} processor={processor} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/legal/index.ts
+++ b/src/components/legal/index.ts
@@ -1,0 +1,1 @@
+export { SubprocessorList } from './SubprocessorList'

--- a/src/lib/legal/config.test.ts
+++ b/src/lib/legal/config.test.ts
@@ -35,12 +35,44 @@ describe('buildLegalConfig — defaults (existing tenant, no org fields)', () =>
     expect(legal.controllerName).toBe('Cloud Native Days Norway')
   })
 
-  it('uses the neutral platform name when neither org nor organizer is set', () => {
+  it('leaves the controller UNRESOLVED when neither org nor organizer is set', () => {
+    // #848: this used to fall back to `PLATFORM_NAME`, so a tenant's privacy
+    // policy named the PLATFORM as its data controller — misdirecting every
+    // Article 15-21 request. There is no fallback any more.
     const legal = buildLegalConfig(
       conf({ organizer: '' as unknown as string }),
       null,
     )
-    expect(legal.controllerName).toBe('Konf')
+    expect(legal.controllerName).toBe('')
+    expect(legal.controllerResolved).toBe(false)
+    expect(legal.controllerName).not.toBe('Konf')
+  })
+
+  it('reports a resolved controller in the other direction', () => {
+    expect(buildLegalConfig(conf(), null).controllerResolved).toBe(true)
+  })
+})
+
+describe('buildLegalConfig — a FAILED organization read is not an absent one', () => {
+  it('flags the identity as unconfirmed rather than silently defaulting', () => {
+    const legal = buildLegalConfig(conf(), null, {
+      organizationReadFailed: true,
+    })
+    expect(legal.identityReadFailed).toBe(true)
+  })
+
+  it('never names the platform when the read failed and the conference is bare', () => {
+    const legal = buildLegalConfig(
+      conf({ organizer: '' as unknown as string }),
+      null,
+      { organizationReadFailed: true },
+    )
+    expect(legal.controllerResolved).toBe(false)
+    expect(legal.controllerName).toBe('')
+  })
+
+  it('is false for an ordinary successful read — the other direction', () => {
+    expect(buildLegalConfig(conf(), null).identityReadFailed).toBe(false)
   })
 })
 

--- a/src/lib/legal/config.ts
+++ b/src/lib/legal/config.ts
@@ -1,5 +1,4 @@
 import { resolveConferenceContact } from '@/lib/email/from'
-import { PLATFORM_NAME } from '@/lib/branding/platform'
 import type { Conference } from '@/lib/conference/types'
 
 /**
@@ -24,6 +23,17 @@ import type { Conference } from '@/lib/conference/types'
  *
  * The Norway-specific prose (tax law, "Norwegian data protection laws",
  * Datatilsynet) renders only when the jurisdiction resolves TO Norway.
+ *
+ * THE CONTROLLER IS NEVER GUESSED EITHER (#848, #690). It used to fall back to
+ * `PLATFORM_NAME` when neither the organization document nor the conference
+ * named an entity — so a FAILED organization read (which `resolveLegalConfig`
+ * could not distinguish from a legitimately absent one) published the PLATFORM
+ * as the data controller of a tenant's event. Naming the wrong controller is
+ * worse than admitting the field is unresolved: it misdirects every access,
+ * erasure and objection request under Articles 15-21, and it is exactly the
+ * failure class #855 spent a week removing — a failed read rendered as a
+ * confident claim. There is now no platform fallback at all;
+ * {@link LegalConfig.controllerResolved} is false and the pages say so.
  */
 
 /** A data-protection supervisory authority a complaint can be lodged with. */
@@ -71,8 +81,26 @@ function safeHttpUrl(value: string | null | undefined): string | undefined {
 }
 
 export interface LegalConfig {
-  /** The data controller / legal entity name shown throughout the pages. */
+  /**
+   * The data controller / legal entity name shown throughout the pages. EMPTY
+   * when no entity could be resolved — pages MUST branch on
+   * {@link LegalConfig.controllerResolved} and never print a blank or a
+   * substitute.
+   */
   controllerName: string
+  /**
+   * False when neither the organization document nor the conference named a
+   * legal entity. There is deliberately NO fallback: see the module doc.
+   */
+  controllerResolved: boolean
+  /**
+   * True when the organization document read FAILED (as opposed to a tenant
+   * that legitimately has no organization document). The identity below may
+   * then be a degraded conference-level fallback, or absent entirely, and the
+   * pages must say the details could not be confirmed rather than presenting
+   * them as current.
+   */
+  identityReadFailed: boolean
   /** The controller's contact address for privacy / terms enquiries. */
   contactEmail: string
   /**
@@ -118,9 +146,23 @@ export interface OrganizationLegalFields {
 export function buildLegalConfig(
   conference: Conference | null | undefined,
   org: OrganizationLegalFields | null | undefined,
+  {
+    organizationReadFailed = false,
+  }: {
+    /**
+     * True when the organization read REJECTED. Distinguishes "this tenant has
+     * no organization document" from "we could not find out", which used to be
+     * the same `null` — the #848 root enabler.
+     */
+    organizationReadFailed?: boolean
+  } = {},
 ): LegalConfig {
+  // Organization name first, then the conference's own `organizer` field — both
+  // are the TENANT's data. Nothing further: an unresolved controller stays
+  // unresolved rather than becoming the platform's name.
   const controllerName =
-    org?.name?.trim() || conference?.organizer?.trim() || PLATFORM_NAME
+    org?.name?.trim() || conference?.organizer?.trim() || ''
+  const controllerResolved = controllerName !== ''
 
   const contactEmail =
     org?.contactEmail?.trim() || resolveConferenceContact(conference)
@@ -168,6 +210,8 @@ export function buildLegalConfig(
 
   return {
     controllerName,
+    controllerResolved,
+    identityReadFailed: organizationReadFailed,
     contactEmail,
     location,
     jurisdiction,

--- a/src/lib/legal/index.ts
+++ b/src/lib/legal/index.ts
@@ -7,3 +7,10 @@ export {
   type OrganizationLegalFields,
 } from './config'
 export { resolveLegalConfig } from './resolve'
+export {
+  discloses,
+  internationalTransferProcessors,
+  type DisclosedSubprocessor,
+  type SubprocessorDisclosure,
+} from './subprocessors'
+export { resolveSubprocessorDisclosure } from './subprocessors.resolve'

--- a/src/lib/legal/resolve.ts
+++ b/src/lib/legal/resolve.ts
@@ -8,10 +8,30 @@ import {
 } from './config'
 
 /**
- * Best-effort fetch of the legal-identity fields from the tenant's organization
- * document. Non-throwing: a legacy conference lacking an `organization` ref, or
- * any transient error, resolves to `null` so `buildLegalConfig` falls back to
- * the conference/Norway defaults.
+ * How the organization's legal-identity read resolved — the seam that makes
+ * "we could not find out" REPRESENTABLE (#848, same shape as
+ * `ConferenceResolutionStatus`).
+ *
+ *  - `ok`          — the document was read.
+ *  - `absent`      — no `organization` ref, or the read SUCCEEDED and matched
+ *                    nothing. A statement about the world.
+ *  - `unavailable` — the read FAILED. Nothing about the controller's identity
+ *                    may be asserted from it.
+ */
+export type OrganizationLegalRead =
+  | { status: 'ok'; org: OrganizationLegalFields }
+  | { status: 'absent' }
+  | { status: 'unavailable' }
+
+/**
+ * Fetch the legal-identity fields from the tenant's organization document.
+ *
+ * NON-THROWING but no longer LOSSY. It used to answer a rejected read with the
+ * same `null` as a legacy conference that has no organization at all, and
+ * `buildLegalConfig` then fell through to `PLATFORM_NAME` — publishing the
+ * PLATFORM as the data controller of a customer's event for the length of an
+ * outage. The status distinguishes the two so the pages can say "could not be
+ * confirmed" instead of naming the wrong entity.
  *
  * This read is UNCACHED and therefore carries no tag of its own: it reaches the
  * organization by a second fetch on `organization._ref` rather than a GROQ
@@ -23,10 +43,10 @@ import {
  */
 async function fetchOrganizationLegal(
   orgRef: string | null | undefined,
-): Promise<OrganizationLegalFields | null> {
-  if (!orgRef) return null
+): Promise<OrganizationLegalRead> {
+  if (!orgRef) return { status: 'absent' }
   try {
-    return await clientReadUncached.fetch<OrganizationLegalFields | null>(
+    const org = await clientReadUncached.fetch<OrganizationLegalFields | null>(
       // groq-global-scoped: `orgRef` is the request conference's OWN
       // `organization._ref` (see `resolveLegalConfig`, whose only input is the
       // conference already resolved for the request host). The id read here IS
@@ -39,8 +59,13 @@ async function fetchOrganizationLegal(
       }`,
       { id: orgRef },
     )
-  } catch {
-    return null
+    return org ? { status: 'ok', org } : { status: 'absent' }
+  } catch (error) {
+    console.error(
+      `[legal] organization read failed for ${orgRef}; the controller identity is UNCONFIRMED and must not be filled in with a default`,
+      error,
+    )
+    return { status: 'unavailable' }
   }
 }
 
@@ -52,6 +77,8 @@ async function fetchOrganizationLegal(
 export async function resolveLegalConfig(
   conference: Conference | null | undefined,
 ): Promise<LegalConfig> {
-  const org = await fetchOrganizationLegal(conference?.organization?._ref)
-  return buildLegalConfig(conference, org)
+  const read = await fetchOrganizationLegal(conference?.organization?._ref)
+  return buildLegalConfig(conference, read.status === 'ok' ? read.org : null, {
+    organizationReadFailed: read.status === 'unavailable',
+  })
 }

--- a/src/lib/legal/subprocessors.resolve.ts
+++ b/src/lib/legal/subprocessors.resolve.ts
@@ -1,0 +1,133 @@
+import 'server-only'
+import { getOrganizationById } from '@/lib/organization/sanity'
+import { perOrgSecretsStore } from '@/lib/secrets/store'
+import { resolveConferenceSlackToken } from '@/lib/slack/token'
+import { isWorkshopsEnabledForConference } from '@/lib/features/workshops'
+import {
+  conferenceProviderType,
+  hasTicketingBinding,
+} from '@/lib/tickets/provider'
+import type { Conference } from '@/lib/conference/types'
+import {
+  buildSubprocessorDisclosure,
+  type SubprocessorDisclosure,
+  type TenantProcessingFacts,
+} from './subprocessors'
+
+/**
+ * Gather the tenant's real processing facts and build the /privacy + /terms
+ * subprocessor disclosure. See `./subprocessors` for the two rules this obeys;
+ * the one that shapes THIS file is rule 2.
+ *
+ * ── WHY THE ORGANIZATION READ IS PROBED FIRST ───────────────────────────────
+ *
+ * The Slack and workshop gates both fail CLOSED on a rejected Sanity read:
+ * `resolveConferenceSlackToken` swallows the rejection inside
+ * `isSlackMirrorEnabledForOrg` and answers `undefined`, and
+ * `isWorkshopsEnabledForConference` runs through `resolveRegistryEntitlement`,
+ * which classifies a rejected read as `'denied'`. That is the correct posture for
+ * handing out a bot token, and exactly the wrong one for a legal disclosure: a
+ * transient read failure would silently publish a SHORTER subprocessor list.
+ *
+ * Neither gate exposes the difference, so this probes `getOrganizationById`
+ * directly — the SAME cached, `organizationTag`-tagged read both gates use, so
+ * the probe costs nothing extra and, when it succeeds, the gates below are
+ * answering from a healthy read. A rejection sets `organizationReadFailed`, which
+ * turns both org-gated signals UNKNOWN, and UNKNOWN discloses.
+ *
+ * A `null` result is NOT a failure: the read succeeded and the organization does
+ * not exist, so the gates genuinely deny and the tenant genuinely uses neither.
+ * Likewise a conference with no `organization` ref: every gate keys on that ref
+ * and fails closed on its absence, so "no ref" is a fact about what runs, not an
+ * unanswered question.
+ *
+ * CACHING: callers run inside a `'use cache'` scope that already tags
+ * `conferenceTag(conference._id)` and `organizationTag(orgRef)` (asserted by
+ * `__tests__/lib/cache/organization-tag-coverage.test.ts`), which is exactly the
+ * invalidation this needs — an override flip or a provider change busts the page.
+ */
+export async function resolveSubprocessorDisclosure(
+  conference: Conference | null | undefined,
+): Promise<SubprocessorDisclosure> {
+  return buildSubprocessorDisclosure(await resolveProcessingFacts(conference))
+}
+
+async function resolveProcessingFacts(
+  conference: Conference | null | undefined,
+): Promise<TenantProcessingFacts> {
+  const tenantKnown = Boolean(conference?._id)
+  if (!conference || !tenantKnown) {
+    return {
+      tenantKnown: false,
+      organizationReadFailed: false,
+      ticketing: null,
+      analyticsCode: null,
+      slackToken: null,
+      workshops: null,
+      dedicatedEmailAccount: null,
+    }
+  }
+
+  const orgRef = conference.organization?._ref ?? null
+  const organizationReadFailed = await organizationReadRejected(orgRef)
+
+  // Both gates are asked ONLY when the org document read is healthy; otherwise
+  // their fail-closed `false` would be indistinguishable from a real "no".
+  const [slackToken, workshops, dedicatedEmailAccount] = organizationReadFailed
+    ? ([null, null, null] as const)
+    : await Promise.all([
+        // Coerced to a boolean IMMEDIATELY: this is the token resolver, and the
+        // token itself must never travel further than this expression.
+        resolveConferenceSlackToken(conference).then(Boolean),
+        isWorkshopsEnabledForConference(conference),
+        // The per-org secret store never throws (a malformed TENANT_SECRETS_JSON
+        // is logged once and treated as empty), so a `null` here is a real "uses
+        // the shared platform account".
+        perOrgSecretsStore
+          .get(orgRef, 'email')
+          .then((creds) => Boolean(creds?.apiKey)),
+      ])
+
+  return {
+    tenantKnown: true,
+    organizationReadFailed,
+    ticketing: {
+      provider: conferenceProviderType(conference),
+      // The BINDING, not the credentials. `resolveTicketingProvider` collapses
+      // "no credentials" into the same `configured: false` as "no event id", so
+      // asking it would drop the disclosure for a conference that is plainly
+      // bound to a vendor and merely mid-provisioning — the under-report
+      // direction. A binding present with credentials absent over-discloses,
+      // which is the direction this page is allowed to err in.
+      bound: hasTicketingBinding(conference),
+      explicitlySelected:
+        conference.ticketingProvider === 'checkin' ||
+        conference.ticketingProvider === 'tito',
+      registrationLink: conference.registrationLink,
+    },
+    analyticsCode: conference.analyticsPirschCode,
+    slackToken,
+    workshops,
+    dedicatedEmailAccount,
+  }
+}
+
+/**
+ * Did the organization document read FAIL? `false` for a nullish ref and for a
+ * read that succeeded and found nothing — only a rejection counts.
+ */
+async function organizationReadRejected(
+  orgRef: string | null,
+): Promise<boolean> {
+  if (!orgRef) return false
+  try {
+    await getOrganizationById(orgRef)
+    return false
+  } catch (error) {
+    console.error(
+      `[legal] organization read failed for ${orgRef}; disclosing every org-gated subprocessor as POSSIBLE rather than omitting it`,
+      error,
+    )
+    return true
+  }
+}

--- a/src/lib/legal/subprocessors.test.ts
+++ b/src/lib/legal/subprocessors.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildSubprocessorDisclosure,
+  discloses,
+  internationalTransferProcessors,
+  registrationLinkVendor,
+  ticketingSignal,
+  type SubprocessorId,
+  type TenantProcessingFacts,
+} from './subprocessors'
+
+/** A fully-resolved, ordinary tenant: Checkin, no analytics, no Slack, no workshops. */
+function facts(
+  overrides: Partial<TenantProcessingFacts> = {},
+): TenantProcessingFacts {
+  return {
+    tenantKnown: true,
+    organizationReadFailed: false,
+    ticketing: {
+      provider: 'checkin',
+      bound: true,
+      explicitlySelected: false,
+      registrationLink: null,
+    },
+    analyticsCode: null,
+    slackToken: false,
+    workshops: false,
+    dedicatedEmailAccount: false,
+    ...overrides,
+  }
+}
+
+function ids(f: TenantProcessingFacts): SubprocessorId[] {
+  return buildSubprocessorDisclosure(f).processors.map((p) => p.id)
+}
+
+describe('the ticketing vendor a tenant actually uses', () => {
+  it('lists Checkin and NOT Tito for a Checkin-bound conference', () => {
+    const list = ids(facts())
+    expect(list).toContain('checkin')
+    expect(list).not.toContain('tito')
+  })
+
+  it('lists Tito and NOT Checkin for a Tito-bound conference', () => {
+    // The headline defect in #690: a tenant on Tito was telling its attendees
+    // that Checkin.no processes their data.
+    const list = ids(
+      facts({
+        ticketing: {
+          provider: 'tito',
+          bound: true,
+          explicitlySelected: true,
+          registrationLink: null,
+        },
+      }),
+    )
+    expect(list).toContain('tito')
+    expect(list).not.toContain('checkin')
+  })
+
+  it('lists NEITHER vendor for a conference with no ticketing binding', () => {
+    // A successful read that says "nothing is bound" is a fact, not an
+    // ambiguity: no attendee data reaches any ticketing vendor through us.
+    const list = ids(
+      facts({
+        ticketing: {
+          provider: 'checkin',
+          bound: false,
+          explicitlySelected: false,
+          registrationLink: null,
+        },
+      }),
+    )
+    expect(list).not.toContain('checkin')
+    expect(list).not.toContain('tito')
+  })
+
+  it('still discloses a vendor that is SELECTED but not fully bound', () => {
+    const disclosure = buildSubprocessorDisclosure(
+      facts({
+        ticketing: {
+          provider: 'tito',
+          bound: false,
+          explicitlySelected: true,
+          registrationLink: null,
+        },
+      }),
+    )
+    const tito = disclosure.processors.find((p) => p.id === 'tito')
+    expect(tito?.certainty).toBe('possible')
+    expect(disclosure.incomplete).toBe(true)
+  })
+
+  it('discloses the vendor an external registration link points at', () => {
+    // A proxy, not a fact — so it earns `possible`, never `confirmed`.
+    const disclosure = buildSubprocessorDisclosure(
+      facts({
+        ticketing: {
+          provider: 'checkin',
+          bound: false,
+          explicitlySelected: false,
+          registrationLink: 'https://ti.to/acme/conf-2026',
+        },
+      }),
+    )
+    expect(disclosure.processors.find((p) => p.id === 'tito')?.certainty).toBe(
+      'possible',
+    )
+  })
+})
+
+describe('registrationLinkVendor', () => {
+  it('recognises vendor hosts and subdomains', () => {
+    expect(registrationLinkVendor('https://event.checkin.no/1/x')).toBe(
+      'checkin',
+    )
+    expect(registrationLinkVendor('https://ti.to/acme/x')).toBe('tito')
+    expect(registrationLinkVendor('https://tito.io/acme/x')).toBe('tito')
+  })
+
+  it('answers null for anything else, including junk', () => {
+    expect(registrationLinkVendor('https://eventbrite.com/e/1')).toBeNull()
+    expect(registrationLinkVendor('not a url')).toBeNull()
+    expect(registrationLinkVendor('')).toBeNull()
+    expect(registrationLinkVendor(null)).toBeNull()
+    // A host that merely CONTAINS a vendor name must not match.
+    expect(registrationLinkVendor('https://notcheckin.no/x')).toBeNull()
+    expect(registrationLinkVendor('https://checkin.no.evil.test/x')).toBeNull()
+  })
+})
+
+describe('ticketingSignal', () => {
+  it('is unknown for BOTH vendors when nothing is known about the tenant', () => {
+    expect(ticketingSignal('checkin', null)).toBe('unknown')
+    expect(ticketingSignal('tito', null)).toBe('unknown')
+  })
+})
+
+describe('analytics is disclosed only when a code is configured', () => {
+  it('lists Pirsch when the tenant has a code', () => {
+    expect(ids(facts({ analyticsCode: 'abc123XYZ' }))).toContain('pirsch')
+  })
+
+  it('omits Pirsch when there is none — no code, no script, no processor', () => {
+    expect(ids(facts({ analyticsCode: '   ' }))).not.toContain('pirsch')
+  })
+
+  it('discloses a MALFORMED code rather than validating the row away', () => {
+    // Deliberate over-disclosure: validating here would drop the row on a typo,
+    // which is the under-report direction.
+    expect(ids(facts({ analyticsCode: 'not a valid code!' }))).toContain(
+      'pirsch',
+    )
+  })
+})
+
+describe('Slack and WorkOS follow the tenant, not the platform', () => {
+  it('lists both when the tenant has a Slack token and workshops enabled', () => {
+    const list = ids(facts({ slackToken: true, workshops: true }))
+    expect(list).toContain('slack')
+    expect(list).toContain('workos')
+  })
+
+  it('lists neither for a tenant with no token and no workshop entitlement', () => {
+    const list = ids(facts())
+    expect(list).not.toContain('slack')
+    expect(list).not.toContain('workos')
+  })
+})
+
+describe('email: which Resend account the organizer sends through', () => {
+  it('says the shared platform account by default', () => {
+    const resend = buildSubprocessorDisclosure(facts()).processors.find(
+      (p) => p.id === 'resend',
+    )
+    expect(resend?.detail).toMatch(/shared platform sending account/i)
+  })
+
+  it('says the organizer’s OWN account when it has its own credentials', () => {
+    const resend = buildSubprocessorDisclosure(
+      facts({ dedicatedEmailAccount: true }),
+    ).processors.find((p) => p.id === 'resend')
+    expect(resend?.detail).toMatch(/own Resend account/i)
+  })
+
+  it('says nothing about the account when it could not be determined', () => {
+    const resend = buildSubprocessorDisclosure(
+      facts({ dedicatedEmailAccount: null }),
+    ).processors.find((p) => p.id === 'resend')
+    expect(resend?.detail).toBeUndefined()
+    // Resend itself is still disclosed — it is used either way.
+    expect(discloses(buildSubprocessorDisclosure(facts()), 'resend')).toBe(true)
+  })
+})
+
+describe('a failed read must NOT shorten the list', () => {
+  it('discloses Slack and WorkOS as POSSIBLE when the organization read failed', () => {
+    // The gates themselves answer `false` here (fail closed). Inheriting that
+    // would publish a shorter subprocessor list during an outage.
+    const disclosure = buildSubprocessorDisclosure(
+      facts({
+        organizationReadFailed: true,
+        slackToken: null,
+        workshops: null,
+      }),
+    )
+    expect(disclosure.processors.find((p) => p.id === 'slack')?.certainty).toBe(
+      'possible',
+    )
+    expect(
+      disclosure.processors.find((p) => p.id === 'workos')?.certainty,
+    ).toBe('possible')
+    expect(disclosure.incomplete).toBe(true)
+  })
+
+  it('discloses org-gated processors even when the gates report a hard false', () => {
+    // The gates cannot distinguish "denied" from "read failed", so the flag —
+    // not the boolean — is what decides. A `false` alongside the flag must not
+    // win.
+    const list = ids(
+      facts({
+        organizationReadFailed: true,
+        slackToken: false,
+        workshops: false,
+      }),
+    )
+    expect(list).toContain('slack')
+    expect(list).toContain('workos')
+  })
+
+  it('discloses EVERY conditional processor when nothing about the tenant is known', () => {
+    const disclosure = buildSubprocessorDisclosure(
+      facts({
+        tenantKnown: false,
+        ticketing: null,
+        analyticsCode: null,
+        slackToken: null,
+        workshops: null,
+        dedicatedEmailAccount: null,
+      }),
+    )
+    for (const id of [
+      'sanity',
+      'vercel',
+      'resend',
+      'checkin',
+      'tito',
+      'pirsch',
+      'slack',
+      'oauth-providers',
+      'workos',
+    ] as const) {
+      expect(discloses(disclosure, id)).toBe(true)
+    }
+    expect(disclosure.incomplete).toBe(true)
+  })
+
+  it('is NOT incomplete when every signal resolved — the other direction', () => {
+    // Without this, the tests above would pass on a build that marked
+    // everything `possible` all the time and proved nothing.
+    expect(buildSubprocessorDisclosure(facts()).incomplete).toBe(false)
+  })
+})
+
+describe('shared platform infrastructure is disclosed for everyone', () => {
+  it('always lists Sanity, Vercel, Resend and the CFP sign-in providers', () => {
+    const list = ids(facts())
+    expect(list).toEqual(
+      expect.arrayContaining(['sanity', 'vercel', 'resend', 'oauth-providers']),
+    )
+  })
+
+  it('labels who chose each processor', () => {
+    const disclosure = buildSubprocessorDisclosure(facts())
+    const by = (id: SubprocessorId) =>
+      disclosure.processors.find((p) => p.id === id)?.chosenBy
+    expect(by('sanity')).toBe('platform')
+    expect(by('checkin')).toBe('organizer')
+  })
+})
+
+describe('the international-transfer list is derived from the SAME disclosure', () => {
+  it('never names a processor the tenant does not use', () => {
+    // Naming "Vercel, Slack, Resend, WorkOS" on every tenant was the same defect
+    // one section further down the privacy page.
+    const disclosure = buildSubprocessorDisclosure(facts())
+    const names = internationalTransferProcessors(disclosure).map((p) => p.name)
+    expect(names).toContain('Vercel.com')
+    expect(names).toContain('Resend.com')
+    expect(names).not.toContain('Slack')
+    expect(names).not.toContain('WorkOS (AuthKit)')
+  })
+
+  it('includes Slack and WorkOS once the tenant actually uses them', () => {
+    const disclosure = buildSubprocessorDisclosure(
+      facts({ slackToken: true, workshops: true }),
+    )
+    const names = internationalTransferProcessors(disclosure).map((p) => p.name)
+    expect(names).toContain('Slack')
+    expect(names).toContain('WorkOS (AuthKit)')
+  })
+
+  it('lists only processors that have a location', () => {
+    const disclosure = buildSubprocessorDisclosure(facts())
+    expect(
+      internationalTransferProcessors(disclosure).every((p) => p.location),
+    ).toBe(true)
+  })
+})

--- a/src/lib/legal/subprocessors.ts
+++ b/src/lib/legal/subprocessors.ts
@@ -1,0 +1,416 @@
+/**
+ * THE tenant-conditional SUBPROCESSOR DISCLOSURE for /privacy and /terms (#690).
+ *
+ * WHY THIS EXISTS. The processor list on the privacy page was hardcoded JSX,
+ * served identically on every tenant domain. A tenant selling through Tito was
+ * telling its attendees that Checkin.no processes their data; a tenant that does
+ * not run workshops was disclosing WorkOS as processing attendee email, name and
+ * user ID. That is not a copy bug: the page is a legal representation by the
+ * TENANT (they are the controller named on it), and the subprocessor list is the
+ * first thing a customer's DPA review reads.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * THE TWO RULES, AND THEY OUTRANK THE MECHANISM
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * 1. NEVER UNDER-REPORT. Omitting a processor a tenant actually uses is the
+ *    failure with legal consequence; naming one it does not is a copy problem.
+ *    So every signal is THREE-STATE — `yes` / `no` / UNKNOWN — and an unknown
+ *    DISCLOSES the processor, marked `certainty: 'possible'`, rather than
+ *    dropping it. Only a signal that positively answers "no" from a SUCCESSFUL
+ *    read removes an entry.
+ *
+ * 2. A FAILED READ MUST NOT SHORTEN THE LIST. This is the #855/#848 class
+ *    applied to the worst possible surface. Almost every feature gate in this
+ *    codebase fails CLOSED on a rejected Sanity read — `resolveRegistryEntitlement`
+ *    answers `'denied'`, `resolveEnabledFeaturesForOrg` logs "treating every
+ *    feature as DISABLED" — which is the right posture for handing out a
+ *    credential and exactly the WRONG one for a disclosure. Deriving this list
+ *    straight from those gates would mean a flaky read silently publishes a
+ *    SHORTER subprocessor list during an outage. So the resolver probes the
+ *    organization read for health FIRST (`./subprocessors.resolve`) and reports
+ *    `organizationReadFailed`, which turns every org-gated signal UNKNOWN
+ *    instead of "no".
+ *
+ * FAILURE BEHAVIOUR CHOSEN, deliberately, out of the two honest options
+ * ("show the full possible set" vs "show an error"): SHOW THE FULL POSSIBLE SET,
+ * with a conspicuous notice saying which parts could not be confirmed. A privacy
+ * policy is where a data subject finds the controller's contact address and how
+ * to exercise their rights — content that does not depend on any of these reads.
+ * Replacing the page with an error during a partial outage removes that, to fix
+ * nothing. (A failure of the CONFERENCE read is different and IS an error state:
+ * with no conference document there is no controller to name either, so the page
+ * has nothing truthful left to say — see the pages' own `isConferenceUnavailable`
+ * branch.)
+ *
+ * PURE — no I/O — so every disclosure rule is unit-testable in isolation. The
+ * signal GATHERING lives in `./subprocessors.resolve` (server-only).
+ */
+
+/** Every processor this platform can place in a tenant's processing chain. */
+export type SubprocessorId =
+  | 'sanity'
+  | 'vercel'
+  | 'resend'
+  | 'checkin'
+  | 'tito'
+  | 'pirsch'
+  | 'slack'
+  | 'oauth-providers'
+  | 'workos'
+
+/**
+ * How sure we are that THIS tenant uses the processor.
+ *
+ * - `confirmed` — a successful read says this tenant uses it.
+ * - `possible`  — we could NOT determine it. Disclosed anyway (rule 1); the page
+ *                 must render the uncertainty rather than presenting it as fact.
+ */
+export type DisclosureCertainty = 'confirmed' | 'possible'
+
+/** A three-state answer about one signal. UNKNOWN is not "no". */
+export type Signal = 'yes' | 'no' | 'unknown'
+
+export interface DisclosedSubprocessor {
+  id: SubprocessorId
+  name: string
+  /** What the processor does with personal data. */
+  purpose: string
+  /** Which heading it renders under. */
+  group: 'infrastructure' | 'authentication'
+  /**
+   * Processing location, disclosed only where it is outside the EU/EEA and so
+   * drives the international-transfer section.
+   */
+  location?: string
+  /**
+   * Who put this processor in the chain: the PLATFORM (shared infrastructure the
+   * tenant did not choose) or the ORGANIZER (a vendor they selected). The
+   * distinction is what a DPA review is actually asking about.
+   */
+  chosenBy: 'platform' | 'organizer'
+  certainty: DisclosureCertainty
+  /** Extra clause appended after the purpose (e.g. which Resend account). */
+  detail?: string
+}
+
+export interface SubprocessorDisclosure {
+  processors: DisclosedSubprocessor[]
+  /**
+   * True when at least one entry is `possible` — i.e. something could not be
+   * determined and the list may name a processor this tenant does not use. The
+   * page MUST say so; a silently over-long list read as fact is its own
+   * inaccuracy.
+   */
+  incomplete: boolean
+}
+
+type CatalogueEntry = Omit<DisclosedSubprocessor, 'certainty' | 'detail'>
+
+/**
+ * The catalogue. One place where a processor's name, purpose and location are
+ * written down, so the "removal checklist" in #690 is a single edit: dropping a
+ * vendor platform-wide means deleting its entry here, and every disclosure
+ * surface follows.
+ */
+export const SUBPROCESSOR_CATALOGUE: Record<SubprocessorId, CatalogueEntry> = {
+  sanity: {
+    id: 'sanity',
+    name: 'Sanity.io',
+    purpose: 'Content management and database services (EU-based)',
+    group: 'infrastructure',
+    chosenBy: 'platform',
+  },
+  vercel: {
+    id: 'vercel',
+    name: 'Vercel.com',
+    purpose:
+      'Website hosting, infrastructure, content delivery, file storage for uploaded attachments, and privacy-friendly analytics (Vercel Analytics & Speed Insights; cookie-less)',
+    group: 'infrastructure',
+    chosenBy: 'platform',
+    location: 'United States',
+  },
+  resend: {
+    id: 'resend',
+    name: 'Resend.com',
+    purpose: 'Email delivery for conference communications',
+    group: 'infrastructure',
+    chosenBy: 'platform',
+    location: 'United States',
+  },
+  checkin: {
+    id: 'checkin',
+    name: 'Checkin.no',
+    purpose: 'Ticket sales, ticket management and event check-in',
+    group: 'infrastructure',
+    chosenBy: 'organizer',
+  },
+  tito: {
+    id: 'tito',
+    name: 'Tito (ti.to)',
+    purpose: 'Ticket sales, ticket management and event check-in',
+    group: 'infrastructure',
+    chosenBy: 'organizer',
+  },
+  pirsch: {
+    id: 'pirsch',
+    name: 'Pirsch Analytics',
+    purpose:
+      'Privacy-focused, cookie-less website analytics (aggregated, no advertising profiles)',
+    group: 'infrastructure',
+    chosenBy: 'organizer',
+  },
+  slack: {
+    id: 'slack',
+    name: 'Slack',
+    purpose:
+      'Internal organizer notifications for operations (e.g., speaker proposal updates)',
+    group: 'infrastructure',
+    chosenBy: 'organizer',
+    location: 'United States',
+  },
+  'oauth-providers': {
+    id: 'oauth-providers',
+    name: 'GitHub/LinkedIn',
+    purpose:
+      'Authentication for the Call for Papers (when you choose to sign in)',
+    group: 'authentication',
+    chosenBy: 'platform',
+  },
+  workos: {
+    id: 'workos',
+    name: 'WorkOS (AuthKit)',
+    purpose:
+      'User authentication and identity management for workshop signups (email, name, user ID, authentication sessions)',
+    group: 'authentication',
+    chosenBy: 'platform',
+    location: 'United States',
+  },
+}
+
+/** The order entries render in, per group. */
+const DISCLOSURE_ORDER: readonly SubprocessorId[] = [
+  'sanity',
+  'vercel',
+  'resend',
+  'checkin',
+  'tito',
+  'pirsch',
+  'slack',
+  'oauth-providers',
+  'workos',
+]
+
+/**
+ * The facts a disclosure is built from. Everything nullable here means "could
+ * not be determined", which is a DIFFERENT value from `false` — see rule 2.
+ */
+export interface TenantProcessingFacts {
+  /**
+   * False when nothing about this tenant could be read at all (no conference
+   * document). Every tenant-conditional signal then resolves UNKNOWN.
+   */
+  tenantKnown: boolean
+  /**
+   * True when the ORGANIZATION document read FAILED. Every org-gated signal
+   * (Slack, workshops/WorkOS) then resolves UNKNOWN rather than inheriting the
+   * gates' fail-closed `false`.
+   */
+  organizationReadFailed: boolean
+  /** The conference's ticketing selection + binding, or `null` when unknown. */
+  ticketing: TicketingFacts | null
+  /**
+   * The RAW `conference.analyticsPirschCode`. Deliberately raw and not passed
+   * through `resolvePirschCode`: a MALFORMED code serves no script, but
+   * validating here would DROP the disclosure on a typo, which is the
+   * under-report direction. A non-empty value discloses Pirsch.
+   */
+  analyticsCode?: string | null
+  /** Whether a Slack bot token resolves for this conference. `null` = unknown. */
+  slackToken: boolean | null
+  /** Whether workshops (and so WorkOS AuthKit) are enabled. `null` = unknown. */
+  workshops: boolean | null
+  /**
+   * Whether the organizer sends through ITS OWN Resend account rather than the
+   * shared platform account. `null` = unknown. Resend is disclosed either way —
+   * this only changes WHICH account, which is the part a DPA cares about.
+   */
+  dedicatedEmailAccount: boolean | null
+}
+
+export interface TicketingFacts {
+  /** The vendor the conference resolves to (absent selection ⇒ Checkin). */
+  provider: 'checkin' | 'tito'
+  /** True when the conference carries the FULL binding for that vendor. */
+  bound: boolean
+  /** True when `ticketingProvider` is set explicitly on the document. */
+  explicitlySelected: boolean
+  /** The organizer's external registration URL, if any. */
+  registrationLink?: string | null
+}
+
+/** Vendor domains recognised in an organizer's external registration link. */
+const REGISTRATION_LINK_VENDORS: ReadonlyArray<{
+  id: 'checkin' | 'tito'
+  hosts: readonly string[]
+}> = [
+  { id: 'checkin', hosts: ['checkin.no'] },
+  { id: 'tito', hosts: ['ti.to', 'tito.io'] },
+]
+
+/**
+ * Which vendor an organizer's `registrationLink` points at, or `null`.
+ *
+ * THIS IS A PROXY, NOT A FACT, and it is used only to move a signal from "no" to
+ * UNKNOWN — never to assert use. A conference can sell through a vendor we have
+ * no integration with: we then share nothing with that vendor ourselves, but the
+ * ORGANIZER (the controller this page speaks for) plainly does, and a policy that
+ * stayed silent would under-report. Matching the link's host is the cheapest
+ * signal available for that, so it earns a `possible`, not a `confirmed`.
+ */
+export function registrationLinkVendor(
+  link: string | null | undefined,
+): 'checkin' | 'tito' | null {
+  const trimmed = link?.trim()
+  if (!trimmed) return null
+  let host: string
+  try {
+    host = new URL(trimmed).hostname.toLowerCase()
+  } catch {
+    return null
+  }
+  for (const vendor of REGISTRATION_LINK_VENDORS) {
+    if (vendor.hosts.some((h) => host === h || host.endsWith(`.${h}`))) {
+      return vendor.id
+    }
+  }
+  return null
+}
+
+/** `yes` when true, `no` when false, `unknown` when null/undefined. */
+function fromNullableBoolean(value: boolean | null | undefined): Signal {
+  if (value === null || value === undefined) return 'unknown'
+  return value ? 'yes' : 'no'
+}
+
+/**
+ * The ticketing signal for ONE vendor.
+ *
+ * A COMPLETE binding for that vendor is the only `yes`: it is what makes the
+ * platform call the vendor's API with attendee data. An explicit selection with
+ * an INCOMPLETE binding, or an external registration link pointing at the vendor,
+ * is `unknown` — the organizer has demonstrably chosen it, so silence would
+ * under-report, but we cannot say the integration is live. Everything else is a
+ * genuine `no` derived from a successful read: an unbound conference shares no
+ * attendee data with any ticketing vendor through us.
+ */
+export function ticketingSignal(
+  vendor: 'checkin' | 'tito',
+  ticketing: TicketingFacts | null,
+): Signal {
+  if (!ticketing) return 'unknown'
+  if (ticketing.bound && ticketing.provider === vendor) return 'yes'
+  if (ticketing.explicitlySelected && ticketing.provider === vendor) {
+    return 'unknown'
+  }
+  if (registrationLinkVendor(ticketing.registrationLink) === vendor) {
+    return 'unknown'
+  }
+  return 'no'
+}
+
+/** The three-state signal for every processor, derived from the facts. */
+export function subprocessorSignals(
+  facts: TenantProcessingFacts,
+): Record<SubprocessorId, Signal> {
+  // With no tenant document nothing tenant-specific is knowable. Note this is
+  // NOT the same as the tenant using nothing.
+  const orgUnknowable = !facts.tenantKnown || facts.organizationReadFailed
+  const orgSignal = (value: boolean | null): Signal =>
+    orgUnknowable ? 'unknown' : fromNullableBoolean(value)
+
+  const analytics: Signal = !facts.tenantKnown
+    ? 'unknown'
+    : facts.analyticsCode?.trim()
+      ? 'yes'
+      : 'no'
+
+  return {
+    // Shared platform infrastructure. Every tenant's data passes through these
+    // whatever they configure, so they are unconditional — and honestly labelled
+    // `chosenBy: 'platform'` rather than implied to be the tenant's choice.
+    sanity: 'yes',
+    vercel: 'yes',
+    resend: 'yes',
+    'oauth-providers': 'yes',
+
+    checkin: facts.tenantKnown
+      ? ticketingSignal('checkin', facts.ticketing)
+      : 'unknown',
+    tito: facts.tenantKnown
+      ? ticketingSignal('tito', facts.ticketing)
+      : 'unknown',
+    pirsch: analytics,
+    slack: orgSignal(facts.slackToken),
+    workos: orgSignal(facts.workshops),
+  }
+}
+
+/**
+ * Build the disclosure. `yes` → confirmed, `unknown` → possible (rule 1),
+ * `no` → omitted.
+ */
+export function buildSubprocessorDisclosure(
+  facts: TenantProcessingFacts,
+): SubprocessorDisclosure {
+  const signals = subprocessorSignals(facts)
+  const processors: DisclosedSubprocessor[] = []
+
+  for (const id of DISCLOSURE_ORDER) {
+    const signal = signals[id]
+    if (signal === 'no') continue
+    processors.push({
+      ...SUBPROCESSOR_CATALOGUE[id],
+      certainty: signal === 'yes' ? 'confirmed' : 'possible',
+      detail: id === 'resend' ? emailAccountDetail(facts) : undefined,
+    })
+  }
+
+  return {
+    processors,
+    incomplete: processors.some((p) => p.certainty === 'possible'),
+  }
+}
+
+/**
+ * Which Resend account the organizer's mail goes through. A tenant with its own
+ * key in the secret store contracts with Resend directly; on the shared account
+ * the platform is the contracting party. Unknown → no clause rather than a
+ * guess.
+ */
+function emailAccountDetail(facts: TenantProcessingFacts): string | undefined {
+  if (facts.dedicatedEmailAccount === null) return undefined
+  return facts.dedicatedEmailAccount
+    ? 'Sent through this organizer’s own Resend account.'
+    : 'Sent through the shared platform sending account.'
+}
+
+/** Whether a processor appears in the disclosure at all (confirmed OR possible). */
+export function discloses(
+  disclosure: SubprocessorDisclosure,
+  id: SubprocessorId,
+): boolean {
+  return disclosure.processors.some((p) => p.id === id)
+}
+
+/**
+ * The disclosed processors that process outside the EU/EEA — what the
+ * international-transfer section must name. Derived from the SAME list, so it
+ * cannot drift from it (naming WorkOS as a US transfer on a tenant that never
+ * uses WorkOS was the same defect one section further down the page).
+ */
+export function internationalTransferProcessors(
+  disclosure: SubprocessorDisclosure,
+): DisclosedSubprocessor[] {
+  return disclosure.processors.filter((p) => p.location)
+}


### PR DESCRIPTION
Fixes #690. Also closes the `/privacy` + `/terms` instance listed under #848.

## The defect

The `/privacy` processor list was **hardcoded JSX served identically on every tenant domain**. A tenant selling through Tito told its attendees that Checkin.no processes their data. A tenant with no workshop entitlement disclosed WorkOS as processing attendee email, name and user ID. Section 6 then repeated the same defect one screen down, naming "Vercel, Slack, Resend, WorkOS" as transfer destinations for everyone.

This is not a copy bug. The page is a legal representation by the **tenant** — they are the controller named on it — and the subprocessor list is the first thing a customer's DPA review reads.

## The mechanism

`src/lib/legal/subprocessors.ts` (pure, no I/O) + `src/lib/legal/subprocessors.resolve.ts` (server-only signal gathering). Signals, all read from code rather than assumed:

| Processor | Signal | Source |
|---|---|---|
| Checkin / Tito | `conferenceProviderType` + `hasTicketingBinding`; explicit selection or a vendor `registrationLink` downgrades to *possible* | `@/lib/tickets/provider` |
| Pirsch | `conference.analyticsPirschCode` (raw, deliberately unvalidated) | `app/layout.tsx` gate |
| Slack | `resolveConferenceSlackToken(conference)`, coerced to a boolean at the call | `@/lib/slack/token` |
| WorkOS (AuthKit) | `isWorkshopsEnabledForConference` | `@/lib/features/workshops` |
| Resend | always disclosed; a per-org `email` secret changes the *account* clause | `@/lib/secrets/store` |
| Sanity, Vercel, GitHub/LinkedIn | unconditional platform infrastructure | root layout / NextAuth config |

Section 6's transfer list is now `internationalTransferProcessors(disclosure)` — derived from the **same** object, so a processor cannot be a transfer destination without also being a subprocessor. The WorkOS transfer block, the "WorkOS User ID" collection bullet, the WorkOS retention row and both WorkOS mentions in `/terms` are gated on the same answer.

## The two rules

**1. Never under-report.** Every signal is three-state — `yes` / `no` / **UNKNOWN** — and an UNKNOWN **discloses** the processor, badged *"May not apply to this event"*, rather than dropping it. Only a `no` derived from a **successful** read removes an entry.

**2. A failed read must not shorten the list.** Nearly every feature gate here fails **closed** on a rejected Sanity read — `resolveRegistryEntitlement` answers `'denied'`, `resolveEnabledFeaturesForOrg` logs *"treating every feature as DISABLED"*, `isSlackMirrorEnabledForOrg` swallows the rejection and returns `false`. Correct for handing out a credential; catastrophic for a disclosure. Deriving the list straight from those gates would silently publish a **shorter** subprocessor list for the length of an outage.

Neither gate exposes the difference, so the resolver **probes `getOrganizationById` for health first** — the same cached, `organizationTag`-tagged read the gates use, so it costs nothing extra — and a rejection sets `organizationReadFailed`, turning every org-gated signal UNKNOWN. A `null` result is *not* a failure: the read succeeded and the org does not exist, so the gates genuinely deny.

**Failure behaviour chosen, out of the two honest options:** *show the full possible set*, with a conspicuous notice naming which parts could not be confirmed. A privacy policy is where a data subject finds the controller's contact address and how to exercise their rights — content that depends on none of these reads. Replacing it with an error during a partial outage removes that to fix nothing.

**The one exception is the conference read itself.** With no conference document there is no controller to name and no configuration to read — nothing left to over-disclose *from* — so `/privacy` now checks `isConferenceUnavailable` **first** and renders "Privacy Policy Temporarily Unavailable". Both pages previously conflated outage with unknown-host because they dropped the resolution `status` when calling `isUnknownHost`; `/terms` rendered **blank** on an outage and now reaches its error branch.

## Also fixed: the wrong data controller (#848)

`fetchOrganizationLegal` answered a **rejected** read with the same `null` as "this tenant has no organization document", and `buildLegalConfig` then fell through to `PLATFORM_NAME`. A failed legal-entity read published **the platform as the data controller of a customer's event** — misdirecting every Article 15-21 request, and doing it inside a `cacheLife('hours')` scope.

`resolveLegalConfig` now returns an `ok` / `absent` / `unavailable` status, and **the controller fallback is gone entirely**: `controllerName` is org name → `conference.organizer` → `''`, with `controllerResolved` and `identityReadFailed` on the config. Both pages branch on it and say so instead of naming anyone. This is the same doctrine the file already applied to jurisdiction.

## Cloud Native Days Norway keeps an accurate page

Verified against the production dataset (read-only, unauthenticated), not assumed:

- All three conferences carry `checkinCustomerId` + `checkinEventId` with `ticketingProvider: null` → `hasTicketingBinding` is **true**, provider resolves **checkin**. → **Checkin.no, confirmed.**
- `analyticsPirschCode` set on all three → **Pirsch, confirmed.**
- `organization-cloud-native-days`: `plan: 'pro'`, **no** `featureOverrides`, **no** per-org secrets → Slack and workshops resolve through the platform-org default. → **Slack + WorkOS, confirmed.**
- No `TENANT_SECRETS_JSON` entry → Resend reads *"shared platform sending account"*.
- Nothing resolves UNKNOWN, so **no uncertainty badge and no amber notice appear** — asserted directly in the test.

**And then confirmed end-to-end on the deployed preview.** CNDN 2026 claims `*.vercel.app` in its `domains[]`, so the Vercel preview for this PR *is* their site, running against the production dataset and the real environment. `GET /privacy` on it returns exactly:

- **Checkin.no present, Tito absent.**
- **Pirsch Analytics, Slack, WorkOS (AuthKit) present.**
- Sanity.io, Vercel.com, Resend.com, GitHub/LinkedIn present, each labelled *"Shared platform infrastructure"*; Checkin/Pirsch/Slack labelled *"Selected by the event organizer"*.
- **No uncertainty badge and no amber notice** — every signal resolved.
- `Data Controller: Cloud Native Days Norway` (the organization document's legal name, not the platform and not the staler `conference.organizer` value "Cloud Native Bergen").
- Resend reads *"shared platform sending account"*.
- Section 6: *"The following providers may process data outside the EU/EEA: Vercel.com (United States), Resend.com (United States), Slack (United States), WorkOS (AuthKit) (United States)."*

That also settles the one thing I could not read directly: `PLATFORM_ORG_ID` is set to their org, since Slack and WorkOS resolve for them.

**This is a TEXT/DOM check of the deployed HTML, not visual verification** — see the last section.

## Verification

Baseline `origin/main` (80bab28) vs this branch, both measured in a **clean detached worktree** — a concurrent session has unrelated uncommitted work in the main checkout, so in-place numbers would have been contaminated.

| | before | after |
|---|---|---|
| `pnpm test` | 520 files / 7609 tests | **522 files / 7655 tests**, all passing |
| `tsc --noEmit` | clean | clean |
| `prettier --check .` | clean | clean |
| `eslint .` | 0 errors, 201 warnings | 0 errors, 201 warnings (unchanged, none in changed files) |
| `knip` | 1 pre-existing config hint | same hint, nothing new |

+46 tests = 25 (`subprocessors.test.ts`) + 17 (`legal-subprocessor-disclosure.test.tsx`) + 4 (`config.test.ts`). File and test counts held at **3 files / 58 tests on every sabotage run**, so nothing silently stopped collecting.

### Sabotage-proven

Each guard removed, suite run, the specific failures observed, guard restored, green re-confirmed.

| sabotage | failures |
|---|---|
| ticketing signal always answers Checkin (the pre-#690 default) | 4 — Tito tenant discloses Checkin; unbound conference discloses one |
| `organizationReadFailed` ignored in the pure builder | 1 — a hard `false` from the gates wins |
| org-read health probe removed from the resolver | 1 — Slack and WorkOS vanish during an outage |
| `PLATFORM_NAME` controller fallback restored | 4 — both pages name the platform as controller/counterparty |
| `isConferenceUnavailable` branch removed from `/privacy` | 1 — an outage renders a fabricated list instead of an error |
| per-org Resend key ignored | 1 — a dedicated account reads as the shared one |
| WorkOS ungated on `/terms` | 1 — a workshop-less tenant is told to sign in with AuthKit |
| transfer list built from the catalogue instead of the disclosure | 2 — Slack/WorkOS named as transfer destinations for everyone |

The page-level tests make the **Sanity client itself throw**, routed per query so the conference read and the organization reads fail independently — the dangerous case is a *healthy* conference read next to a *failing* org read, where the page renders happily and quietly drops processors. Every assertion is made in both directions; a test that only proved "Tito appears" would also pass on a build that listed every vendor for everyone, which is the bug.

## One thing for the owner to decide, not me

**Should the page name subprocessors we use on the tenant's behalf that the tenant never chose — our Vercel hosting, our Sanity dataset, our Resend account?**

I have **kept them listed**, and added a per-row label: *"Shared platform infrastructure"* vs *"Selected by the event organizer"*. My recommendation is to keep it that way: under Art. 28 they are sub-processors in the tenant's chain whether or not the tenant picked them, a DPA review will ask for them by name, and omitting them would be the exact under-disclosure this PR exists to remove. The label answers the question a reviewer is actually asking without hiding anything.

The alternative — a separate "Platform infrastructure" section with a sentence explaining that the organizer contracts with the platform, which in turn contracts with these — is a defensible presentation choice and is a small change on top of what is here. **Say the word and I will move it; I did not want to pick silently.**

## What I could NOT determine, and what I did not fix

- **YouTube / Vimeo embeds** (`src/components/VideoEmbed.tsx`) are a genuinely per-tenant processor — the iframe renders only when a talk or conference carries a video URL — and they are disclosed **nowhere**, before this PR or after. Determining it needs the privacy page to read talk records, which it does not do today. **Flagged, not guessed.** Worth its own issue.
- **`registrationLinkVendor` is a PROXY, not a fact.** Matching a vendor host in the organizer's external `registrationLink` only ever moves a signal from `no` to UNKNOWN — it never asserts use. Said so in the code comment and here.
- **Ticketing keys on the BINDING, not the credentials.** `resolveTicketingProvider` collapses "no credentials" into the same `configured: false` as "no event id", so asking it would drop the row for a conference plainly bound to a vendor and merely mid-provisioning. A binding present with credentials absent over-discloses — the direction this page is allowed to err in.
- **Pirsch reads the RAW field**, not `resolvePirschCode`. Validating here would drop the row on a typo, which is the under-report direction. A malformed code discloses Pirsch and serves no script.
- **Vercel's "United States" location is inherited from the previous copy**, not verified against this deployment's actual function region. It errs safe (over-disclosure) and matches what the page already said.
- **The workshop DATA-COLLECTION block is still unconditional** — capacity, waitlist, signup status. Only the WorkOS *mentions* inside it are gated. That is over-disclosure of the tenant's **own** processing, not of a subprocessor, so it is a copy problem rather than this PR's class. Left alone knowingly.
- **Web push / VAPID and badge signing are platform-global** and involve no third-party vendor beyond the recipient's own browser push service; badges are self-issued (Credly appears only as an outbound share link the recipient clicks). Neither was disclosed before and neither is added.
- **Vercel Blob** (CFP proposal attachments) was disclosed nowhere; it is now folded into the Vercel row's purpose text rather than given its own entry, since it is the same processor.
- **Dropped "GDPR compliant" from the Sanity row.** That is a legal claim about a third party that we are not in a position to certify on an organizer's behalf. "EU-based" stays.
- **No visual verification.** Playwright is broken on this machine and `pnpm shoot` cannot run. Six stories cover every state (`Components/SubprocessorList`: platform tenant, Tito customer, own email account, no ticketing vendor, organization read failed, nothing known) and CI publishes them — but **nobody has looked at the rendered pixels**.
- `lastUpdated` is bumped on both pages, because the disclosure text genuinely changed.

Refs #848
