### PR TITLE
fix(speaker,sponsor,badge): guard the seven MEDIUM by-id reads of the #863 census

### DIFF
--- a/__tests__/api/trpc/sponsor-activity.test.ts
+++ b/__tests__/api/trpc/sponsor-activity.test.ts
@@ -27,9 +27,19 @@ vi.mock('@/lib/sanity/client', () => ({
   clientWrite: { fetch: vi.fn(), patch: vi.fn(), transaction: vi.fn() },
   clientRead: { fetch: vi.fn() },
   clientReadUncached: {
+    // REFERENCE-OWNERSHIP PROBE (#863): `crm.create` also proves the `sponsor`
+    // ref it writes belongs to this org. These tests are about the ASSIGNMENT
+    // guard, so answer "ours" for the one sponsor id they use; the cross-tenant
+    // refusals live in `src/server/routers/tenancy.writes.sponsor.test.ts`.
     fetch: vi.fn(
-      async (_query: string, params: { ids?: string[] } = {}) =>
-        params.ids?.length ?? 0,
+      async (query: string, params: { ids?: string[]; id?: string } = {}) => {
+        if (query.includes('"memberOrgIds"')) {
+          return params.id === 'sponsor-1'
+            ? { _type: 'sponsor', orgId: 'org-test' }
+            : null
+        }
+        return params.ids?.length ?? 0
+      },
     ),
   },
 }))

--- a/__tests__/api/trpc/sponsor-contract-signature-guards.test.ts
+++ b/__tests__/api/trpc/sponsor-contract-signature-guards.test.ts
@@ -7,7 +7,7 @@ import {
   updateSponsorForConference,
 } from '@/lib/sponsor-crm/sanity'
 import { getContractTemplate } from '@/lib/sponsor-crm/contract-templates'
-import { clientWrite } from '@/lib/sanity/client'
+import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
 import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
 
 vi.mock('@/lib/conference/sanity')
@@ -98,6 +98,19 @@ beforeEach(() => {
     sponsorForConference: makeSfc(),
     error: undefined,
   })
+  // OWNERSHIP PROBE (#863). `crm.sendContract` now proves the client-supplied
+  // `templateId` belongs to this conference BEFORE anything else — a foreign
+  // template used to render straight into the PDF this conference signs. These
+  // cases are about the READINESS guards, so answer "ours" for the template id
+  // they pass; the cross-tenant refusal lives in
+  // `src/server/routers/tenancy.writes.sponsor.test.ts`.
+  vi.mocked(
+    clientReadUncached.fetch as never as ReturnType<typeof vi.fn>,
+  ).mockImplementation(async (query: string, params: { id?: string } = {}) =>
+    query.includes('"memberOrgIds"') && params.id === 'tmpl-1'
+      ? { _type: 'contractTemplate', conferenceId: 'conf-1' }
+      : null,
+  )
 })
 
 afterEach(() => {

--- a/__tests__/api/trpc/sponsor-pipeline-guards.test.ts
+++ b/__tests__/api/trpc/sponsor-pipeline-guards.test.ts
@@ -72,6 +72,31 @@ function makeSfc(
   }
 }
 
+/**
+ * REFERENCE-OWNERSHIP PROBE (#863). `crm.create`/`crm.update` now prove every
+ * reference id they write — `sponsor`, `tier`, `addons[]`, `contractTemplate` —
+ * belongs to this tenant before anything else runs. These tests are about the
+ * TIER INVARIANT, so answer "ours" for the ids they use; `deleted-tier` is
+ * deliberately left unknown, which is what "does not resolve" means to a probe.
+ * The cross-tenant refusals live in `src/server/routers/tenancy.writes.sponsor.test.ts`.
+ */
+const OWNED_TENANT: Record<string, Record<string, unknown>> = {
+  s1: { _type: 'sponsor', orgId: 'org-test' },
+  'tier-gold': { _type: 'sponsorTier', conferenceId: 'conf-1' },
+}
+
+function seedOwnershipProbe() {
+  vi.mocked(clientReadUncached.fetch as any).mockImplementation(
+    async (query: string, params: any = {}) => {
+      if (query.includes('"memberOrgIds"')) {
+        return OWNED_TENANT[params?.id as string] ?? null
+      }
+      if (query.startsWith('count(')) return params?.ids?.length ?? 0
+      return null
+    },
+  )
+}
+
 const createCaller = (speaker: any) =>
   appRouter.createCaller({
     session: { user: { email: speaker.email }, speaker },
@@ -107,6 +132,7 @@ describe('sponsor CRM pipeline tier invariant — all write paths', () => {
     })
     // Tiers resolve by default; reject-path tests override to false.
     vi.mocked(tierExists).mockResolvedValue(true)
+    seedOwnershipProbe()
   })
 
   afterEach(() => {

--- a/src/lib/badge/sanity.scoped.test.ts
+++ b/src/lib/badge/sanity.scoped.test.ts
@@ -15,7 +15,10 @@ vi.mock('../sanity/client', () => ({
   clientReadUncached: { fetch: (...a: unknown[]) => badgeFetch(...a) },
 }))
 
-import { getBadgeForConference } from './sanity'
+import {
+  getBadgeForConference,
+  listBadgesForSpeakerInConference,
+} from './sanity'
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -75,5 +78,49 @@ describe('getBadgeForConference is tenant-scoped at the query', () => {
 
     expect(result.reason).toBe('unavailable')
     expect(result.reason).not.toBe('not-found')
+  })
+})
+
+/**
+ * #863 row 9. `badge.admin.list?speakerId=…` read through a query filtered on
+ * `speaker._ref` alone. THE ROUTER TESTS CANNOT SEE THIS: they mock this
+ * function, so the conference predicate would exist only in the mock — which is
+ * exactly how the twelve census rows shipped. Assert it at the query.
+ */
+describe('listBadgesForSpeakerInConference is tenant-scoped at the query', () => {
+  it('constrains the read to BOTH the speaker and the conference', async () => {
+    badgeFetch.mockResolvedValue([])
+
+    await listBadgesForSpeakerInConference('sp-1', 'conf-A')
+
+    const [query, params] = badgeFetch.mock.calls[0]
+    expect(query).toContain('speaker._ref == $speakerId')
+    expect(query).toContain('conference._ref == $conferenceId')
+    expect(params).toEqual({ speakerId: 'sp-1', conferenceId: 'conf-A' })
+  })
+
+  it('carries the conference predicate UNCONDITIONALLY', async () => {
+    badgeFetch.mockResolvedValue([])
+
+    await listBadgesForSpeakerInConference('sp-1', 'conf-A')
+
+    const [query] = badgeFetch.mock.calls[0]
+    expect(query).not.toContain('defined($conferenceId)')
+  })
+
+  it('reads NOTHING when the conference is missing', async () => {
+    const result = await listBadgesForSpeakerInConference('sp-1', '')
+
+    expect(badgeFetch).not.toHaveBeenCalled()
+    expect(result.badges).toEqual([])
+  })
+
+  it('reports a failed read rather than an empty list', async () => {
+    badgeFetch.mockRejectedValue(new Error('ECONNREFUSED sanity.io'))
+
+    const result = await listBadgesForSpeakerInConference('sp-1', 'conf-A')
+
+    expect(result.badges).toBeUndefined()
+    expect(result.error).toBeInstanceOf(Error)
   })
 })

--- a/src/lib/badge/sanity.ts
+++ b/src/lib/badge/sanity.ts
@@ -306,13 +306,34 @@ export async function listBadgesForConference(
   }
 }
 
