### PR TITLE
feat: add travel funding indicator to schedule admin and enable typescript CLI

### DIFF
--- a/__tests__/app/day-one/fresh-tenant-admin-surfaces.test.tsx
+++ b/__tests__/app/day-one/fresh-tenant-admin-surfaces.test.tsx
@@ -66,7 +66,10 @@ vi.mock('@/lib/trpc/client', () => ({
     schedule: {
       save: { useMutation: () => ({ mutateAsync: saveMutateAsync }) },
       action: { useMutation: () => ({ mutateAsync: actionMutateAsync }) },
-      admin: { pollVersions: { useQuery: () => ({ data: undefined }) } },
+      admin: {
+        pollVersions: { useQuery: () => ({ data: undefined }) },
+        pollProposalsStatus: { useQuery: () => ({ data: undefined }) },
+      },
     },
   },
 }))

--- a/__tests__/components/admin/schedule/ScheduleEditor.test.tsx
+++ b/__tests__/components/admin/schedule/ScheduleEditor.test.tsx
@@ -50,6 +50,7 @@ vi.mock('@/lib/trpc/client', () => ({
       action: { useMutation: () => ({ mutateAsync: actionMutateAsync }) },
       admin: {
         pollVersions: { useQuery: () => ({ data: pollData.current }) },
+        pollProposalsStatus: { useQuery: () => ({ data: undefined }) },
       },
     },
   },

--- a/__tests__/components/cfp/CFPProfilePage.emailAutosave.test.tsx
+++ b/__tests__/components/cfp/CFPProfilePage.emailAutosave.test.tsx
@@ -72,6 +72,10 @@ vi.mock('@/app/(cfp)/cfp/profile/link-actions', () => ({
   startProviderLink: vi.fn(),
 }))
 
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ update: vi.fn() }),
+}))
+
 import { CFPProfilePage } from '@/components/cfp/CFPProfilePage'
 
 beforeEach(() => {

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,8 @@ const config: NextConfig = {
   reactStrictMode: false, // disabled due to https://github.com/vercel/next.js/issues/35822
   cacheComponents: true,
   experimental: {
+    // Workaround for typecheck OOM issues during builds
+    // https://nextjs.org/docs/app/api-reference/next-config-js/useTypeScriptCli
     useTypeScriptCli: true,
   },
   turbopack: {

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,9 @@ import { NextConfig } from 'next'
 const config: NextConfig = {
   reactStrictMode: false, // disabled due to https://github.com/vercel/next.js/issues/35822
   cacheComponents: true,
+  experimental: {
+    useTypeScriptCli: true,
+  },
   turbopack: {
     // Use Turbopack for production builds to fix Tailwind v4 CSS generation
     resolveAlias: {

--- a/src/app/(admin)/admin/messages/[id]/page.tsx
+++ b/src/app/(admin)/admin/messages/[id]/page.tsx
@@ -33,7 +33,7 @@ export default async function AdminConversationPage({
     // scroll internally WITHOUT the page claiming a full viewport inside the
     // dashboard shell — an h-[100dvh] wrapper here stacked on the shell's chrome
     // and produced ~200px of dead scroll below the card.
-    <div className="mx-auto max-w-3xl p-4">
+    <div className="w-full p-4">
       <div className="mb-4 shrink-0">
         <BackLink fallbackUrl="/admin/messages">Back to Messages</BackLink>
       </div>

--- a/src/app/(admin)/admin/messages/page.tsx
+++ b/src/app/(admin)/admin/messages/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function AdminMessagesPage() {
   return (
-    <div className="mx-auto max-w-3xl">
+    <div className="w-full">
       <div className="mb-6">
         <h1 className="font-space-grotesk text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
           Messages

--- a/src/app/(admin)/admin/platform/new-organization/page.tsx
+++ b/src/app/(admin)/admin/platform/new-organization/page.tsx
@@ -29,7 +29,7 @@ export default async function NewOrganizationPage() {
   }
 
   return (
-    <div className="mx-auto max-w-3xl space-y-6">
+    <div className="w-full space-y-6">
       <AdminPageHeader
         icon={<BuildingOffice2Icon />}
         title="New organization"

--- a/src/app/(admin)/admin/proposals/[id]/page.tsx
+++ b/src/app/(admin)/admin/proposals/[id]/page.tsx
@@ -1,3 +1,5 @@
+import { clientReadUncached } from '@/lib/sanity/client'
+import { CalendarIcon } from '@heroicons/react/20/solid'
 import { notFound } from 'next/navigation'
 import { formatDate } from '@/lib/time'
 import { ClockIcon } from '@heroicons/react/20/solid'
@@ -59,10 +61,42 @@ export default async function ProposalDetailPage({
       notFound()
     }
 
+    const schedules = conference
+      ? await clientReadUncached.fetch<{ _id: string; status: string }[]>(
+          `*[_type == "schedule" && conference._ref == $conferenceId && references($proposalId)] { _id, status }`,
+          { conferenceId: conference._id, proposalId: id },
+        )
+      : []
+
+    const inSchedule =
+      schedules.length > 0
+        ? schedules.some((s) => s.status === 'official')
+          ? 'official'
+          : schedules.some((s) => s.status === 'draft')
+            ? 'draft'
+            : null
+        : null
+
     return (
       <div className="flex h-full min-h-screen flex-col lg:flex-row">
         <div className="min-w-0 flex-1">
-          <div className="mx-auto max-w-4xl p-4">
+          <div className="w-full p-4">
+            {inSchedule && (
+              <div
+                className={`mb-4 flex items-center gap-2 rounded-md p-3 text-sm font-medium ${
+                  inSchedule === 'official'
+                    ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300'
+                    : 'bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300'
+                }`}
+              >
+                <CalendarIcon className="h-5 w-5" />
+                <span>
+                  {inSchedule === 'official'
+                    ? 'This proposal is included in the Official Schedule.'
+                    : 'This proposal is currently placed in a Draft Schedule.'}
+                </span>
+              </div>
+            )}
             <div className="mb-5">
               <div className="mb-3 flex items-center justify-between">
                 <BackLink fallbackUrl="/admin/proposals">

--- a/src/app/(admin)/admin/schedule/page.tsx
+++ b/src/app/(admin)/admin/schedule/page.tsx
@@ -10,7 +10,7 @@ export default async function AdminSchedule() {
 
   if (error) {
     return (
-      <div className="mx-auto h-full max-w-7xl">
+      <div className="h-full w-full">
         <div className="border-b border-gray-200 pb-5 dark:border-gray-700">
           <div className="flex items-center gap-3">
             <CalendarIcon className="h-8 w-8 text-gray-400 dark:text-gray-500" />

--- a/src/app/(admin)/admin/settings/new-edition/page.tsx
+++ b/src/app/(admin)/admin/settings/new-edition/page.tsx
@@ -76,7 +76,7 @@ export default async function NewEditionPage() {
   const defaults = nextEditionDefaults(conference)
 
   return (
-    <div className="mx-auto max-w-3xl space-y-6">
+    <div className="w-full space-y-6">
       <AdminPageHeader
         icon={<SparklesIcon />}
         title="Create next edition"

--- a/src/components/admin/LoadingSkeleton.tsx
+++ b/src/components/admin/LoadingSkeleton.tsx
@@ -134,7 +134,7 @@ export function SkeletonProposalDetail({
     >
       {/* Main content area */}
       <div className="min-w-0 flex-1">
-        <div className="mx-auto max-w-4xl p-4 lg:p-0">
+        <div className="w-full p-4 lg:p-0">
           <div className="mb-8 animate-pulse">
             {/* Back button and metadata row */}
             <div className="mb-4 flex items-center justify-between">

--- a/src/components/admin/PageLoadingSkeleton.tsx
+++ b/src/components/admin/PageLoadingSkeleton.tsx
@@ -86,7 +86,7 @@ export function AdminDashboardLoading() {
 
 export function AdminFormPageLoading() {
   return (
-    <div className="mx-auto max-w-4xl">
+    <div className="w-full">
       <div className="pb-6">
         <div className="animate-pulse">
           <div className="h-8 w-44 rounded bg-gray-200 sm:w-64 dark:bg-gray-700" />

--- a/src/components/admin/schedule/DraggableProposal.tsx
+++ b/src/components/admin/schedule/DraggableProposal.tsx
@@ -355,7 +355,9 @@ export function DraggableProposal({
         ? '🚫'
         : proposal.status === Status.accepted
           ? '⚠️'
-          : '✅'
+          : proposal.status === Status.confirmed
+            ? '✅'
+            : '📝'
     const statusText =
       proposal.status === Status.withdrawn
         ? 'Withdrawn by speaker'
@@ -363,7 +365,9 @@ export function DraggableProposal({
           ? 'Rejected by organizers'
           : proposal.status === Status.accepted
             ? 'Accepted (not yet confirmed by speaker)'
-            : 'Confirmed'
+            : proposal.status === Status.confirmed
+              ? 'Confirmed'
+              : 'Submitted (pending review)'
     parts.push(`${statusEmoji} Status: ${statusText}`)
 
     const levelEmoji =

--- a/src/components/admin/schedule/DraggableProposal.tsx
+++ b/src/components/admin/schedule/DraggableProposal.tsx
@@ -101,9 +101,9 @@ export function DraggableProposal({
     else if (duration <= TALK_THRESHOLDS.MEDIUM) size = 'medium'
     else size = 'long'
 
-    const requiresFunding = Array.isArray(proposal.speakers)
+    const requiresTravelFunding = Array.isArray(proposal.speakers)
       ? proposal.speakers.some(
-          (s: any) =>
+          (s: { flags?: string[] }) =>
             s && Array.isArray(s.flags) && s.flags.includes('requires-funding'),
         )
       : false
@@ -115,7 +115,7 @@ export function DraggableProposal({
       talkSize: size,
       dragId: id,
       speakerInfo: populatedSpeakerNames(proposal),
-      requiresFunding,
+      requiresTravelFunding,
     }
   }, [proposal, sourceTrackIndex, sourceTimeSlot, providedDurationMinutes])
 
@@ -395,7 +395,7 @@ export function DraggableProposal({
       parts.push(`🏷️ Topics: ${topicList}`)
     }
 
-    if (requiresFunding) {
+    if (requiresTravelFunding) {
       parts.push(`✈️ Requires Travel Funding`)
     }
 
@@ -458,27 +458,35 @@ export function DraggableProposal({
           </div>
 
           <div className="flex shrink-0 items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
-            {requiresFunding && (
-              <BanknotesIcon
-                className={
-                  talkSize === 'short' || talkSize === 'very-short'
-                    ? 'h-2.5 w-2.5 text-emerald-500 dark:text-emerald-400'
-                    : 'h-3 w-3 text-emerald-500 dark:text-emerald-400'
-                }
-                title="Requires Travel Funding"
-              />
+            {requiresTravelFunding && (
+              <>
+                <BanknotesIcon
+                  className={
+                    talkSize === 'short' || talkSize === 'very-short'
+                      ? 'h-2.5 w-2.5 text-emerald-500 dark:text-emerald-400'
+                      : 'h-3 w-3 text-emerald-500 dark:text-emerald-400'
+                  }
+                  title="Requires Travel Funding"
+                  aria-label="Requires Travel Funding"
+                />
+                <span className="sr-only">Requires Travel Funding</span>
+              </>
             )}
             {isOverridden && (
-              <ScissorsIcon
-                className={
-                  talkSize === 'short' || talkSize === 'very-short'
-                    ? 'h-2.5 w-2.5 text-amber-500'
-                    : 'h-3 w-3 text-amber-500'
-                }
-                title={`Duration overridden (original: ${getProposalDurationMinutes(proposal)}m)`}
-              />
+              <>
+                <ScissorsIcon
+                  className={
+                    talkSize === 'short' || talkSize === 'very-short'
+                      ? 'h-2.5 w-2.5 text-amber-500'
+                      : 'h-3 w-3 text-amber-500'
+                  }
+                  title={`Duration overridden (original: ${getProposalDurationMinutes(proposal)}m)`}
+                  aria-label={`Duration overridden (original: ${getProposalDurationMinutes(proposal)}m)`}
+                />
+                <span className="sr-only">Duration overridden</span>
+              </>
             )}
-            {!requiresFunding && !isOverridden && (
+            {!requiresTravelFunding && !isOverridden && (
               <ClockIcon
                 className={
                   talkSize === 'short' || talkSize === 'very-short'

--- a/src/components/admin/schedule/DraggableProposal.tsx
+++ b/src/components/admin/schedule/DraggableProposal.tsx
@@ -21,6 +21,8 @@ import {
   AcademicCapIcon,
   TagIcon,
   ExclamationTriangleIcon,
+  BanknotesIcon,
+  ScissorsIcon,
 } from '@heroicons/react/24/outline'
 import './schedule.css'
 
@@ -71,6 +73,7 @@ export function DraggableProposal({
     dragId,
     speakerInfo,
     isOverridden,
+    requiresFunding,
   } = useMemo(() => {
     const defaultDuration = getProposalDurationMinutes(proposal)
     const duration = providedDurationMinutes ?? defaultDuration
@@ -98,6 +101,13 @@ export function DraggableProposal({
     else if (duration <= TALK_THRESHOLDS.MEDIUM) size = 'medium'
     else size = 'long'
 
+    const requiresFunding = Array.isArray(proposal.speakers)
+      ? proposal.speakers.some(
+          (s: any) =>
+            s && Array.isArray(s.flags) && s.flags.includes('requires-funding'),
+        )
+      : false
+
     return {
       dragItem: item,
       durationMinutes: duration,
@@ -105,6 +115,7 @@ export function DraggableProposal({
       talkSize: size,
       dragId: id,
       speakerInfo: populatedSpeakerNames(proposal),
+      requiresFunding,
     }
   }, [proposal, sourceTrackIndex, sourceTimeSlot, providedDurationMinutes])
 
@@ -380,8 +391,19 @@ export function DraggableProposal({
       parts.push(`🏷️ Topics: ${topicList}`)
     }
 
+    if (requiresFunding) {
+      parts.push(`✈️ Requires Travel Funding`)
+    }
+
     return parts.join('\n')
-  }, [proposal, levelConfig, formatDisplay, durationMinutes, speakerInfo])
+  }, [
+    proposal,
+    levelConfig,
+    formatDisplay,
+    durationMinutes,
+    speakerInfo,
+    requiresFunding,
+  ])
 
   return (
     <>
@@ -432,20 +454,36 @@ export function DraggableProposal({
           </div>
 
           <div className="flex shrink-0 items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
-            <ClockIcon
-              className={
-                talkSize === 'short' || talkSize === 'very-short'
-                  ? 'h-2.5 w-2.5'
-                  : 'h-3 w-3'
-              }
-            />
-            <span className="tabular-nums">{durationMinutes}m</span>
+            {requiresFunding && (
+              <BanknotesIcon
+                className={
+                  talkSize === 'short' || talkSize === 'very-short'
+                    ? 'h-2.5 w-2.5 text-emerald-500 dark:text-emerald-400'
+                    : 'h-3 w-3 text-emerald-500 dark:text-emerald-400'
+                }
+                title="Requires Travel Funding"
+              />
+            )}
             {isOverridden && (
-              <ExclamationTriangleIcon
-                className="h-3 w-3 text-amber-500"
+              <ScissorsIcon
+                className={
+                  talkSize === 'short' || talkSize === 'very-short'
+                    ? 'h-2.5 w-2.5 text-amber-500'
+                    : 'h-3 w-3 text-amber-500'
+                }
                 title={`Duration overridden (original: ${getProposalDurationMinutes(proposal)}m)`}
               />
             )}
+            {!requiresFunding && !isOverridden && (
+              <ClockIcon
+                className={
+                  talkSize === 'short' || talkSize === 'very-short'
+                    ? 'h-2.5 w-2.5'
+                    : 'h-3 w-3'
+                }
+              />
+            )}
+            <span className="tabular-nums">{durationMinutes}m</span>
           </div>
         </div>
 

--- a/src/components/admin/schedule/DraggableProposal.tsx
+++ b/src/components/admin/schedule/DraggableProposal.tsx
@@ -73,7 +73,7 @@ export function DraggableProposal({
     dragId,
     speakerInfo,
     isOverridden,
-    requiresFunding,
+    requiresTravelFunding,
   } = useMemo(() => {
     const defaultDuration = getProposalDurationMinutes(proposal)
     const duration = providedDurationMinutes ?? defaultDuration
@@ -406,7 +406,7 @@ export function DraggableProposal({
     formatDisplay,
     durationMinutes,
     speakerInfo,
-    requiresFunding,
+    requiresTravelFunding,
   ])
 
   return (

--- a/src/components/admin/schedule/ScheduleEditor.tsx
+++ b/src/components/admin/schedule/ScheduleEditor.tsx
@@ -35,7 +35,7 @@ import {
   computeUnassigned,
   scheduledProposalIdsExcludingDay,
 } from '@/lib/schedule/operations'
-import { ProposalExisting, Status } from '@/lib/proposal/types'
+import { ProposalExisting } from '@/lib/proposal/types'
 import { UnassignedProposals } from './UnassignedProposals'
 import { MemoizedDroppableTrack as DroppableTrack } from './DroppableTrack'
 import { DraggableProposal } from './DraggableProposal'
@@ -306,10 +306,10 @@ export function ScheduleEditor({
     },
   )
 
-  const { data: updatedStatuses } = api.schedule.admin.pollProposalsStatus.useQuery(
-    undefined,
-    { refetchInterval: 10000 },
-  )
+  const { data: updatedStatuses } =
+    api.schedule.admin.pollProposalsStatus.useQuery(undefined, {
+      refetchInterval: 10000,
+    })
 
   const [externalChangeError, setExternalChangeError] = useState<string | null>(
     null,

--- a/src/components/admin/schedule/ScheduleEditor.tsx
+++ b/src/components/admin/schedule/ScheduleEditor.tsx
@@ -306,11 +306,9 @@ export function ScheduleEditor({
     },
   )
 
-  const { data: updatedProposals } = api.proposal.admin.list.useQuery(
-    { status: [Status.submitted, Status.accepted, Status.confirmed] },
-    {
-      refetchInterval: 10000,
-    },
+  const { data: updatedStatuses } = api.schedule.admin.pollProposalsStatus.useQuery(
+    undefined,
+    { refetchInterval: 10000 },
   )
 
   const [externalChangeError, setExternalChangeError] = useState<string | null>(
@@ -336,11 +334,11 @@ export function ScheduleEditor({
   }, [mergedSchedules])
 
   useEffect(() => {
-    if (updatedProposals) {
+    if (updatedStatuses) {
       // Use raw dispatch to update proposals in the background without affecting dirty state
-      dispatch({ type: 'updateProposals', proposals: updatedProposals })
+      dispatch({ type: 'updateProposalsStatus', statuses: updatedStatuses })
     }
-  }, [updatedProposals])
+  }, [updatedStatuses])
 
   // Every MUTATING dispatch goes through here. In live mode it is a no-op, so
   // even a path that forgets to hide its affordance (or a stale keyboard

--- a/src/components/admin/schedule/ScheduleEditor.tsx
+++ b/src/components/admin/schedule/ScheduleEditor.tsx
@@ -35,7 +35,7 @@ import {
   computeUnassigned,
   scheduledProposalIdsExcludingDay,
 } from '@/lib/schedule/operations'
-import { ProposalExisting } from '@/lib/proposal/types'
+import { ProposalExisting, Status } from '@/lib/proposal/types'
 import { UnassignedProposals } from './UnassignedProposals'
 import { MemoizedDroppableTrack as DroppableTrack } from './DroppableTrack'
 import { DraggableProposal } from './DraggableProposal'
@@ -306,6 +306,13 @@ export function ScheduleEditor({
     },
   )
 
+  const { data: updatedProposals } = api.proposal.admin.list.useQuery(
+    { status: [Status.submitted, Status.accepted, Status.confirmed] },
+    {
+      refetchInterval: 10000,
+    },
+  )
+
   const [externalChangeError, setExternalChangeError] = useState<string | null>(
     null,
   )
@@ -327,6 +334,13 @@ export function ScheduleEditor({
     }
     dispatch({ type: 'resetSchedules', schedules: mergedSchedules })
   }, [mergedSchedules])
+
+  useEffect(() => {
+    if (updatedProposals) {
+      // Use raw dispatch to update proposals in the background without affecting dirty state
+      dispatch({ type: 'updateProposals', proposals: updatedProposals })
+    }
+  }, [updatedProposals])
 
   // Every MUTATING dispatch goes through here. In live mode it is a no-op, so
   // even a path that forgets to hide its affordance (or a stale keyboard

--- a/src/components/cfp/CFPProfilePage.tsx
+++ b/src/components/cfp/CFPProfilePage.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useSession } from 'next-auth/react'
 import { useState, useEffect, useCallback } from 'react'
 import { Speaker, SpeakerInput } from '@/lib/speaker/types'
 import { api } from '@/lib/trpc/client'
@@ -47,6 +48,8 @@ export function CFPProfilePage({
   currentProvider,
   linkResult,
 }: CFPProfilePageProps) {
+  const { update } = useSession()
+
   const {
     data: profile,
     error: profileError,
@@ -61,10 +64,11 @@ export function CFPProfilePage({
   })
 
   const updateProfileMutation = api.speaker.update.useMutation({
-    onSuccess: () => {
+    onSuccess: async (data) => {
       setSuccessMessage('Profile updated successfully!')
       setTimeout(() => setSuccessMessage(''), 3000)
       refreshProfile()
+      await update({ speaker: data })
     },
   })
 

--- a/src/components/cfp/ProposalForm.tsx
+++ b/src/components/cfp/ProposalForm.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useSession } from 'next-auth/react'
 import { Conference } from '@/lib/conference/types'
 import { isCfpOpen, isWithdrawalCutoffActive } from '@/lib/conference/state'
 import { api } from '@/lib/trpc/client'
@@ -72,6 +73,7 @@ export function ProposalForm({
   )
 
   const router = useRouter()
+  const { update } = useSession()
 
   const isReadOnly = mode === 'readOnly'
 
@@ -297,7 +299,8 @@ export function ProposalForm({
       }
 
       try {
-        await updateSpeakerMutation.mutateAsync(speaker)
+        const updatedSpeaker = await updateSpeakerMutation.mutateAsync(speaker)
+        await update({ speaker: updatedSpeaker })
       } catch {
         window.scrollTo(0, 0)
         return

--- a/src/lib/proposal/data/sanity.ts
+++ b/src/lib/proposal/data/sanity.ts
@@ -264,8 +264,8 @@ export async function getProposals({
         "schedule": *[_type == "schedule" && conference._ref == ^.conference._ref && ${OFFICIAL_SCHEDULE_FILTER} && ^._id in tracks[].talks[].talk._ref] | order(date asc) [0]
       } {
         "date": schedule.date,
-        "trackTitle": schedule.tracks[count(talks[talk._ref == ^.talkId]) > 0][0].trackTitle,
-        "timeSlot": schedule.tracks[count(talks[talk._ref == ^.talkId]) > 0][0].talks[talk._ref == ^.talkId][0]{
+        "trackTitle": schedule.tracks[^.talkId in talks[].talk._ref][0].trackTitle,
+        "timeSlot": schedule.tracks[^.talkId in talks[].talk._ref][0].talks[talk._ref == ^.talkId][0]{
           startTime,
           endTime
         }

--- a/src/lib/schedule/reducer.ts
+++ b/src/lib/schedule/reducer.ts
@@ -64,7 +64,7 @@ export type ScheduleAction =
     }
   | { type: 'changeDay'; dayIndex: number }
   | { type: 'resetSchedules'; schedules: EditorSchedule[] }
-  | { type: 'updateProposals'; proposals: ProposalExisting[] }
+  | { type: 'updateProposalsStatus'; statuses: { _id: string; status: string }[] }
   | { type: 'saveStart' }
   | {
       type: 'saveDaySucceeded'
@@ -258,21 +258,26 @@ export function scheduleReducer(
       }
     }
 
-    case 'updateProposals': {
-      const proposalMap = new Map(action.proposals.map(p => [p._id, p]))
+    case 'updateProposalsStatus': {
+      const statusMap = new Map(action.statuses.map(s => [s._id, s.status]))
+      
+      const updatedProposals = state.proposals.map(p => 
+        statusMap.has(p._id) ? { ...p, status: statusMap.get(p._id) as any } : p
+      )
+
       const updatedSchedules = state.schedules.map(schedule => ({
         ...schedule,
         tracks: schedule.tracks.map(track => ({
           ...track,
           talks: track.talks.map(talk => {
-            if (talk.kind === 'talk' && talk.talk && proposalMap.has(talk.talk._id)) {
-              return { ...talk, talk: proposalMap.get(talk.talk._id)! }
+            if (talk.kind === 'talk' && talk.talk && statusMap.has(talk.talk._id)) {
+              return { ...talk, talk: { ...talk.talk, status: statusMap.get(talk.talk._id) as any } }
             }
             return talk
           }),
         })),
       }))
-      return { ...state, proposals: action.proposals, schedules: updatedSchedules }
+      return { ...state, proposals: updatedProposals, schedules: updatedSchedules }
     }
 
     case 'saveStart':

--- a/src/lib/schedule/reducer.ts
+++ b/src/lib/schedule/reducer.ts
@@ -64,6 +64,7 @@ export type ScheduleAction =
     }
   | { type: 'changeDay'; dayIndex: number }
   | { type: 'resetSchedules'; schedules: EditorSchedule[] }
+  | { type: 'updateProposals'; proposals: ProposalExisting[] }
   | { type: 'saveStart' }
   | {
       type: 'saveDaySucceeded'
@@ -255,6 +256,23 @@ export function scheduleReducer(
         dirty: action.schedules.map(() => false),
         ui: { ...state.ui, error: null },
       }
+    }
+
+    case 'updateProposals': {
+      const proposalMap = new Map(action.proposals.map(p => [p._id, p]))
+      const updatedSchedules = state.schedules.map(schedule => ({
+        ...schedule,
+        tracks: schedule.tracks.map(track => ({
+          ...track,
+          talks: track.talks.map(talk => {
+            if (talk.kind === 'talk' && talk.talk && proposalMap.has(talk.talk._id)) {
+              return { ...talk, talk: proposalMap.get(talk.talk._id)! }
+            }
+            return talk
+          }),
+        })),
+      }))
+      return { ...state, proposals: action.proposals, schedules: updatedSchedules }
     }
 
     case 'saveStart':

--- a/src/lib/schedule/reducer.ts
+++ b/src/lib/schedule/reducer.ts
@@ -1,5 +1,5 @@
 import { ScheduleTrack, TrackTalk } from '@/lib/conference/types'
-import { ProposalExisting } from '@/lib/proposal/types'
+import { ProposalExisting, Status } from '@/lib/proposal/types'
 import { DragItem, DropPosition, EditorSchedule } from './types'
 import * as ops from './operations'
 
@@ -64,7 +64,10 @@ export type ScheduleAction =
     }
   | { type: 'changeDay'; dayIndex: number }
   | { type: 'resetSchedules'; schedules: EditorSchedule[] }
-  | { type: 'updateProposalsStatus'; statuses: { _id: string; status: string }[] }
+  | {
+      type: 'updateProposalsStatus'
+      statuses: { _id: string; status: string }[]
+    }
   | { type: 'saveStart' }
   | {
       type: 'saveDaySucceeded'
@@ -259,25 +262,41 @@ export function scheduleReducer(
     }
 
     case 'updateProposalsStatus': {
-      const statusMap = new Map(action.statuses.map(s => [s._id, s.status]))
-      
-      const updatedProposals = state.proposals.map(p => 
-        statusMap.has(p._id) ? { ...p, status: statusMap.get(p._id) as any } : p
+      const statusMap = new Map(action.statuses.map((s) => [s._id, s.status]))
+
+      const updatedProposals = state.proposals.map((p) =>
+        statusMap.has(p._id)
+          ? { ...p, status: statusMap.get(p._id) as Status }
+          : p,
       )
 
-      const updatedSchedules = state.schedules.map(schedule => ({
+      const updatedSchedules = state.schedules.map((schedule) => ({
         ...schedule,
-        tracks: schedule.tracks.map(track => ({
+        tracks: schedule.tracks.map((track) => ({
           ...track,
-          talks: track.talks.map(talk => {
-            if (talk.kind === 'talk' && talk.talk && statusMap.has(talk.talk._id)) {
-              return { ...talk, talk: { ...talk.talk, status: statusMap.get(talk.talk._id) as any } }
+          talks: track.talks.map((talk) => {
+            if (
+              talk.kind === 'talk' &&
+              talk.talk &&
+              statusMap.has(talk.talk._id)
+            ) {
+              return {
+                ...talk,
+                talk: {
+                  ...talk.talk,
+                  status: statusMap.get(talk.talk._id) as Status,
+                },
+              }
             }
             return talk
           }),
         })),
       }))
-      return { ...state, proposals: updatedProposals, schedules: updatedSchedules }
+      return {
+        ...state,
+        proposals: updatedProposals,
+        schedules: updatedSchedules,
+      }
     }
 
     case 'saveStart':

--- a/src/lib/speaker/sanity.ts
+++ b/src/lib/speaker/sanity.ts
@@ -870,8 +870,8 @@ export async function getPublicSpeaker(
             "schedule": *[_type == "schedule" && conference._ref == $conferenceId && ${OFFICIAL_SCHEDULE_FILTER} && ^._id in tracks[].talks[].talk._ref] | order(date asc) [0]
           } {
             "date": schedule.date,
-            "trackTitle": schedule.tracks[count(talks[talk._ref == ^.talkId]) > 0][0].trackTitle,
-            "timeSlot": schedule.tracks[count(talks[talk._ref == ^.talkId]) > 0][0].talks[talk._ref == ^.talkId][0]{
+            "trackTitle": schedule.tracks[^.talkId in talks[].talk._ref][0].trackTitle,
+            "timeSlot": schedule.tracks[^.talkId in talks[].talk._ref][0].talks[talk._ref == ^.talkId][0]{
               startTime,
               endTime
             }

--- a/src/server/routers/schedule.ts
+++ b/src/server/routers/schedule.ts
@@ -218,6 +218,22 @@ export const scheduleRouter = router({
       )
     }),
 
+    pollProposalsStatus: adminProcedure.query(async () => {
+      const { conference, error } = await getConferenceForCurrentDomain()
+      if (error || !conference) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to fetch conference',
+        })
+      }
+      return await clientWrite.fetch<
+        { _id: string; status: string }[]
+      >(
+        `*[_type == "talk" && conference._ref == $conferenceId]{ _id, status }`,
+        { conferenceId: conference._id },
+      )
+    }),
+
     delete: adminProcedure
       .input(z.object({ id: z.string() }))
       .mutation(async ({ input }) => {

--- a/src/server/routers/schedule.ts
+++ b/src/server/routers/schedule.ts
@@ -226,9 +226,7 @@ export const scheduleRouter = router({
           message: 'Failed to fetch conference',
         })
       }
-      return await clientWrite.fetch<
-        { _id: string; status: string }[]
-      >(
+      return await clientWrite.fetch<{ _id: string; status: string }[]>(
         `*[_type == "talk" && conference._ref == $conferenceId]{ _id, status }`,
         { conferenceId: conference._id },
       )


### PR DESCRIPTION
## Description

This PR introduces several quality-of-life enhancements and fixes to the Schedule Admin view, along with resolving some general repository cleanliness and typechecking issues.

### Schedule Admin Enhancements
* **Travel Funding Indicator:** Added a `BanknotesIcon` in the schedule editor for proposals where the speaker has the `requires-funding` flag.
* **Duration Override Indicator:** Added a `ScissorsIcon` to clearly highlight when a talk's duration has been overridden by an organizer, replacing the standard clock icon to prevent layout shifts.
* **Accurate Tooltips:** Fixed an issue where the tooltip incorrectly defaulted unhandled statuses (like `submitted`) to "Confirmed". It now accurately distinguishes between `submitted` and `confirmed`.
* **Real-time Status Polling:** Implemented lightweight background polling (`pollProposalsStatus`) in the schedule editor that queries Sanity directly (via `clientWrite.fetch` to bypass the Next.js cache). This ensures the schedule seamlessly and reactively updates proposal statuses as speakers confirm them, without disrupting any active drag-and-drop operations.

### Housekeeping & Fixes
* **Orphaned Files Cleanup:** Removed several unused/orphaned utility scripts and JSON dumps (`dump-schedule-read.ts`, `summarize.js`, `all_proposals.json`, etc.).
* **Next.js TypeScript CLI:** Enabled `experimental.useTypeScriptCli` in `next.config.ts` as a targeted workaround for typechecking OOM errors during Vercel builds.
* **Accessibility & Typing:** Addressed Copilot review comments by adding `aria-label` tags to the new SVG icons, using safer inline typing instead of `any` when mapping speakers, and clarifying variable names (`requiresTravelFunding`).

## Workflow Checklist
- [x] Tested schedule dragging and tooltip rendering
- [x] Verified `api.schedule.admin.pollProposalsStatus` bypasses cache
- [x] Addressed all automated PR review feedback
