### PR TITLE
docs(agents): drop the rtk mandate and move durable agent rules into AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ These are the rules that repeatedly caught real defects here. Follow them withou
 - **Work in an isolated worktree** (`git worktree add`). Several agents share this checkout and have overwritten each other's uncommitted work.
 - **Do not overstate.** Name the holes you leave. The dominant defect on this project is a true-sounding claim that CI cannot falsify — not broken code.
 - **Git:** conventional commits; **no AI co-author trailers** (a pre-push hook rejects them); never pass `-S` (no gpg here).
+- **Keep the final report under ~400 words.** Put the evidence — sabotage matrices, before/after numbers, per-file tables, the reasoning — **in the PR body**, where a human reviews it and where it persists. The report back is a routing summary: what you built, what you proved, what you could not, what needs a decision. Reports have been running 1,500–2,500 words and duplicating the PR body verbatim; that is paid for twice and read once. **Brevity here is not less rigour — it is the same rigour, filed where it belongs.**
 
 ## Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,17 +13,36 @@ Multi-tenant website for Cloud Native conferences.
 - **Admin Access:** Protected by `is_organizer: true` flag in user profile.
 - **Filtering:** Filtering logic (Proposals, Sponsors) must reside on the API/Server side using Zod schemas.
 
-## RTK - Token-Optimized Commands
+## Commands
 