-export async function listBadgesForSpeaker(
+/**
+ * Every badge THIS CONFERENCE has issued to one speaker.
+ *
+ * WHY BOTH PREDICATES (#863). The previous `listBadgesForSpeaker` filtered on
+ * `speaker._ref` alone, so `badge.admin.list?speakerId=…` returned an arbitrary
+ * person's badges — including the `speaker->{email}` projection and the
+ * `emailSent`/`emailError` delivery state — to an organizer of any tenant. A
+ * speaker is a GLOBAL person shared across tenants (see `requireSpeakerInCurrentOrg`),
+ * so their id is not self-scoping: only the badge's own conference is.
+ *
+ * The conference predicate is UNCONDITIONAL and `conferenceId` is required — an
+ * optional one that degrades to "all tenants" when absent is the fail-open
+ * `optionalTenantFilter` shape `eslint-rules/no-unscoped-groq.js` reports. A
+ * foreign speaker is therefore indistinguishable from one with no badges: both
+ * are the empty list, so this cannot be used to probe who exists.
+ */
+export async function listBadgesForSpeakerInConference(
   speakerId: string,
+  conferenceId: string,
 ): Promise<{ badges?: BadgeRecord[]; error?: Error }> {
+  if (!speakerId || !conferenceId) {
+    return { badges: [] }
+  }
+
   try {
     const badges = await clientRead.fetch<BadgeRecord[]>(
-      `*[_type == "speakerBadge" && speaker._ref == $speakerId] | order(issuedAt desc) {${BADGE_FIELDS}}`,
-      { speakerId },
+      `*[_type == "speakerBadge" && speaker._ref == $speakerId && conference._ref == $conferenceId] | order(issuedAt desc) {${BADGE_FIELDS}}`,
+      { speakerId, conferenceId },
     )
 
     return { badges: badges || [] }

--- a/src/lib/speaker/sanity.projection.test.ts
+++ b/src/lib/speaker/sanity.projection.test.ts
@@ -72,7 +72,7 @@ const DROPPED_FIELDS = [
 
 async function capturedQuery(): Promise<string> {
   fetchMock.mockResolvedValue(null)
-  await getSpeakerAdminDetail('sp-1')
+  await getSpeakerAdminDetail('sp-1', 'org-A')
   return fetchMock.mock.calls[0][0] as string
 }
 
@@ -80,7 +80,8 @@ beforeEach(() => vi.clearAllMocks())
 
 describe('getSpeakerAdminDetail projects explicitly (#863)', () => {
   it('does not spread the document', async () => {
-    expect(await capturedQuery()).not.toContain('...')
+    const query = await capturedQuery()
+    expect(query.slice(query.indexOf('[0]{'))).not.toContain('...')
   })
 
   it('projects every field its type promises', async () => {
@@ -103,19 +104,46 @@ describe('getSpeakerAdminDetail projects explicitly (#863)', () => {
   })
 
   it('drops the identity and cross-tenant fields the census named', async () => {
+    // The PROJECTION only. `organizations` also appears in the root filter, as
+    // the membership half of the tenant predicate — which is the opposite of
+    // returning it.
     const query = await capturedQuery()
+    const projection = query.slice(query.indexOf('[0]{'))
     for (const field of DROPPED_FIELDS) {
-      expect(query).not.toContain(field)
+      expect(projection).not.toContain(field)
     }
   })
 
-  it('is still a by-id read, so the caller must guard it', async () => {
-    // Deliberately NOT scoped in GROQ. Speaker ownership is membership ∪
-    // participation and has one authoritative implementation
-    // (`requireSpeakerInCurrentOrg`); a second copy of it as a predicate here is
-    // a copy that can drift, and the copy that drifts fails open.
+  it('carries the org predicate as well as the id', async () => {
+    // An `_id` is a dataset-wide key and scopes nothing. The predicate is the
+    // SAME `SPEAKER_ORG_FILTER` the admin lists use, so this cannot return a
+    // person who is not already on this org's admin surface — a second control
+    // beside `requireSpeakerInCurrentOrg`, not a replacement for it.
     const query = await capturedQuery()
     expect(query).toContain('_id == $speakerId')
-    expect(query).not.toContain('$orgId')
+    expect(query).toContain('$orgId in coalesce(organizations, [])[]._ref')
+  })
+
+  it('carries it UNCONDITIONALLY, and reads nothing without an org', async () => {
+    // The fail-open shape this must never become is a predicate guarded by its
+    // own parameter (`!defined($orgId) || …`), which reads every tenant when the
+    // argument is absent — `optionalTenantFilter` in
+    // `eslint-rules/no-unscoped-groq.js`.
+    expect(await capturedQuery()).not.toContain('defined($orgId)')
+
+    vi.clearAllMocks()
+    const result = await getSpeakerAdminDetail('sp-1', '')
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.speaker).toBeNull()
+  })
+
+  it('answers a speaker outside the org exactly as it answers a missing one', async () => {
+    fetchMock.mockResolvedValue(null)
+
+    const result = await getSpeakerAdminDetail('sp-theirs', 'org-A')
+
+    expect(result.speaker).toBeNull()
+    expect(result.err).toBeNull()
   })
 })

--- a/src/lib/speaker/sanity.projection.test.ts
+++ b/src/lib/speaker/sanity.projection.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+/**
+ * #863 row 3. `speaker.admin.getById` read through `getSpeaker`, whose
+ * projection opens with a bare `...` over the speaker document — so the admin
+ * detail endpoint returned every field the schema has and every field it ever
+ * grows: the login match-set (`knownEmails`), the linked identity providers,
+ * and the OTHER tenants this global person belongs to (`organizations`).
+ *
+ * The guard on the procedure decides WHO may read; this projection decides WHAT
+ * is read, and the two are independent controls. TypeScript cannot enforce the
+ * second: a field the query forgot and a field the document lacks both arrive
+ * `undefined`, so a projection that silently drops something a consumer needs
+ * type-checks perfectly. Hence these cases — `FIELDS` below must mirror
+ * `SpeakerAdminDetail` exactly.
+ */
+const fetchMock = vi.fn()
+vi.mock('@/lib/sanity/client', () => ({
+  clientRead: { fetch: (...a: unknown[]) => fetchMock(...a) },
+  clientReadUncached: { fetch: (...a: unknown[]) => fetchMock(...a) },
+  clientReadCached: { fetch: (...a: unknown[]) => fetchMock(...a) },
+  clientWrite: { fetch: (...a: unknown[]) => fetchMock(...a) },
+}))
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationRefForCurrentConference: vi.fn(),
+}))
+vi.mock('next/cache', () => ({
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
+}))
+
+import { getSpeakerAdminDetail } from './sanity'
+
+/** Every member of `SpeakerAdminDetail`, which the query must project. */
+const FIELDS = [
+  '_id',
+  '_createdAt',
+  '_updatedAt',
+  'name',
+  'title',
+  'bio',
+  'email',
+  'links',
+  'flags',
+  'gender',
+  'genderSelfDescribe',
+  'country',
+  'consent',
+  'slug',
+  'image',
+]
+
+/**
+ * Dropped on purpose. `knownEmails` and `providers` describe how this person
+ * AUTHENTICATES, `organizations` names the other tenants they belong to, and the
+ * rest nothing on an admin surface reads. None of them administer a speaker.
+ *
+ * `imageURL` is NOT in this list even though it is not projected as a field: it
+ * is the fallback SOURCE inside `coalesce(image.asset->url, imageURL)`, which is
+ * how every other read resolves a display image.
+ */
+const DROPPED_FIELDS = [
+  'knownEmails',
+  'providers',
+  'organizations',
+  '_rev',
+  'messagingEmailDefault',
+  'pushSubscriptions',
+  'isOrganizer',
+  'organizerOrgIds',
+]
+
+async function capturedQuery(): Promise<string> {
+  fetchMock.mockResolvedValue(null)
+  await getSpeakerAdminDetail('sp-1')
+  return fetchMock.mock.calls[0][0] as string
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('getSpeakerAdminDetail projects explicitly (#863)', () => {
+  it('does not spread the document', async () => {
+    expect(await capturedQuery()).not.toContain('...')
+  })
+
+  it('projects every field its type promises', async () => {
+    const query = await capturedQuery()
+    for (const field of FIELDS) {
+      expect(query).toContain(field)
+    }
+  })
+
+  it('projects the fields the admin editor writes back', async () => {
+    // `SpeakerManagementModal` renders and submits these through
+    // `speaker.admin.update`. They are sensitive, and the control on them is the
+    // ownership guard — dropping them here would break the editor SILENTLY the
+    // moment it reads through this endpoint, exactly the trap `bankingDetails`
+    // was in #865.
+    const query = await capturedQuery()
+    for (const field of ['email', 'gender', 'country', 'consent']) {
+      expect(query).toContain(field)
+    }
+  })
+
+  it('drops the identity and cross-tenant fields the census named', async () => {
+    const query = await capturedQuery()
+    for (const field of DROPPED_FIELDS) {
+      expect(query).not.toContain(field)
+    }
+  })
+
+  it('is still a by-id read, so the caller must guard it', async () => {
+    // Deliberately NOT scoped in GROQ. Speaker ownership is membership ∪
+    // participation and has one authoritative implementation
+    // (`requireSpeakerInCurrentOrg`); a second copy of it as a predicate here is
+    // a copy that can drift, and the copy that drifts fails open.
+    const query = await capturedQuery()
+    expect(query).toContain('_id == $speakerId')
+    expect(query).not.toContain('$orgId')
+  })
+})

--- a/src/lib/speaker/sanity.ts
+++ b/src/lib/speaker/sanity.ts
@@ -852,23 +852,39 @@ export async function getSpeaker(
  * person's `knownEmails`, `providers` and other-tenant `organizations` to an
  * organizer. See the type for exactly what is dropped and what stays.
  *
- * IT IS NOT A TENANCY GUARD. The `_id` is a dataset-wide key, so this is still a
- * global by-id read; the caller MUST prove standing over `speakerId` first
- * (`requireSpeakerInCurrentOrg`), which is why the router guards BEFORE calling
- * this and never after. Speaker ownership is membership ∪ participation, which
- * has one authoritative implementation in `src/server/tenancy.ts` — expressing it
- * a third time as a GROQ predicate here would be a copy to keep in lockstep, and
- * the copy that drifts is the one that fails open.
+ * IT IS SCOPED, AND STILL NOT THE GUARD. An `_id` is a dataset-wide key, so a
+ * by-id read scopes nothing on its own; the predicate is the SAME
+ * `SPEAKER_ORG_FILTER` constant the admin lists use, so this returns a person
+ * only if they are already on this org's admin surface. `orgId` is REQUIRED and
+ * the predicate unconditional — an optional one degrading to "all tenants" is the
+ * fail-open `optionalTenantFilter` shape `eslint-rules/no-unscoped-groq.js`
+ * reports. A foreign speaker is therefore indistinguishable from a nonexistent
+ * one: both are `null`.
+ *
+ * The caller must STILL prove standing first, and does: `speaker.admin.getById`
+ * calls `requireSpeakerInCurrentOrg` and passes the org id THAT returns, so the
+ * authoritative decision stays in `src/server/tenancy.ts` and this predicate is
+ * the second, independent control rather than a competing implementation of the
+ * first.
  */
 export async function getSpeakerAdminDetail(
   speakerId: string,
+  orgId: string,
 ): Promise<{ speaker: SpeakerAdminDetail | null; err: Error | null }> {
   let speaker: SpeakerAdminDetail | null = null
   let err = null
 
+  if (!speakerId || !orgId) return { speaker: null, err: null }
+
   try {
     speaker = await clientRead.fetch<SpeakerAdminDetail | null>(
-      `*[ _type == "speaker" && _id == $speakerId][0]{
+      // groq-global-scoped: the tenant predicate is membership ∨ participation —
+      // the same terms as `SPEAKER_ORG_FILTER` above and as
+      // `requireSpeakerInCurrentOrg`. Written out in full rather than
+      // interpolated for the same reason `requireSpeakersInCurrentOrg` writes it
+      // out: what this call site admits should be readable here, and a `${...}`
+      // inside a root filter is scoping neither review nor this rule can see.
+      `*[ _type == "speaker" && _id == $speakerId && ($orgId in coalesce(organizations, [])[]._ref || count(*[_type == "talk" && references(^._id) && conference->organization._ref == $orgId]) > 0)][0]{
       _id,
       _createdAt,
       _updatedAt,
@@ -885,7 +901,7 @@ export async function getSpeakerAdminDetail(
       "slug": slug.current,
       "image": coalesce(image.asset->url, imageURL)
     }`,
-      { speakerId },
+      { speakerId, orgId },
       { cache: 'no-store' },
     )
   } catch (error) {

--- a/src/lib/speaker/sanity.ts
+++ b/src/lib/speaker/sanity.ts
@@ -1,4 +1,4 @@
-import { Speaker, SpeakerInput } from '@/lib/speaker/types'
+import { Speaker, SpeakerAdminDetail, SpeakerInput } from '@/lib/speaker/types'
 import {
   clientReadUncached as clientRead,
   clientWrite,
@@ -829,6 +829,61 @@ export async function getSpeaker(
       "image": coalesce(image.asset->url, imageURL),
       ${IS_ORGANIZER_FIELD},
       ${ORGANIZER_ORG_IDS_FIELD}
+    }`,
+      { speakerId },
+      { cache: 'no-store' },
+    )
+  } catch (error) {
+    err = error as Error
+  }
+
+  return { speaker, err }
+}
+
+/**
+ * The ADMIN-DETAIL read behind `speaker.admin.getById`, explicitly projected
+ * against {@link SpeakerAdminDetail} (#863).
+ *
+ * WHY IT IS A SEPARATE FUNCTION rather than a narrower `getSpeaker`. That one is
+ * the SELF read — the CFP profile page, `speaker.getCurrent` and the auth token
+ * all go through it and legitimately need the whole document, including the
+ * login/identity fields. Narrowing it would break a person's own profile editor.
+ * What was wrong was an ADMIN endpoint reusing the self read and so returning a
+ * person's `knownEmails`, `providers` and other-tenant `organizations` to an
+ * organizer. See the type for exactly what is dropped and what stays.
+ *
+ * IT IS NOT A TENANCY GUARD. The `_id` is a dataset-wide key, so this is still a
+ * global by-id read; the caller MUST prove standing over `speakerId` first
+ * (`requireSpeakerInCurrentOrg`), which is why the router guards BEFORE calling
+ * this and never after. Speaker ownership is membership ∪ participation, which
+ * has one authoritative implementation in `src/server/tenancy.ts` — expressing it
+ * a third time as a GROQ predicate here would be a copy to keep in lockstep, and
+ * the copy that drifts is the one that fails open.
+ */
+export async function getSpeakerAdminDetail(
+  speakerId: string,
+): Promise<{ speaker: SpeakerAdminDetail | null; err: Error | null }> {
+  let speaker: SpeakerAdminDetail | null = null
+  let err = null
+
+  try {
+    speaker = await clientRead.fetch<SpeakerAdminDetail | null>(
+      `*[ _type == "speaker" && _id == $speakerId][0]{
+      _id,
+      _createdAt,
+      _updatedAt,
+      name,
+      title,
+      bio,
+      email,
+      links,
+      flags,
+      gender,
+      genderSelfDescribe,
+      country,
+      consent,
+      "slug": slug.current,
+      "image": coalesce(image.asset->url, imageURL)
     }`,
       { speakerId },
       { cache: 'no-store' },

--- a/src/lib/speaker/types.ts
+++ b/src/lib/speaker/types.ts
@@ -168,6 +168,49 @@ export interface Speaker extends SpeakerBase {
   messagingEmailDefault?: boolean
 }
 
+/**
+ * The exact payload `speaker.admin.getById` puts on the wire, and the return
+ * type of {@link getSpeakerAdminDetail} — the two are narrowed in LOCKSTEP on
+ * purpose (#863).
+ *
+ * `getSpeaker` opens with a bare `...` over the speaker document, so the admin
+ * detail endpoint shipped every field the schema has and every field it ever
+ * grows: `knownEmails` and `providers` (the login match-set and linked identity
+ * providers), `organizations` (every OTHER tenant this person belongs to), and
+ * the two whole-dataset computed fields. None of those administer a person;
+ * they describe how they authenticate and who else they work with.
+ *
+ * WHAT DELIBERATELY STAYS: `email`, `gender`, `genderSelfDescribe`, `country`
+ * and `consent`. Those are exactly the fields `SpeakerManagementModal` renders
+ * and writes back through `speaker.admin.update`, so dropping them would break
+ * the admin editor the moment it reads through this endpoint — the same trap
+ * `bankingDetails` was in #865. They are sensitive, and the fix for reading
+ * them across tenants is the ownership guard, not a thinner projection.
+ *
+ * An explicit projection that forgets a needed field fails SILENTLY (`undefined`,
+ * not an error), so this type is the check: a consumer reading a dropped field
+ * is a compile error. `sanity.projection.test.ts` additionally asserts the field
+ * list against the query text, because TypeScript cannot tell a field the query
+ * forgot from one the document simply lacks.
+ */
+export interface SpeakerAdminDetail {
+  _id: string
+  _createdAt: string
+  _updatedAt: string
+  name: string
+  slug?: string
+  title?: string
+  bio?: string
+  email: string
+  links?: string[]
+  flags?: Flags[]
+  gender?: Gender | null
+  genderSelfDescribe?: string | null
+  country?: string | null
+  consent?: SpeakerConsent
+  image?: string
+}
+
 export interface SpeakerWithTalks extends Speaker {
   talks?: ProposalExisting[]
 }

--- a/src/server/routers/badge.tenancy.test.ts
+++ b/src/server/routers/badge.tenancy.test.ts
@@ -1,7 +1,8 @@
 /**
  * @vitest-environment node
  *
- * CROSS-TENANT DELIVERY for badges (#863, HIGH).
+ * CROSS-TENANT DELIVERY AND READS for badges (#863, HIGH row 2 + MEDIUM rows
+ * 8-9).
  *
  * `badge.admin.resendEmail` looked a badge up with `getBadgeById` — a by-PUBLIC-id
  * read with no conference predicate — and then MAILED whichever speaker came
@@ -17,6 +18,18 @@
  * foreign badge, and these tests fail on the ADDRESS THAT GETS MAILED, not on an
  * error message that moved. The predicate itself is pinned separately, at the
  * query, in `src/lib/badge/sanity.scoped.test.ts`.
+ *
+ * The two MEDIUM rows are the READ siblings of the same defect, and they are
+ * asserted the same way — on the badge and the speaker email that come back:
+ *
+ *   - row 8, `admin.getById`, also went through `getBadgeById`. `BADGE_FIELDS`
+ *     projects `speaker->{email, talks[]->}` and the `emailSent`/`emailError`
+ *     delivery state, so it returned strictly more about another tenant's
+ *     speaker than the PUBLIC `verify` on the same id does.
+ *   - row 9, `admin.list`'s `speakerId` branch, filtered on `speaker._ref`
+ *     alone. A speaker is a GLOBAL person who may hold badges from several
+ *     conferences, so that id scopes nothing — which is why the fixture below
+ *     gives one shared speaker a badge in each tenant.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
@@ -34,6 +47,8 @@ const h = vi.hoisted(() => ({
   getConference: vi.fn(),
   getBadgeById: vi.fn(),
   getBadgeForConference: vi.fn(),
+  listBadgesForSpeakerInConference: vi.fn(),
+  listBadgesForConference: vi.fn(),
   sendBadgeEmailWithRetry: vi.fn(),
   getSpeaker: vi.fn(),
 }))
@@ -44,8 +59,8 @@ vi.mock('@/lib/conference/sanity', () => ({
 vi.mock('@/lib/badge/sanity', () => ({
   getBadgeById: h.getBadgeById,
   getBadgeForConference: h.getBadgeForConference,
-  listBadgesForConference: vi.fn(),
-  listBadgesForSpeaker: vi.fn(),
+  listBadgesForConference: h.listBadgesForConference,
+  listBadgesForSpeakerInConference: h.listBadgesForSpeakerInConference,
   deleteBadge: vi.fn(),
 }))
 vi.mock('@/lib/email/badge', () => ({
@@ -99,11 +114,16 @@ function ctx(): Context {
 
 const badge = () => t.createCallerFactory(badgeRouter)(ctx())
 
-function badgeRecord(badgeId: string, conferenceId: string, email: string) {
+function badgeRecord(
+  badgeId: string,
+  conferenceId: string,
+  email: string,
+  speakerId = `sp-${badgeId}`,
+) {
   return {
     _id: `doc-${badgeId}`,
     badgeId,
-    speaker: { _id: `sp-${badgeId}`, name: 'Speaker', email },
+    speaker: { _id: speakerId, name: 'Speaker', email },
     conference: {
       _id: conferenceId,
       title: 'Their Conference',
@@ -113,10 +133,29 @@ function badgeRecord(badgeId: string, conferenceId: string, email: string) {
   }
 }
 
+/**
+ * The same human, holding a badge from each tenant — the case a `speaker._ref`
+ * filter cannot tell apart, and the reason row 9 needed a conference predicate
+ * rather than a speaker-ownership check.
+ */
+const SHARED_SPEAKER = 'sp-shared'
+
 /** The whole dataset, keyed by the public badge id the caller supplies. */
 const dataset: Record<string, ReturnType<typeof badgeRecord>> = {
   'badge-ours': badgeRecord('badge-ours', CONF_A, OUR_EMAIL),
   'badge-theirs': badgeRecord('badge-theirs', CONF_B, FOREIGN_EMAIL),
+  'badge-shared-ours': badgeRecord(
+    'badge-shared-ours',
+    CONF_A,
+    OUR_EMAIL,
+    SHARED_SPEAKER,
+  ),
+  'badge-shared-theirs': badgeRecord(
+    'badge-shared-theirs',
+    CONF_B,
+    FOREIGN_EMAIL,
+    SHARED_SPEAKER,
+  ),
 }
 
 /** Every address `sendBadgeEmailWithRetry` was asked to deliver to. */
@@ -164,6 +203,23 @@ beforeEach(() => {
       return { badge: found }
     },
   )
+  // The SCOPED speaker list, over the same dataset. The `!conferenceId` arm
+  // models the FAIL-OPEN shape this must never become — a tenant predicate that
+  // degrades to "all tenants" when its argument is absent
+  // (`optionalTenantFilter` in `eslint-rules/no-unscoped-groq.js`), which is
+  // also what the pre-fix `listBadgesForSpeaker` did unconditionally. It is here
+  // so that dropping the router's `conferenceId` argument fails these tests on
+  // the FOREIGN BADGE COMING BACK rather than on an empty result.
+  h.listBadgesForSpeakerInConference.mockImplementation(
+    async (speakerId: string, conferenceId?: string) => ({
+      badges: Object.values(dataset).filter(
+        (b) =>
+          b.speaker._id === speakerId &&
+          (!conferenceId || b.conference._id === conferenceId),
+      ),
+    }),
+  )
+  h.listBadgesForConference.mockResolvedValue({ badges: [] })
   h.sendBadgeEmailWithRetry.mockResolvedValue({ success: true, emailId: 'e-1' })
   h.getSpeaker.mockResolvedValue({ speaker: null, err: null })
   vi.spyOn(console, 'warn').mockImplementation(() => {})
@@ -258,5 +314,106 @@ describe('badge.admin.resendEmail is conference-scoped (#863)', () => {
       speakerEmail: OUR_EMAIL,
       conferenceName: 'Their Conference',
     })
+  })
+})
+
+describe('badge.admin.getById is conference-scoped (#863 row 8)', () => {
+  it('does not return another tenant’s badge, speaker email included', async () => {
+    const outcome = await settle(
+      badge().admin.getById({ badgeId: 'badge-theirs' }),
+    )
+
+    // Unguarded this RESOLVES with the foreign record, so the first assertion
+    // fails on the document itself — `speaker.email` is the field the census
+    // named, and `verify` on the same id never returns it.
+    expect(outcome.value).toBeUndefined()
+    expect(outcome.error).toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'Badge not found',
+    })
+  })
+
+  it('asks WITHIN the request’s conference and never uses the public read', async () => {
+    await settle(badge().admin.getById({ badgeId: 'badge-theirs' }))
+
+    expect(h.getBadgeForConference).toHaveBeenCalledWith('badge-theirs', CONF_A)
+    expect(h.getBadgeById).not.toHaveBeenCalled()
+  })
+
+  it('answers a foreign badge exactly as it answers a nonexistent one', async () => {
+    const foreign = await settle(
+      badge().admin.getById({ badgeId: 'badge-theirs' }),
+    )
+    const missing = await settle(
+      badge().admin.getById({ badgeId: 'no-such-badge' }),
+    )
+
+    expect(foreign.error).toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'Badge not found',
+    })
+    expect(missing.error).toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'Badge not found',
+    })
+  })
+
+  it('still returns OUR OWN badge in full', async () => {
+    const outcome = await settle(
+      badge().admin.getById({ badgeId: 'badge-ours' }),
+    )
+
+    expect(outcome.error).toBeUndefined()
+    expect(outcome.value).toMatchObject({
+      badgeId: 'badge-ours',
+      speaker: { email: OUR_EMAIL },
+    })
+  })
+
+  it('a read FAILURE is still a 500, not a not-found', async () => {
+    // #848: an unreadable store must not be laundered into "no such badge".
+    h.getBadgeForConference.mockResolvedValue({
+      error: new Error('dataset unreachable'),
+      reason: 'unavailable',
+    })
+
+    const outcome = await settle(
+      badge().admin.getById({ badgeId: 'badge-ours' }),
+    )
+
+    expect(outcome.error).toMatchObject({ code: 'INTERNAL_SERVER_ERROR' })
+  })
+})
+
+describe('badge.admin.list speakerId branch is conference-scoped (#863 row 9)', () => {
+  /** Every badge id the caller got back. */
+  const idsOf = (badges: unknown) =>
+    (badges as { badgeId: string }[]).map((b) => b.badgeId)
+
+  it('returns only THIS conference’s badges for a speaker both tenants share', async () => {
+    const badges = await badge().admin.list({ speakerId: SHARED_SPEAKER })
+
+    // Unscoped, this list also holds `badge-shared-theirs` — the other tenant's
+    // badge for the same person, carrying their conference's speaker email and
+    // its delivery state. Assert the exact set, so a leak is a failing VALUE.
+    expect(idsOf(badges)).toEqual(['badge-shared-ours'])
+    expect(JSON.stringify(badges)).not.toContain(FOREIGN_EMAIL)
+  })
+
+  it('passes the request’s conference to the lookup', async () => {
+    await badge().admin.list({ speakerId: SHARED_SPEAKER })
+
+    expect(h.listBadgesForSpeakerInConference).toHaveBeenCalledWith(
+      SHARED_SPEAKER,
+      CONF_A,
+    )
+  })
+
+  it('returns nothing for a speaker who has no badge here', async () => {
+    // A speaker of another tenant entirely is the same empty list as a speaker
+    // with no badges — the branch cannot be used to probe who exists.
+    const badges = await badge().admin.list({ speakerId: 'sp-badge-theirs' })
+
+    expect(idsOf(badges)).toEqual([])
   })
 })

