### PR TITLE
Fix the I'm speaking card on the speaker dashboard

### DIFF
--- a/src/app/(cfp)/cfp/list/page.tsx
+++ b/src/app/(cfp)/cfp/list/page.tsx
@@ -10,6 +10,7 @@ import { clientReadCached } from '@/lib/sanity/client'
 import { groq } from 'next-sanity'
 import { isConferenceOver } from '@/lib/conference/state'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { getSpeaker } from '@/lib/speaker/sanity'
 import { CompactConferenceCard } from '@/components/cfp/CompactConferenceCard'
 import { SpeakerShareSidebar } from '@/components/cfp/SpeakerShareSidebar'
 import { BadgeShare } from '@/components/cfp/BadgeShare'
@@ -39,6 +40,7 @@ export default async function SpeakerDashboard() {
 
   const speaker = session.speaker
   const speakerId = speaker._id
+  const { speaker: currentSpeaker } = await getSpeaker(speakerId)
 
   // Identity guidance ("not seeing your talks?"): the session speaker doesn't
   // carry `providers[]`, so read just that field (cached, not the whole doc) to
@@ -241,7 +243,7 @@ export default async function SpeakerDashboard() {
   const latestBadge = allBadges[0]
 
   const speakerWithTalks = {
-    ...speaker,
+    ...(currentSpeaker ?? speaker),
     talks: confirmedTalks,
   }
 


### PR DESCRIPTION
Changed the speaker dashboard so the I'm speaking at card reads the current speaker document instead of the session snapshot. 

What changed:
- Added getSpeaker lookup for the signed-in speaker.
- Built speakerWithTalks from currentSpeaker ?? session.speaker.

Effect:
- The share card now uses the up-to-date saved profile image from Sanity.
- If the live lookup ever fails, it falls back to the old session behavior.

Note: GPT-5.4 and as websites of development tooling `mise` and `fnox` are gone, can't test anything locally.