-**ALWAYS prefix terminal commands with `rtk`** (e.g., `rtk git status`, `rtk vitest`, `rtk tsc`, `rtk lint`, `rtk cargo test`). Also use in chains: `rtk git add . && rtk git commit -m "msg"`.
-Project uses [mise](https://mise.jdx.sh/). Key commands:
+Project uses [mise](https://mise.jdx.sh/).
 
-- `rtk mise run all` (check, test, build)
-- `rtk mise run check` (lint, typecheck, format check)
-- `rtk next build` (Next.js build with compact route metrics)
-- `rtk pnpm install` (compact dependency installation)
-- `mise run dev` & `mise run storybook` (for local servers)
-- For CLI (`cli/` Rust): `cd cli && rtk mise run <check|clippy|fmt|test|build>`
+- `mise run all` (check, test, build) · `mise run check` (lint, typecheck, format check)
+- `mise run dev` & `mise run storybook` (local servers)
+- For CLI (`cli/` Rust): `cd cli && mise run <check|clippy|fmt|test|build>`
+
+**Do NOT use `rtk`.** This file previously mandated it on every command. It is not installed, and independent benchmarking (JetBrains, 86 paired SkillsBench tasks, measuring real billing rather than rtk's self-reported metrics) found a **+7.6% cost _increase_** at low reasoning effort and ~zero at high — because it only intercepts Bash, while Read/Grep/Glob bypass it entirely, capping any saving near 3% of input tokens.
+
+**Verification commands that are easy to get wrong:**
+
+- **`next lint` is vacuous in Next 16** — it treats "lint" as a directory and exits 0 having linted nothing. Use `npx eslint .`.
+- `tenancy/no-unscoped-groq` is **CI-ratcheted per file** (`pnpm run lint:tenancy`). A file may not gain a warning. Fixing sites is welcome — regenerate with `pnpm run lint:tenancy:update` in the same PR.
+- **Playwright is broken on the primary dev machine** (every browser dies at launch, SIGTRAP). `pnpm shoot` cannot run, so **never claim visual verification**; add stories and rely on CI-published Storybook.
+- **Production Sanity is readable** from this repo with no `.env` or token: `npx sanity documents query '...'`. Two traps: an _unauthenticated_ query returns `[]`/`0` rather than erroring, and a bare zero `count()` prints an error — wrap as `{"n": count(...)}`. Treat as **read-only** unless explicitly told otherwise.
+
+## Agent discipline
+
+These are the rules that repeatedly caught real defects here. Follow them without being re-told; a brief that repeats them is wasting tokens.
+
+- **Sabotage-prove every guard.** Remove it, show the specific test fails, restore, show green. **Check file AND test counts every run** — a malformed edit that breaks an import silently stops tests and reads as a pass.
+- **A test must fail on a VALUE or on the action succeeding, never on an absence.** Confirm nothing else in the path could produce the same refusal; a test that passes because an unrelated guard refuses with the same code proves nothing.
+- **Guard before fetch.** Fetching then refusing leaks a 1-bit existence oracle (nonexistent vs foreign return different errors). Assert the fetch was never called.
+- **Never drop a field from a GROQ projection without finding its consumers.** A missing field is `undefined`, not an error — it breaks silently in production.
+- **A mock is never evidence about the thing it mocks.** `jose` is aliased suite-wide; to claim a library behaves some way, exercise the real one in a standalone `node -e`. Surprise about a mature dependency should trigger doubt, not excitement.
+- **Answer every unresolved review-bot thread** before declaring work done. Bot threads outside the review brief have been the real defect repeatedly.
+- **Work in an isolated worktree** (`git worktree add`). Several agents share this checkout and have overwritten each other's uncommitted work.
+- **Do not overstate.** Name the holes you leave. The dominant defect on this project is a true-sounding claim that CI cannot falsify — not broken code.
+- **Git:** conventional commits; **no AI co-author trailers** (a pre-push hook rejects them); never pass `-S` (no gpg here).
 
 ## Workflow
 
@@ -52,7 +71,7 @@ Project uses [mise](https://mise.jdx.sh/). Key commands:
   - **Deterministic Dates:** Mock `globalThis.Date` in Storybook `beforeEach` to fix relative dates (prevents visual diff thrashing).
 - **Visual inspection is MANDATORY for UI work.** Whenever you create or change a component/layout, **look at the rendered result** — never conclude "it works" from code review, measurements, or unit tests alone (they miss overflow, truncation, spacing, and responsive bugs). Workflow:
   - Ensure the component has a Storybook story (add one if missing) so it's inspectable in isolation.
-  - Screenshot it with **`rtk pnpm shoot <story-id> [width] [height]`** (`scripts/shoot-story.mjs`) — defaults to iPhone-portrait (393×852, DPR 3), auto-starts Storybook, flattens decorator insets so the capture maps 1:1 to the app, and prints a hard per-card viewport-overflow check. Then actually view the PNG.
+  - Screenshot it with **`pnpm shoot <story-id> [width] [height]`** (`scripts/shoot-story.mjs`) — defaults to iPhone-portrait (393×852, DPR 3), auto-starts Storybook, flattens decorator insets so the capture maps 1:1 to the app, and prints a hard per-card viewport-overflow check. Then actually view the PNG.
   - For full-screen/mobile views set `parameters.layout: 'fullscreen'` on the story so captures aren't inset.
   - Prefer isolated Storybook capture over trusting a deployed URL — a stale **PWA service worker** can serve an old bundle (see `public/sw.js` / `scripts/stamp-sw.mjs`); a Safari **Private tab** bypasses the SW when checking production.
 - **Testing (Vitest):** Test behavior over implementation. Prefer integration tests. Mock at boundaries.

--- a/docs/TENANT_SCOPING.md
+++ b/docs/TENANT_SCOPING.md
@@ -355,11 +355,11 @@ unscoped root filter:
    instead of scoping. **If it is already scoped but the rule cannot see how,**
    annotate `// groq-global-scoped: <how>` and name the mechanism — never reach
    for `groq-global:` there.
-6. **Track progress** with `rtk pnpm run lint:tenancy`, which prints the current
+6. **Track progress** with `pnpm run lint:tenancy`, which prints the current
    per-file counts against the baseline. The count is per ROOT FILTER, so one
    literal can contribute several — and clearing a literal's outer root does not
    clear a nested one. **Lock your fixes in** with
-   `rtk pnpm run lint:tenancy:update`, committing the regenerated baseline in the
+   `pnpm run lint:tenancy:update`, committing the regenerated baseline in the
    same PR; otherwise the ceiling you just earned stays where it was.
 
 ### Migrated exemplars (the pattern)


### PR DESCRIPTION
## Why

Two changes, both aimed at token cost rather than correctness.

### 1. The `rtk` mandate was wrong and inert

`AGENTS.md` told every agent to prefix all terminal commands with `rtk`. Two problems:

- **It is not installed** on the primary dev machine, so no command has ever used it.
- **Independent measurement says it costs more, not less.** JetBrains benchmarked it across 86 paired SkillsBench tasks measuring *actual billing* rather than rtk's self-reported metrics: **+7.6% cost increase** at low reasoning effort (p=0.004), roughly zero at high. rtk only intercepts the Bash tool — Read, Grep and Glob bypass it entirely, and it refuses to rewrite pipes, heredocs and python — so it touched about a fifth of tool output, capping any possible saving near 3% of input tokens. Its own dashboard reported 96.2M tokens saved while the bill rose, because it counts raw output as the counterfactual and ignores that cached re-reads bill at a tenth.

Removed rather than fixed. Also dropped the `rtk` prefix from the two live commands in `docs/TENANT_SCOPING.md` and the `pnpm shoot` line, so nothing tells a reader to run a binary that isn't there.

### 2. Durable agent rules moved into the file agents actually receive

**Subagents get `AGENTS.md`; they do not get the orchestrator's notes.** So every rule below has been re-typed by hand into individual agent briefs, and those briefs are a large share of the token cost — several ran 95k–345k tokens each. Stating them once here shortens every future brief and stops a rule being silently dropped when a brief omits it.

Each rule earned its place by catching a real defect in the last week:

| Rule | What it caught |
|---|---|
| Sabotage-prove every guard; check file **and** test counts | A guard whose removal passed the whole suite |
| Tests must fail on a **value**, not an absence | A test that passed because an unrelated guard refused with the same code |
| Guard **before** fetch | A 1-bit existence oracle on foreign document ids |
| Never drop a projection field without finding its consumers | Nearly broke the travel-support payout pane, which renders IBAN/SWIFT |
| A mock is never evidence about the thing it mocks | A fabricated "verified" claim about `jose` in a signature-verification comment |
| Answer every unresolved review-bot thread | Four times a bot thread outside the review brief **was** the real defect |
| Work in an isolated worktree | Agents sharing this checkout overwrote each other's uncommitted work |
| Do not overstate | The dominant defect here is a true-sounding claim CI cannot falsify |

Also folded in the verification traps that repeatedly cost time: `next lint` is vacuous in Next 16, the tenancy ratchet is now per-file CI-gated, Playwright is broken so visual verification cannot be claimed, and an unauthenticated Sanity query returns `[]`/`0` rather than erroring — which has twice been mistaken for "no data".

## Scope

Documentation only. No code, no behaviour change.

Sources: <https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/> · <https://github.com/rtk-ai/rtk>