--- a/src/server/routers/badge.ts
+++ b/src/server/routers/badge.ts
@@ -31,7 +31,7 @@ import {
   getBadgeById,
   getBadgeForConference,
   listBadgesForConference,
-  listBadgesForSpeaker,
+  listBadgesForSpeakerInConference,
   deleteBadge,
 } from '@/lib/badge/sanity'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
@@ -312,8 +312,18 @@ export const badgeRouter = router({
       .query(async ({ input }) => {
         try {
           if (input.speakerId) {
-            const { badges, error } = await listBadgesForSpeaker(
+            // OWNERSHIP (#863). This branch filtered on `speaker._ref` alone.
+            // A speaker is a GLOBAL person, so their id is a dataset-wide key
+            // rather than a tenant boundary, and an organizer of tenant A could
+            // list tenant B's badges for anyone — with B's speaker email and
+            // B's delivery status attached. The conference predicate now lives
+            // in the query, so no foreign badge enters the request at all and a
+            // speaker outside this conference is the same empty list as one
+            // with no badges.
+            const conferenceId = await resolveConferenceId()
+            const { badges, error } = await listBadgesForSpeakerInConference(
               input.speakerId,
+              conferenceId,
             )
             if (error) {
               throw new TRPCError({
@@ -350,9 +360,24 @@ export const badgeRouter = router({
       .input(BadgeIdInputSchema)
       .query(async ({ input }) => {
         try {
-          const { badge, error } = await getBadgeById(input.badgeId)
+          // OWNERSHIP (#863). `getBadgeById` filters on the PUBLIC `badgeId`
+          // with no conference predicate, which is right for the public
+          // verification surface and wrong here: `BADGE_FIELDS` projects
+          // `speaker->{email, talks[]->}` plus the `emailSent`/`emailError`
+          // delivery state, i.e. strictly more than the public `verify`
+          // returns. Read through the scoped lookup instead, so an organizer
+          // of another tenant gets the same 'Badge not found' as for an id
+          // that does not exist.
+          const conferenceId = await resolveConferenceId()
+          const { badge, error, reason } = await getBadgeForConference(
+            input.badgeId,
+            conferenceId,
+          )
 
-          if (error) {
+          // A FAILED read is not a verdict (#848): only `unavailable` is a 500.
+          // `not-found` covers "no such badge" and "not this conference's"
+          // alike, which is the point — the two must be indistinguishable.
+          if (reason === 'unavailable') {
             throw new TRPCError({
               code: 'INTERNAL_SERVER_ERROR',
               message: 'Failed to fetch badge',

--- a/src/server/routers/speaker.ts
+++ b/src/server/routers/speaker.ts
@@ -18,6 +18,7 @@ import {
 import { mergeSpeakers, MergeValidationError } from '@/lib/speaker/merge'
 import {
   getSpeaker,
+  getSpeakerAdminDetail,
   updateSpeaker,
   getOrganizers,
   getSpeakers,
@@ -396,7 +397,18 @@ export const speakerRouter = router({
       }),
 
     getById: adminProcedure.input(IdParamSchema).query(async ({ input }) => {
-      const { speaker, err } = await getSpeaker(input.id)
+      // OWNERSHIP (#863). `adminProcedure` proves only that the caller organizes
+      // SOME org, and `input.id` is client input, so without this an organizer of
+      // tenant A could read any person in the dataset. The guard runs BEFORE the
+      // fetch, so a foreign speaker's document never enters the request — and it
+      // refuses a foreign id with the same NOT_FOUND as a nonexistent one, so
+      // there is no existence oracle either. Its siblings `update` and `delete`
+      // were already guarded this way; this read was not.
+      await requireSpeakerInCurrentOrg(input.id)
+
+      // The narrowed projection (#863), NOT the self read `getSpeaker`, which
+      // spreads the whole document — see `SpeakerAdminDetail`.
+      const { speaker, err } = await getSpeakerAdminDetail(input.id)
 
       if (err) {
         throw new TRPCError({

--- a/src/server/routers/speaker.ts
+++ b/src/server/routers/speaker.ts
@@ -404,11 +404,13 @@ export const speakerRouter = router({
       // refuses a foreign id with the same NOT_FOUND as a nonexistent one, so
       // there is no existence oracle either. Its siblings `update` and `delete`
       // were already guarded this way; this read was not.
-      await requireSpeakerInCurrentOrg(input.id)
+      const orgId = await requireSpeakerInCurrentOrg(input.id)
 
       // The narrowed projection (#863), NOT the self read `getSpeaker`, which
-      // spreads the whole document — see `SpeakerAdminDetail`.
-      const { speaker, err } = await getSpeakerAdminDetail(input.id)
+      // spreads the whole document — see `SpeakerAdminDetail`. It carries the
+      // org predicate too, using the id the guard just proved: two independent
+      // controls, and the read cannot be reached with an unresolved tenant.
+      const { speaker, err } = await getSpeakerAdminDetail(input.id, orgId)
 
       if (err) {
         throw new TRPCError({

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -318,6 +318,53 @@ async function assertTierResolvable(
 }
 
 /**
+ * REFERENCE-INJECTION GUARD for the CRM pipeline record (#863, the #731 F1/F4
+ * shape).
+ *
+ * `crm.create` / `crm.update` write four client-supplied ids into reference
+ * fields of a `sponsorForConference` this org DOES own: `sponsor`, `tier`,
+ * `addons[]` and `contractTemplate`. No foreign document is patched, so the
+ * existing `requireDocument*` guards on the record itself never saw these — but
+ * every scoped view that reads the record DEREFERENCES them. A foreign
+ * `sponsor` puts another tenant's company name, org number and address into this
+ * tenant's pipeline list, board and CSV exports; a foreign `tier` puts their
+ * pricing there and, via `contractTemplate`, their contract terms into the PDF
+ * this conference sends out. `assertTierResolvable` was the only check in place
+ * and it only ever asked whether the id EXISTS — dataset-wide, which for a
+ * dataset-wide key is no check at all.
+ *
+ * Each id is proved on its OWN type's boundary: `sponsor` is org-owned (as
+ * `sponsor.getById`/`update`/`delete` already treat it), tiers, add-ons — which
+ * are `sponsorTier` documents too — and contract templates are conference-owned.
+ * A nonexistent id and another tenant's id both refuse as NOT_FOUND, so this
+ * adds no existence oracle. Add-ons go through the PLURAL form, which refuses the
+ * whole array unless every id is ours: a partial apply would write the foreign
+ * half of the request while reporting success.
+ */
+async function assertCrmReferencesAreOurs(refs: {
+  sponsor?: string
+  tier?: string | null
+  addons?: string[]
+  contractTemplate?: string | null
+}): Promise<void> {
+  if (refs.sponsor) {
+    await requireDocumentInCurrentOrg(refs.sponsor, 'sponsor')
+  }
+  if (refs.tier) {
+    await requireDocumentInCurrentConference(refs.tier, 'sponsorTier')
+  }
+  if (refs.addons && refs.addons.length > 0) {
+    await requireDocumentsInCurrentConference(refs.addons, 'sponsorTier')
+  }
+  if (refs.contractTemplate) {
+    await requireDocumentInCurrentConference(
+      refs.contractTemplate,
+      'contractTemplate',
+    )
+  }
+}
+
+/**
  * SE-3: sanitize sponsor logo SVG fields SERVER-SIDE before persistence.
  *
  * Sponsor logos are `inlineSvg` strings uploaded by organizers (SponsorAddModal)
@@ -971,6 +1018,10 @@ export const sponsorRouter = router({
           tags: input.tags as SponsorTag[] | undefined,
         }
 
+        // OWNERSHIP of every reference this record will carry (#863), before any
+        // read or write touches them.
+        await assertCrmReferencesAreOurs(data)
+
         // Note: This is a check-then-act pattern. Sanity does not support
         // atomic transactions, so two concurrent requests could both pass this
         // check before either creates the record. In practice this is
@@ -1054,6 +1105,11 @@ export const sponsorRouter = router({
       .input(SponsorForConferenceUpdateSchema)
       .mutation(async ({ input, ctx }) => {
         const { id, ...updateData } = input
+
+        // OWNERSHIP of every reference this edit would write (#863). `sponsor`
+        // is not editable here, but `tier`, `addons[]` and `contractTemplate`
+        // are — and they are refused before the record is even read.
+        await assertCrmReferencesAreOurs(updateData)
 
         // Fetch existing data for change detection
         const { sponsorForConference: existing } =
@@ -1718,6 +1774,21 @@ export const sponsorRouter = router({
         )
         .query(async ({ input }) => {
           if (input.sponsorForConferenceId) {
+            // OWNERSHIP (#863). `listActivitiesForSponsor` filters on
+            // `sponsorForConference._ref == $sponsorId` and nothing else, so
+            // this branch handed an organizer of any tenant another tenant's
+            // CRM notes — free-text negotiation history plus the `createdBy`
+            // author names. The other branch below was already conference-
+            // scoped, and the sibling `activities.create` already guards the
+            // same id; only this read did not.
+            //
+            // Guarded BEFORE the fetch, so the foreign activities never enter
+            // the request, and a foreign id refuses identically to a
+            // nonexistent one.
+            await requireDocumentInCurrentConference(
+              input.sponsorForConferenceId,
+              'sponsorForConference',
+            )
             const { activities, error } = await listActivitiesForSponsor(
               input.sponsorForConferenceId,
               input.limit,
@@ -2021,6 +2092,18 @@ export const sponsorRouter = router({
       .input(SendContractSchema)
       .mutation(async ({ input, ctx }) => {
         const logCtx = `[sendContract] sfc=${input.sponsorForConferenceId}`
+
+        // OWNERSHIP (#863). The `sponsorForConferenceId` half is scoped by
+        // `getSponsorForCurrentConference`, but `templateId` is a SECOND piece
+        // of client input and `getContractTemplate` is a global by-id read — so
+        // an organizer could render ANOTHER tenant's contract terms into the PDF
+        // this conference then signs and mails out. Guarded FIRST, before any
+        // lookup, so no foreign document enters the request at all; the sibling
+        // `contractTemplates.get/update/delete` guard the same way.
+        await requireDocumentInCurrentConference(
+          input.templateId,
+          'contractTemplate',
+        )
 
         const { sponsorForConference: sfc, error: sfcError } =
           await getSponsorForCurrentConference(input.sponsorForConferenceId)
@@ -3394,6 +3477,16 @@ export const sponsorRouter = router({
     generatePdf: adminProcedure
       .input(GenerateContractPdfSchema)
       .mutation(async ({ input }) => {
+        // OWNERSHIP (#863). Same defect as `crm.sendContract`, and worse in one
+        // respect: the rendered template comes straight back to the caller as a
+        // base64 PDF, so a foreign template's full terms were readable without
+        // sending anything. Guard first — the document must not be fetched at
+        // all for an id we do not own.
+        await requireDocumentInCurrentConference(
+          input.templateId,
+          'contractTemplate',
+        )
+
         const { template, error: templateError } = await getContractTemplate(
           input.templateId,
         )

--- a/src/server/routers/tenancy.writes.sponsor.test.ts
+++ b/src/server/routers/tenancy.writes.sponsor.test.ts
@@ -28,6 +28,12 @@ const h = vi.hoisted(() => ({
   getConference: vi.fn(),
   /** What the ownership probe reports for the id under test. */
   tenant: null as Record<string, unknown> | null,
+  /**
+   * PER-ID answers, for the procedures that carry SEVERAL client-supplied ids at
+   * once (#863 row 7: `sponsor`, `tier`, `addons[]`, `contractTemplate`). Falls
+   * back to `tenant` for any id not listed.
+   */
+  tenantById: {} as Record<string, Record<string, unknown> | null>,
   /** How many of a bulk request's ids the scoped count reports as ours. */
   ownedCount: 0,
   writes: [] as string[],
@@ -38,8 +44,12 @@ vi.mock('@/lib/conference/sanity', () => ({
 }))
 
 vi.mock('@/lib/sanity/client', () => {
-  const fetch = async (query: string) => {
-    if (query.includes('"memberOrgIds"')) return h.tenant
+  const fetch = async (query: string, params?: Record<string, unknown>) => {
+    if (query.includes('"memberOrgIds"')) {
+      const id = params?.id as string | undefined
+      if (id && id in h.tenantById) return h.tenantById[id]
+      return h.tenant
+    }
     if (query.startsWith('count(')) return h.ownedCount
     return null
   }
@@ -81,6 +91,11 @@ const lib = vi.hoisted(() => ({
   bulkDeleteSponsors: vi.fn(),
   deleteSponsorForConference: vi.fn(),
   createSponsorActivity: vi.fn(),
+  listActivitiesForSponsor: vi.fn(),
+  listActivitiesForConference: vi.fn(),
+  getSponsorForConference: vi.fn(),
+  createSponsorForConference: vi.fn(),
+  updateSponsorForConference: vi.fn(),
   getContractTemplate: vi.fn(),
   updateContractTemplate: vi.fn(),
   deleteContractTemplate: vi.fn(),
@@ -102,6 +117,14 @@ vi.mock('@/lib/sponsor-crm/bulk', () => ({
 vi.mock('@/lib/sponsor-crm/sanity', async (importOriginal) => ({
   ...((await importOriginal()) as Record<string, unknown>),
   deleteSponsorForConference: lib.deleteSponsorForConference,
+  getSponsorForConference: lib.getSponsorForConference,
+  createSponsorForConference: lib.createSponsorForConference,
+  updateSponsorForConference: lib.updateSponsorForConference,
+}))
+vi.mock('@/lib/sponsor-crm/activities', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  listActivitiesForSponsor: lib.listActivitiesForSponsor,
+  listActivitiesForConference: lib.listActivitiesForConference,
 }))
 vi.mock('@/lib/sponsor-crm/activity', async (importOriginal) => ({
   ...((await importOriginal()) as Record<string, unknown>),
@@ -150,6 +173,36 @@ function ctx(): Context {
 
 const sponsor = () => t.createCallerFactory(sponsorRouter)(ctx())
 
+/**
+ * What an unguarded `crm.activities.list` handed back: another tenant's
+ * free-text negotiation notes, with the organizer who wrote them named.
+ */
+const FOREIGN_ACTIVITY = {
+  _id: 'act-B',
+  activityType: 'note',
+  description: 'They will not go above 40k — push the gold tier at renewal.',
+  createdBy: { _id: 'sp-B', name: 'Their Organizer' },
+}
+
+/** A tenancy answer for ONE id, for the multi-reference procedures. */
+function tenantOf(kind: 'ours' | 'theirs', type: string) {
+  return kind === 'ours'
+    ? {
+        _type: type,
+        orgId: ORG_A,
+        conferenceId: CONF_A,
+        conferenceOrgId: ORG_A,
+        memberOrgIds: [],
+      }
+    : {
+        _type: type,
+        orgId: 'org-B',
+        conferenceId: 'conf-OTHER',
+        conferenceOrgId: 'org-B',
+        memberOrgIds: [],
+      }
+}
+
 /** The probe reports the target as belonging to ANOTHER tenant. */
 function foreign(type: string) {
   h.tenant = {
@@ -175,6 +228,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   h.writes.length = 0
   h.tenant = null
+  h.tenantById = {}
   h.ownedCount = 0
   h.getConference.mockResolvedValue({
     conference: { _id: CONF_A, organization: { _ref: ORG_A } },
@@ -215,6 +269,26 @@ beforeEach(() => {
     error: null,
   })
   lib.deleteContractTemplate.mockResolvedValue({ error: null })
+  lib.listActivitiesForSponsor.mockResolvedValue({
+    activities: [FOREIGN_ACTIVITY],
+    error: null,
+  })
+  lib.listActivitiesForConference.mockResolvedValue({
+    activities: [],
+    error: null,
+  })
+  lib.getSponsorForConference.mockResolvedValue({
+    sponsorForConference: undefined,
+    error: undefined,
+  })
+  lib.createSponsorForConference.mockResolvedValue({
+    sponsorForConference: { _id: 'sfc-new' },
+    error: undefined,
+  })
+  lib.updateSponsorForConference.mockResolvedValue({
+    sponsorForConference: { _id: 'sfc-A' },
+    error: undefined,
+  })
   vi.spyOn(console, 'warn').mockImplementation(() => {})
   vi.spyOn(console, 'error').mockImplementation(() => {})
 })
@@ -446,6 +520,251 @@ describe('contract templates are conference-scoped (#730)', () => {
       sponsor().contractTemplates.delete({ id: 'tpl-A' }),
     ).resolves.toBeTruthy()
     expect(lib.deleteContractTemplate).toHaveBeenCalledWith('tpl-A')
+  })
+})
+
+/**
+ * #863 row 4. `crm.activities.list` has two branches: the conference one was
+ * already scoped, the `sponsorForConferenceId` one filtered on
+ * `sponsorForConference._ref == $sponsorId` and NOTHING else. The sibling
+ * `activities.create` guards the same id — only the read did not.
+ */
+describe('crm.activities.list is conference-scoped (#863 row 4)', () => {
+  async function settle<T>(p: Promise<T>) {
+    try {
+      return { value: await p, error: undefined as unknown }
+    } catch (error) {
+      return { value: undefined, error }
+    }
+  }
+
+  it('does not return another conference’s CRM notes', async () => {
+    foreign('sponsorForConference')
+
+    const outcome = await settle(
+      sponsor().crm.activities.list({ sponsorForConferenceId: 'sfc-B' }),
+    )
+
+    // Unguarded this RESOLVES with `[FOREIGN_ACTIVITY]`, so this fails on the
+    // note text and the author name coming back, not on a moved message.
+    expect(outcome.value).toBeUndefined()
+    expect(JSON.stringify(outcome.value ?? '')).not.toContain('gold tier')
+    expect(outcome.error).toMatchObject({ code: 'NOT_FOUND' })
+  })
+
+  it('refuses BEFORE the read', async () => {
+    foreign('sponsorForConference')
+
+    await settle(
+      sponsor().crm.activities.list({ sponsorForConferenceId: 'sfc-B' }),
+    )
+
+    expect(lib.listActivitiesForSponsor).not.toHaveBeenCalled()
+  })
+
+  it('still lists our OWN sponsor’s activities', async () => {
+    owned('sponsorForConference')
+
+    await expect(
+      sponsor().crm.activities.list({ sponsorForConferenceId: 'sfc-A' }),
+    ).resolves.toEqual([FOREIGN_ACTIVITY])
+    expect(lib.listActivitiesForSponsor).toHaveBeenCalledWith(
+      'sfc-A',
+      undefined,
+    )
+  })
+
+  it('the conference-wide branch is untouched', async () => {
+    await expect(sponsor().crm.activities.list({})).resolves.toEqual([])
+    expect(lib.listActivitiesForConference).toHaveBeenCalled()
+  })
+})
+
+/**
+ * #863 rows 5-6. Both procedures take a `templateId` straight from the client
+ * and read it with the GLOBAL `getContractTemplate`. `sendContract` renders the
+ * result into the PDF this conference signs and mails; `generatePdf` hands it
+ * back to the caller as base64, so a foreign template's full terms were readable
+ * without sending anything.
+ */
+describe('contract rendering refuses a foreign template (#863 rows 5-6)', () => {
+  it('sendContract refuses, and never reads the template', async () => {
+    foreign('contractTemplate')
+
+    await expect(
+      sponsor().crm.sendContract({
+        sponsorForConferenceId: 'sfc-A',
+        templateId: 'tpl-B',
+      }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(lib.getContractTemplate).not.toHaveBeenCalled()
+  })
+
+  it('generatePdf refuses, and never reads the template', async () => {
+    foreign('contractTemplate')
+
+    await expect(
+      sponsor().contractTemplates.generatePdf({
+        sponsorForConferenceId: 'sfc-A',
+        templateId: 'tpl-B',
+      }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(lib.getContractTemplate).not.toHaveBeenCalled()
+  })
+
+  it('our OWN template is still read by both', async () => {
+    // The guard is the subject; both then stop at the sponsor lookup, which
+    // these tests leave empty. Reaching that point IS the positive result.
+    owned('contractTemplate')
+
+    await expect(
+      sponsor().contractTemplates.generatePdf({
+        sponsorForConferenceId: 'sfc-A',
+        templateId: 'tpl-A',
+      }),
+    ).rejects.toMatchObject({ message: 'Sponsor relationship not found' })
+    expect(lib.getContractTemplate).toHaveBeenCalledWith('tpl-A')
+
+    await expect(
+      sponsor().crm.sendContract({
+        sponsorForConferenceId: 'sfc-A',
+        templateId: 'tpl-A',
+      }),
+    ).rejects.toMatchObject({ message: 'Sponsor relationship not found.' })
+  })
+})
+
+/**
+ * #863 row 7 — REFERENCE INJECTION, the #731 F1/F4 shape.
+ *
+ * `crm.create`/`crm.update` write four client-supplied ids into reference fields
+ * of a record this org owns. No foreign document is patched, so the guards on
+ * the record itself never saw them — but every scoped view DEREFERENCES them, so
+ * another tenant's company, pricing and contract terms render inside this
+ * tenant's pipeline. `tierExists` was the only check and it asked existence
+ * only, dataset-wide.
+ */
+describe('CRM references must belong to this tenant (#863 row 7)', () => {
+  const base = {
+    sponsor: 'sp-A',
+    status: 'prospect' as const,
+    contractStatus: 'none' as const,
+    invoiceStatus: 'not-sent' as const,
+    // Explicit null: `undefined` would auto-assign the caller and drag the
+    // organizer lookup into these cases, which are about REFERENCES.
+    assignedTo: null,
+  }
+
+  it('create refuses a foreign SPONSOR ref', async () => {
+    h.tenantById = { 'sp-B': tenantOf('theirs', 'sponsor') }
+
+    await expect(
+      sponsor().crm.create({ ...base, sponsor: 'sp-B' }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(lib.createSponsorForConference).not.toHaveBeenCalled()
+  })
+
+  it('create refuses a foreign TIER ref', async () => {
+    h.tenantById = {
+      'sp-A': tenantOf('ours', 'sponsor'),
+      'tier-B': tenantOf('theirs', 'sponsorTier'),
+    }
+
+    await expect(
+      sponsor().crm.create({ ...base, tier: 'tier-B' }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(lib.createSponsorForConference).not.toHaveBeenCalled()
+  })
+
+  it('create refuses a foreign CONTRACT TEMPLATE ref', async () => {
+    h.tenantById = {
+      'sp-A': tenantOf('ours', 'sponsor'),
+      'tpl-B': tenantOf('theirs', 'contractTemplate'),
+    }
+
+    await expect(
+      sponsor().crm.create({ ...base, contractTemplate: 'tpl-B' }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(lib.createSponsorForConference).not.toHaveBeenCalled()
+  })
+
+  it('create refuses the WHOLE addons array when one id is not ours', async () => {
+    h.tenantById = { 'sp-A': tenantOf('ours', 'sponsor') }
+    h.ownedCount = 1 // one of the two supplied add-ons is ours
+
+    await expect(
+      sponsor().crm.create({ ...base, addons: ['add-A', 'add-B'] }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(lib.createSponsorForConference).not.toHaveBeenCalled()
+  })
+
+  it('create writes the record when every reference is ours', async () => {
+    h.tenantById = {
+      'sp-A': tenantOf('ours', 'sponsor'),
+      'tier-A': tenantOf('ours', 'sponsorTier'),
+      'tpl-A': tenantOf('ours', 'contractTemplate'),
+    }
+    h.ownedCount = 2
+
+    await expect(
+      sponsor().crm.create({
+        ...base,
+        tier: 'tier-A',
+        addons: ['add-A', 'add-B'],
+        contractTemplate: 'tpl-A',
+      }),
+    ).resolves.toMatchObject({ _id: 'sfc-new' })
+    expect(lib.createSponsorForConference).toHaveBeenCalledWith(
+      expect.objectContaining({ sponsor: 'sp-A', tier: 'tier-A' }),
+    )
+  })
+
+  it('update refuses a foreign TIER ref', async () => {
+    h.tenantById = { 'tier-B': tenantOf('theirs', 'sponsorTier') }
+
+    await expect(
+      sponsor().crm.update({ id: 'sfc-A', tier: 'tier-B' }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(lib.updateSponsorForConference).not.toHaveBeenCalled()
+  })
+
+  it('update refuses a foreign CONTRACT TEMPLATE ref', async () => {
+    h.tenantById = { 'tpl-B': tenantOf('theirs', 'contractTemplate') }
+
+    await expect(
+      sponsor().crm.update({ id: 'sfc-A', contractTemplate: 'tpl-B' }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(lib.updateSponsorForConference).not.toHaveBeenCalled()
+  })
+
+  it('update refuses BEFORE the record is even read', async () => {
+    h.tenantById = { 'tier-B': tenantOf('theirs', 'sponsorTier') }
+
+    await expect(
+      sponsor().crm.update({ id: 'sfc-A', tier: 'tier-B' }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(lib.getSponsorForConference).not.toHaveBeenCalled()
+  })
+
+  it('update still applies our OWN tier', async () => {
+    h.tenantById = { 'tier-A': tenantOf('ours', 'sponsorTier') }
+    lib.getSponsorForConference.mockResolvedValue({
+      sponsorForConference: {
+        _id: 'sfc-A',
+        conference: { _id: CONF_A },
+        status: 'negotiating',
+        invoiceStatus: 'not-sent',
+      },
+      error: undefined,
+    })
+
+    await expect(
+      sponsor().crm.update({ id: 'sfc-A', tier: 'tier-A' }),
+    ).resolves.toMatchObject({ _id: 'sfc-A' })
+    expect(lib.updateSponsorForConference).toHaveBeenCalledWith(
+      'sfc-A',
+      expect.objectContaining({ tier: 'tier-A' }),
+    )
   })
 })
 

--- a/src/server/routers/tenancy.writes.sponsor.test.ts
+++ b/src/server/routers/tenancy.writes.sponsor.test.ts
@@ -99,6 +99,7 @@ const lib = vi.hoisted(() => ({
   getContractTemplate: vi.fn(),
   updateContractTemplate: vi.fn(),
   deleteContractTemplate: vi.fn(),
+  generateContractPdf: vi.fn(),
 }))
 
 vi.mock('@/lib/sponsor/sanity', async (importOriginal) => ({
@@ -129,6 +130,9 @@ vi.mock('@/lib/sponsor-crm/activities', async (importOriginal) => ({
 vi.mock('@/lib/sponsor-crm/activity', async (importOriginal) => ({
   ...((await importOriginal()) as Record<string, unknown>),
   createSponsorActivity: lib.createSponsorActivity,
+}))
+vi.mock('@/lib/sponsor-crm/contract-pdf', () => ({
+  generateContractPdf: lib.generateContractPdf,
 }))
 vi.mock('@/lib/sponsor-crm/contract-templates', async (importOriginal) => ({
   ...((await importOriginal()) as Record<string, unknown>),
@@ -183,6 +187,35 @@ const FOREIGN_ACTIVITY = {
   description: 'They will not go above 40k — push the gold tier at renewal.',
   createdBy: { _id: 'sp-B', name: 'Their Organizer' },
 }
+
+/** The title of the OTHER tenant's contract template, as it would render. */
+const FOREIGN_TEMPLATE_TITLE = 'Their standard terms'
+
+/**
+ * Ours, and complete enough that every readiness guard in `sendContract` passes
+ * — tier, positive value, a live deal, a primary contact and a titled
+ * conference. So the only thing that can stop these procedures is the template.
+ */
+const CONTRACT_READY_SFC = {
+  _id: 'sfc-A',
+  sponsor: { _id: 'sp-A', name: 'Acme AS', orgNumber: '123456789' },
+  conference: { _id: CONF_A, title: 'Our Conference' },
+  tier: { _id: 'tier-A', title: 'Gold', tagline: '' },
+  status: 'negotiating',
+  contractStatus: 'verbal-agreement',
+  contractValue: 50000,
+  contractCurrency: 'NOK',
+  invoiceStatus: 'not-sent',
+  contactPersons: [
+    { _key: 'c1', name: 'Jane Doe', email: 'jane@acme.test', isPrimary: true },
+  ],
+}
+
+/** The titles of every template that actually reached the PDF renderer. */
+const rendered = () =>
+  lib.generateContractPdf.mock.calls.map(
+    (call) => (call[0] as { title: string }).title,
+  )
 
 /** A tenancy answer for ONE id, for the multi-reference procedures. */
 function tenantOf(kind: 'ours' | 'theirs', type: string) {
@@ -260,10 +293,14 @@ beforeEach(() => {
     activityId: 'act-1',
     error: null,
   })
-  lib.getContractTemplate.mockResolvedValue({
-    template: { _id: 'tpl-B', title: 'Foreign' },
+  lib.getContractTemplate.mockImplementation(async (id: string) => ({
+    template: {
+      _id: id,
+      title: id === 'tpl-A' ? 'Our terms' : FOREIGN_TEMPLATE_TITLE,
+    },
     error: null,
-  })
+  }))
+  lib.generateContractPdf.mockResolvedValue(Buffer.from('%PDF-1.7'))
   lib.updateContractTemplate.mockResolvedValue({
     template: { _id: 'tpl-B' },
     error: null,
@@ -277,8 +314,12 @@ beforeEach(() => {
     activities: [],
     error: null,
   })
+  // A COMPLETE, contract-ready relationship of OURS. Rows 5-6 are about the
+  // second id in the payload (`templateId`), so the first one must not be what
+  // stops the procedure — otherwise removing the template guard would still
+  // refuse, for the wrong reason, and the test would pass while blind.
   lib.getSponsorForConference.mockResolvedValue({
-    sponsorForConference: undefined,
+    sponsorForConference: CONTRACT_READY_SFC,
     error: undefined,
   })
   lib.createSponsorForConference.mockResolvedValue({
@@ -588,49 +629,103 @@ describe('crm.activities.list is conference-scoped (#863 row 4)', () => {
  * without sending anything.
  */
 describe('contract rendering refuses a foreign template (#863 rows 5-6)', () => {
-  it('sendContract refuses, and never reads the template', async () => {
-    foreign('contractTemplate')
+  async function settle<T>(p: Promise<T>) {
+    try {
+      return { value: await p, error: undefined as unknown }
+    } catch (error) {
+      return { value: undefined, error }
+    }
+  }
 
-    await expect(
+  it('sendContract does not render another tenant’s terms', async () => {
+    // The sponsor half is OURS and contract-ready, so nothing but the template
+    // guard can stop this. Unguarded, `rendered()` holds the other tenant's
+    // template — which is what would have been signed and mailed.
+    h.tenantById = { 'tpl-B': tenantOf('theirs', 'contractTemplate') }
+
+    const outcome = await settle(
       sponsor().crm.sendContract({
         sponsorForConferenceId: 'sfc-A',
         templateId: 'tpl-B',
       }),
-    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    )
+
+    expect(rendered()).toEqual([])
     expect(lib.getContractTemplate).not.toHaveBeenCalled()
+    expect(outcome.error).toMatchObject({ code: 'NOT_FOUND' })
   })
 
-  it('generatePdf refuses, and never reads the template', async () => {
-    foreign('contractTemplate')
+  it('generatePdf does not return another tenant’s terms as a PDF', async () => {
+    h.tenantById = { 'tpl-B': tenantOf('theirs', 'contractTemplate') }
 
-    await expect(
+    const outcome = await settle(
       sponsor().contractTemplates.generatePdf({
         sponsorForConferenceId: 'sfc-A',
         templateId: 'tpl-B',
       }),
-    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    )
+
+    // Unguarded this RESOLVES with `{ pdf: <base64>, filename }` built from the
+    // foreign template, so the first two lines fail on what was rendered and
+    // handed back, not on a message.
+    expect(rendered()).toEqual([])
+    expect(outcome.value).toBeUndefined()
     expect(lib.getContractTemplate).not.toHaveBeenCalled()
+    expect(outcome.error).toMatchObject({ code: 'NOT_FOUND' })
   })
 
-  it('our OWN template is still read by both', async () => {
-    // The guard is the subject; both then stop at the sponsor lookup, which
-    // these tests leave empty. Reaching that point IS the positive result.
-    owned('contractTemplate')
+  it('generatePdf still renders OUR OWN template', async () => {
+    h.tenantById = { 'tpl-A': tenantOf('ours', 'contractTemplate') }
 
     await expect(
       sponsor().contractTemplates.generatePdf({
         sponsorForConferenceId: 'sfc-A',
         templateId: 'tpl-A',
       }),
-    ).rejects.toMatchObject({ message: 'Sponsor relationship not found' })
+    ).resolves.toMatchObject({ pdf: expect.any(String) })
+    expect(rendered()).toEqual(['Our terms'])
+  })
+
+  it('sendContract still reaches OUR OWN template', async () => {
+    // Delivery itself (asset upload, mail) is out of scope here; getting past
+    // the guard to the template read is the positive result.
+    h.tenantById = { 'tpl-A': tenantOf('ours', 'contractTemplate') }
+
+    await settle(
+      sponsor().crm.sendContract({
+        sponsorForConferenceId: 'sfc-A',
+        templateId: 'tpl-A',
+      }),
+    )
+
     expect(lib.getContractTemplate).toHaveBeenCalledWith('tpl-A')
+    expect(rendered()).toEqual(['Our terms'])
+  })
 
-    await expect(
-      sponsor().crm.sendContract({
+  it('a foreign template id refuses exactly as an unknown one does', async () => {
+    h.tenantById = { 'tpl-B': tenantOf('theirs', 'contractTemplate') }
+    const foreignOutcome = await settle(
+      sponsor().contractTemplates.generatePdf({
         sponsorForConferenceId: 'sfc-A',
-        templateId: 'tpl-A',
+        templateId: 'tpl-B',
       }),
-    ).rejects.toMatchObject({ message: 'Sponsor relationship not found.' })
+    )
+    h.tenantById = {} // nothing knows this id at all
+    const unknownOutcome = await settle(
+      sponsor().contractTemplates.generatePdf({
+        sponsorForConferenceId: 'sfc-A',
+        templateId: 'tpl-nowhere',
+      }),
+    )
+
+    expect(foreignOutcome.error).toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'No contractTemplate with that id for this request',
+    })
+    expect(unknownOutcome.error).toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'No contractTemplate with that id for this request',
+    })
   })
 })
 

--- a/src/server/routers/tenancy.writes.test.ts
+++ b/src/server/routers/tenancy.writes.test.ts
@@ -50,6 +50,7 @@ const h = vi.hoisted(() => ({
   failParticipationProbe: false,
   updateSpeaker: vi.fn(),
   getSpeaker: vi.fn(),
+  getSpeakerAdminDetail: vi.fn(),
   mergeSpeakers: vi.fn(),
   updateProfileEmail: vi.fn(),
   updateProposal: vi.fn(),
@@ -212,6 +213,7 @@ vi.mock('@/lib/speaker/sanity', async (importOriginal) => {
   return {
     ...actual,
     getSpeaker: h.getSpeaker,
+    getSpeakerAdminDetail: h.getSpeakerAdminDetail,
     updateSpeaker: h.updateSpeaker,
     generateUniqueSlug: async (name: string) => name.toLowerCase(),
   }
@@ -257,6 +259,8 @@ const callProposal = t.createCallerFactory(proposalRouter)
 
 const ORG_A = 'org-A'
 const ORG_B = 'org-B'
+/** Fake, but it is the field #863 row 3 named — assert on it, not on an absence. */
+const FOREIGN_SPEAKER_EMAIL = 'their-speaker@other.test'
 
 /** A caller who is an organizer of ORG_A — the request org in every test. */
 function ctx(): Context {
@@ -375,6 +379,22 @@ beforeEach(() => {
   seed()
   host(ORG_A)
   h.getSpeaker.mockResolvedValue({ speaker: { _id: 'speaker-A' }, err: null })
+  // The GLOBAL by-id detail read behind `speaker.admin.getById`. It answers for
+  // ANY id in the dataset, as the real one does — so if the guard in front of it
+  // is removed, the foreign person's record really does come back (#863 row 3).
+  h.getSpeakerAdminDetail.mockImplementation(async (id: string) =>
+    h.docs.has(id)
+      ? {
+          speaker: {
+            _id: id,
+            name: 'Person',
+            email:
+              id === 'speaker-B' ? FOREIGN_SPEAKER_EMAIL : 'ours@example.test',
+          },
+          err: null,
+        }
+      : { speaker: null, err: null },
+  )
   h.updateSpeaker.mockImplementation(async (id: string) => {
     h.writes.push({ op: 'updateSpeaker', id, guarded: h.probes > 0 })
     return { speaker: { _id: id }, err: null }
@@ -596,6 +616,85 @@ describe('speaker admin mutations refuse a foreign id (#730)', () => {
       'merge',
       'delete',
     ])
+  })
+})
+
+/**
+ * #863 row 3 — the READ sibling of the mutations above.
+ *
+ * `speaker.admin.getById` was a plain `adminProcedure` while `update`, `delete`,
+ * `merge` and `updateEmail` in the same router all prove standing over the id
+ * they are handed. `adminProcedure` proves only that the caller organizes SOME
+ * org, so an organizer of tenant A could ask for tenant B's person and receive
+ * them — through `getSpeaker`, whose bare `...` shipped their email, login
+ * match-set, linked providers, gender, country and GDPR consent records.
+ *
+ * These run the REAL `requireSpeakerInCurrentOrg` against the same fake dataset,
+ * and the detail read is mocked as the GLOBAL read it is, so removing the guard
+ * fails them on the RECORD COMING BACK.
+ */
+describe('speaker.admin.getById is org-scoped (#863 row 3)', () => {
+  async function settle<T>(p: Promise<T>) {
+    try {
+      return { value: await p, error: undefined as unknown }
+    } catch (error) {
+      return { value: undefined, error }
+    }
+  }
+
+  it('does not return another tenant’s person', async () => {
+    const outcome = await settle(speaker().admin.getById({ id: 'speaker-B' }))
+
+    // Unguarded this RESOLVES with `{ _id: 'speaker-B', email: … }`, so the
+    // first line fails on the document itself.
+    expect(outcome.value).toBeUndefined()
+    expect(JSON.stringify(outcome.value ?? '')).not.toContain(
+      FOREIGN_SPEAKER_EMAIL,
+    )
+    expect(outcome.error).toMatchObject({ code: 'NOT_FOUND' })
+  })
+
+  it('refuses BEFORE the read — the foreign document never enters the request', async () => {
+    await settle(speaker().admin.getById({ id: 'speaker-B' }))
+
+    expect(h.getSpeakerAdminDetail).not.toHaveBeenCalled()
+  })
+
+  it('answers a foreign id exactly as it answers a nonexistent one', async () => {
+    const foreign = await settle(speaker().admin.getById({ id: 'speaker-B' }))
+    const missing = await settle(speaker().admin.getById({ id: 'no-such-id' }))
+
+    expect(foreign.error).toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'No speaker with that id for this request',
+    })
+    expect(missing.error).toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'No speaker with that id for this request',
+    })
+  })
+
+  it('refuses a non-speaker document — wrong `_type`', async () => {
+    const outcome = await settle(speaker().admin.getById({ id: 'conf-A' }))
+
+    expect(outcome.error).toMatchObject({ code: 'NOT_FOUND' })
+    expect(h.getSpeakerAdminDetail).not.toHaveBeenCalled()
+  })
+
+  it('still returns a person this org holds — the guard is not a blanket deny', async () => {
+    const outcome = await settle(speaker().admin.getById({ id: 'speaker-A' }))
+
+    expect(outcome.error).toBeUndefined()
+    expect(outcome.value).toMatchObject({ _id: 'speaker-A' })
+  })
+
+  it('reads through the NARROWED projection, not the self read', async () => {
+    // `getSpeaker` is the SELF read and spreads the whole document. Row 3 is as
+    // much about WHAT came back as about who could ask for it.
+    await settle(speaker().admin.getById({ id: 'speaker-A' }))
+
+    expect(h.getSpeakerAdminDetail).toHaveBeenCalledWith('speaker-A')
+    expect(h.getSpeaker).not.toHaveBeenCalled()
   })
 })
 

--- a/src/server/routers/tenancy.writes.test.ts
+++ b/src/server/routers/tenancy.writes.test.ts
@@ -693,7 +693,7 @@ describe('speaker.admin.getById is org-scoped (#863 row 3)', () => {
     // much about WHAT came back as about who could ask for it.
     await settle(speaker().admin.getById({ id: 'speaker-A' }))
 
-    expect(h.getSpeakerAdminDetail).toHaveBeenCalledWith('speaker-A')
+    expect(h.getSpeakerAdminDetail).toHaveBeenCalledWith('speaker-A', ORG_A)
     expect(h.getSpeaker).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Fixes the seven **MEDIUM** rows of #863 (rows 3-9). The two HIGH rows shipped in #865; rows 10-12 (LOW) are deliberately untouched.

Every one of these is the same defect. `adminProcedure` proves only that the caller organizes SOME org, and each procedure then took a document id straight from client input and answered for it dataset-wide. The pattern #865 established is applied throughout: **guard before fetch**, so the foreign document never enters the request, and **foreign ≡ nonexistent**, so no refusal is an existence oracle.

## What each row was, and what it is now

| Row | Procedure | Fix |
|---|---|---|
| 3 | `speaker.admin.getById` | `requireSpeakerInCurrentOrg` before the read + a new explicitly-projected `getSpeakerAdminDetail` that also carries the org predicate |
| 4 | `crm.activities.list` (id branch) | `requireDocumentInCurrentConference(…, 'sponsorForConference')` before `listActivitiesForSponsor` |
| 5 | `crm.sendContract` (`templateId`) | `requireDocumentInCurrentConference(…, 'contractTemplate')` as the FIRST statement |
| 6 | `contractTemplates.generatePdf` (`templateId`) | same guard, before the template read |
| 7 | `crm.create` / `crm.update` ref injection | new `assertCrmReferencesAreOurs` proves `sponsor`, `tier`, `addons[]`, `contractTemplate` on each type's own boundary |
| 8 | `badge.admin.getById` | reads through `getBadgeForConference` (#865's scoped lookup) instead of the public `getBadgeById` |
| 9 | `badge.admin.list` (speakerId branch) | `listBadgesForSpeaker` replaced by `listBadgesForSpeakerInConference`, conference predicate unconditional |

**All seven were real.** Nothing in the census turned out to be a false positive, and I checked each against source before touching it. One characterisation was slightly off, though: the brief said row 8 needed its bare `...` replaced. `BADGE_FIELDS` has no spread — it is already an explicit projection, just a wider one than the public `verify` returns. Once the read is conference-scoped those fields are the caller's own tenant's, and narrowing `BADGE_FIELDS` would reach into `/api/badge/[badgeId]/*`, which is public and must answer for any issuer. So row 8 is a predicate fix only, and I say so rather than manufacturing a projection change.

## Row 3 in detail — what the projection drops, and what it must not

`getSpeaker` opens with a bare `...`, so this endpoint shipped every field the schema has and every field it ever grows: `email`, `knownEmails`, `providers`, `gender`, `country` and the GDPR `consent` records.

`getSpeaker` itself is **untouched**. It is the SELF read — `speaker.getCurrent`, the CFP profile page and the auth token all go through it and legitimately need the whole document. Narrowing it would have broken a person's own profile editor. The admin path gets a separate function instead, `getSpeakerAdminDetail`, projected against the new `SpeakerAdminDetail` type.

**`email`, `gender`, `genderSelfDescribe`, `country` and `consent` STAY**, and that is the result of checking the consumers rather than the assumption. `SpeakerManagementModal` renders and writes all of them back through `speaker.admin.update` (`consent` at `SpeakerManagementModal.tsx:100`/`130`), so dropping them would have broken the admin editor the moment it reads through this endpoint — the same trap `bankingDetails` was in #865. They are sensitive; the control on them is the ownership guard, not a thinner projection.

Dropped as unread: `knownEmails` and `providers` (how the person authenticates), `organizations` (**the other tenants they belong to**), `_rev`, `messagingEmailDefault`, and the two whole-dataset computed fields `isOrganizer`/`organizerOrgIds`. The return type was narrowed in lockstep, so a consumer reading a dropped field is a compile error rather than a runtime `undefined`, and `sanity.projection.test.ts` asserts the field list against the query text because TypeScript cannot tell a field the query forgot from one the document lacks.

**The consumer check, stated plainly:** `speaker.admin.getById` and `badge.admin.getById` have **no in-repo consumer at all** — no component, page or story calls either. The admin speaker surfaces feed off `getSpeakers` (the list) and the `admin.update` result, not off `getById`. They remain live tRPC endpoints on the agent/CLI surface, which is why they are fixed rather than deleted, and it is why the projection had to be chosen from what the admin UI *edits* rather than from a compiler error.

## Row 7 in detail

`crm.create`/`crm.update` write four client-supplied ids into reference fields of a record this org owns. No foreign document is patched — which is why the existing `requireDocument*` guards never saw them — but every scoped view DEREFERENCES them: a foreign `sponsor` puts another tenant's company, org number and address into this tenant's pipeline, board and CSV exports; a foreign `tier` puts their pricing there; a foreign `contractTemplate` puts their terms into the PDF this conference sends. `assertTierResolvable` was the only check and it only ever asked whether the id EXISTS, dataset-wide, which for a dataset-wide key is no check at all.

Each id is now proved on its own type's boundary — `sponsor` is org-owned, tiers, add-ons (also `sponsorTier` documents) and templates are conference-owned. Add-ons go through the plural form, which refuses the whole array unless every id is ours: a partial apply would perform the foreign half of the request while reporting success.

**One ordering consequence, named:** the tenancy guard now runs BEFORE `assertTierResolvable`, so a dangling tier id gets `No sponsorTier with that id for this request` instead of the friendlier "The selected sponsor tier no longer exists". That is deliberate — the other order is precisely the 1-bit oracle #863's comment describes, distinguishing "does not exist anywhere" from "exists, not yours". `assertTierResolvable` is kept as belt-and-braces for the delete-between-check-and-use race.

## Verification

Sabotage-proven, each restored and re-run green, with file **and** test counts checked every time so a broken import cannot read as a pass.

| Sabotage | Result |
|---|---|
| Drop `requireSpeakerInCurrentOrg` from `speaker.admin.getById` | 1 file / 61 tests, **4 failed** — `expected { _id: 'speaker-B', …(2) } to be undefined`. Fails because the foreign person *is returned*. |
| Re-add `...` to the speaker projection | 2 files / 68 tests, **1 failed** on the spread |
| Drop the org predicate from `getSpeakerAdminDetail` | 2 files / 68 tests, **1 failed** — and the ROUTER file stayed entirely green |
| Drop the guard from `crm.activities.list` | 1 file / 40 tests, **2 failed** — `expected [ { _id: 'act-B', …(3) } ] to be undefined`, i.e. the other tenant's note text |
| Drop the template guard from `crm.sendContract` | 1 file / 42 tests, **1 failed** — `expected [ 'Their standard terms' ] to deeply equal []` |
| Drop the template guard from `generatePdf` | 1 file / 42 tests, **2 failed**, same rendered-title assertion |
| Neuter `assertCrmReferencesAreOurs` | 1 file / 42 tests, **7 failed** — `promise resolved "{ _id: 'sfc-new' }" instead of rejecting`, i.e. the write went through |
| Point `badge.admin.getById` back at `getBadgeById` | 1 file / 14 tests, **4 failed** — `expected { _id: 'doc-badge-theirs', …(4) } to be undefined` |
| Drop the conference argument in `badge.admin.list` | 1 file / 14 tests, **3 failed** — `expected [ 'badge-shared-ours', …(1) ] to deeply equal [ 'badge-shared-ours' ]` (typecheck catches it too) |
| Drop `conference._ref == $conferenceId` from the scoped badge query | 2 files / 23 tests, **1 failed** — and the ROUTER file stayed entirely green |

Every one fails on a VALUE or on the action succeeding. None fails on an absence.

**The query-level tests earn their place twice.** Both predicate sabotages left the router suites 100% green, because those mock the scoped read — exactly the blindness #863 identifies as how twelve rows shipped. `sanity.scoped.test.ts` and `sanity.projection.test.ts` are the only things that catch them.

**A blind test I wrote and then caught.** The first `sendContract` case PASSED with the guard removed: it left the sponsor lookup empty, so the procedure refused at the sponsor half — NOT_FOUND either way, and the template read was never reached because it sits after that lookup. Only running the sabotage found it. The fixture is now a complete, contract-ready relationship of ours, so nothing but the template guard can stop the procedure, and the assertion is on the titles that reached the PDF renderer. That is the second commit.

**Numbers**, against `origin/main` (measured in a clean worktree at `80bab285`, not the shared checkout):

| | before | after |
|---|---|---|
| `pnpm test` | 520 files / 7609 tests | **521 files / 7652 tests**, all passing |
| `pnpm typecheck` | clean | clean |
| `npx prettier --check .` | clean | clean |
| `npx eslint .` | 0 errors, 201 warnings | 0 errors, **200 warnings** |
| `tenancy/no-unscoped-groq` | 201 in 51 files | **200 in 51 files** |

Per-file, which is the unit the ratchet uses: **no file increased**; `src/lib/badge/sanity.ts` went 8 → 7 (the unscoped `listBadgesForSpeaker` is gone, its scoped replacement adds no warning). `src/lib/speaker/sanity.ts` holds at 12 — the new read carries `// groq-global-scoped:` naming its predicate, which is the rule's own vocabulary for scoping it cannot see, alongside the identical predicate written out the same way in `src/server/tenancy.ts`.

## Residue — named, not hidden

- **`getContractTemplate` is still a global by-id read**, now with three guarded call sites instead of one. Converting it to a scoped read would have been the stronger shape, but `contractTemplates.get` already guards it the same way and rewriting a working path inside a security PR is the wrong place to spend the risk. The lint count for `sponsor.ts` is unchanged at 4.
- **`assertTierResolvable`/`tierExists` are now effectively unreachable for the supplied-tier path** — the tenancy guard proves existence first. Kept, not deleted: they still cover the delete-between-check-and-use race, and removing them is a separate cleanup.
- **`crm.update` cannot change the `sponsor` ref**, so `assertCrmReferencesAreOurs` only exercises three of its four arms there. That is the schema's doing, not a gap; the helper is written for both call sites.
- **`speaker.admin.create` and `update` still return the full `getSpeaker` payload.** Both are guarded (create makes the document; update calls `requireSpeakerInCurrentOrg`), so this is over-return rather than cross-tenant exposure. Narrowing them means changing what `SpeakerManagementModal` receives, and belongs with that component.
- **Row 12's fetch-before-guard oracle in `volunteer.update`/`delete` is untouched** — it is LOW and out of scope.
- Three test fixtures needed the ownership probe seeded (`sponsor-activity`, `sponsor-pipeline-guards`, `sponsor-contract-signature-guards`). Those are fixture updates for guards that now run earlier, not weakened assertions; each says so in a comment and points at where the cross-tenant refusal lives.

Refs #863
